### PR TITLE
Security/correctness audit fixes + payment & analytics WIP

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -25,7 +25,7 @@ envs:
   value: "2"
 - key: LOGGER_LEVEL
   scope: RUN_TIME
-  value: "-4"
+  value: "0"
 - key: LOGGER_ADD_SOURCE
   scope: RUN_TIME
   value: "true"
@@ -193,6 +193,14 @@ envs:
 - key: STRIPE_PAYMENT_TEST_INVOICE_EXPIRATION
   scope: RUN_TIME
   value: 15m
+- key: STRIPE_PAYMENT_WEBHOOK_SECRET
+  scope: RUN_TIME
+  type: SECRET
+  value: ""
+- key: STRIPE_PAYMENT_TEST_WEBHOOK_SECRET
+  scope: RUN_TIME
+  type: SECRET
+  value: ""
 - key: REVALIDATION_PROJECT_ID
   scope: RUN_TIME
   type: SECRET
@@ -281,7 +289,7 @@ envs:
   value: 10m
 - key: BIGQUERY_USE_LITERAL_DATES
   scope: RUN_TIME
-  value: "true"
+  value: "false"
 - key: BIGQUERY_CIRCUIT_BREAKER_MAX_FAILURES
   scope: RUN_TIME
   value: "5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,12 @@ COPY --from=builder /grbpwr-manager/config/certs/ca-certificate.crt /etc/grbpwr-
 
 WORKDIR /
 
+# Run as an unprivileged user. The app binds :8081 (>1024), writes nothing to the
+# local filesystem (media -> S3, state -> remote MySQL), and only reads the public
+# CA cert, so it does not need root.
+RUN addgroup -S app && adduser -S -u 10001 -G app app
+USER app
+
 EXPOSE 8081
 
 # Use full path to binary to avoid PATH issues

--- a/app/app.go
+++ b/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"log/slog"
 
@@ -53,6 +54,7 @@ type App struct {
 	ga4w *ga4sync.Worker
 	bqc  dependency.BQClient
 	re   dependency.RevalidationService
+	rm   *stockreserve.Manager
 	c    *config.Config
 	done chan struct{}
 }
@@ -94,13 +96,9 @@ func (a *App) Start(ctx context.Context) error {
 	}
 
 	reservationMgr := stockreserve.NewDefaultManager()
-	a.oc = ordercleanup.New(&a.c.OrderCleanup, a.db, reservationMgr)
-	if err = a.oc.Start(ctx); err != nil {
-		slog.Default().ErrorContext(ctx, "couldn't start order cleanup worker",
-			slog.String("err", err.Error()),
-		)
-		return err
-	}
+	a.rm = reservationMgr
+	// NOTE: the order cleanup worker is created later, after the Stripe
+	// processors exist, so its safety-net expiry can verify payment with Stripe.
 
 	a.sc = storefrontcleanup.New(&a.c.StorefrontCleanup, a.db)
 	if err = a.sc.Start(ctx); err != nil {
@@ -168,6 +166,24 @@ func (a *App) Start(ctx context.Context) error {
 			)
 			return err
 		}
+	}
+
+	// Order cleanup safety-net: route expired card orders through the Stripe
+	// processors so a succeeded-but-unrecorded payment is confirmed instead of
+	// cancelled. Wired here so it can verify payment status with Stripe.
+	expirer := &stripeOrderExpirer{repo: a.db}
+	if p, ok := stripeMain.(*stripe.Processor); ok {
+		expirer.main = p
+	}
+	if p, ok := stripeTest.(*stripe.Processor); ok {
+		expirer.test = p
+	}
+	a.oc = ordercleanup.New(&a.c.OrderCleanup, a.db, reservationMgr, expirer)
+	if err = a.oc.Start(ctx); err != nil {
+		slog.Default().ErrorContext(ctx, "couldn't start order cleanup worker",
+			slog.String("err", err.Error()),
+		)
+		return err
 	}
 
 	a.re, err = revalidation.New(ctx, &a.c.Revalidation)
@@ -251,6 +267,23 @@ func (a *App) Start(ctx context.Context) error {
 	}
 	a.hs.SetWebhookHandler(webhookHandler)
 
+	// Stripe webhook: server-to-server payment confirmation (primary path; the
+	// in-process monitor and lazy CheckForTransactions remain fallbacks). Enabled
+	// only when a signing secret is configured for at least one processor.
+	var stripeProcs []*stripe.Processor
+	if p, ok := stripeMain.(*stripe.Processor); ok {
+		stripeProcs = append(stripeProcs, p)
+	}
+	if p, ok := stripeTest.(*stripe.Processor); ok {
+		stripeProcs = append(stripeProcs, p)
+	}
+	if stripeWebhook := stripe.NewWebhookHandler(stripeProcs...); stripeWebhook.Enabled() {
+		a.hs.SetStripeWebhookHandler(stripeWebhook)
+		slog.Default().InfoContext(ctx, "stripe webhook handler enabled")
+	} else {
+		slog.Default().InfoContext(ctx, "stripe webhook handler disabled (no signing secret configured)")
+	}
+
 	if err = a.hs.Start(ctx, adminS, frontendS, authS); err != nil {
 		slog.Default().ErrorContext(ctx, "cannot start http server")
 		return err
@@ -260,8 +293,22 @@ func (a *App) Start(ctx context.Context) error {
 }
 
 // Stop stops the application and waits for all services to exit.
-// Workers are stopped first so they release DB connections before database close.
+// Shutdown order: drain the API server first (so no new request reaches a worker
+// or the DB), then stop the workers, then close the database.
 func (a *App) Stop(ctx context.Context) {
+	// Drain in-flight gRPC/REST requests and stop the listener before tearing
+	// anything down, so handlers don't race against stopped workers or a closed
+	// connection pool.
+	if a.hs != nil {
+		shutdownCtx, cancel := context.WithTimeout(ctx, 25*time.Second)
+		if err := a.hs.Shutdown(shutdownCtx); err != nil {
+			slog.Default().ErrorContext(ctx, "error draining http server on shutdown",
+				slog.String("err", err.Error()),
+			)
+		}
+		cancel()
+	}
+
 	// Stop workers before closing DB — avoids panics and error storms from workers
 	// hitting a closed connection. In-flight emails remain in DB and will be retried on next run.
 	if a.ma != nil {
@@ -283,6 +330,11 @@ func (a *App) Stop(ctx context.Context) {
 		_ = a.ga4w.Stop()
 	}
 
+	// Stop the in-memory stock reservation manager's cleanup goroutine.
+	if a.rm != nil {
+		a.rm.Stop()
+	}
+
 	if a.bqc != nil {
 		a.bqc.Close()
 	}
@@ -293,4 +345,42 @@ func (a *App) Stop(ctx context.Context) {
 // Done returns a channel that is closed after the application has exited
 func (a *App) Done() chan struct{} {
 	return a.done
+}
+
+// stripeOrderExpirer routes an order's safety-net expiry to the correct Stripe
+// processor (live vs test) by its payment method, running the provider-checked
+// expiry that confirms a succeeded payment instead of cancelling it. For
+// non-card methods (or when a processor is unavailable) it falls back to the
+// store-level expiry, which only cancels orders whose payment is not done.
+// Implements ordercleanup.PaymentExpirer.
+type stripeOrderExpirer struct {
+	repo dependency.Repository
+	main ordercleanup.PaymentExpirer
+	test ordercleanup.PaymentExpirer
+}
+
+func (e *stripeOrderExpirer) ExpireOrderPayment(ctx context.Context, orderUUID string) error {
+	payment, err := e.repo.Order().GetPaymentByOrderUUID(ctx, orderUUID)
+	if err != nil {
+		return fmt.Errorf("can't get payment for order %s: %w", orderUUID, err)
+	}
+
+	pm, ok := cache.GetPaymentMethodById(payment.PaymentMethodID)
+	if ok {
+		switch pm.Method.Name {
+		case entity.CARD:
+			if e.main != nil {
+				return e.main.ExpireOrderPayment(ctx, orderUUID)
+			}
+		case entity.CARD_TEST:
+			if e.test != nil {
+				return e.test.ExpireOrderPayment(ctx, orderUUID)
+			}
+		}
+	}
+
+	// Non-card method or processor unavailable: the store-level expiry only
+	// cancels orders whose payment is not done, so it is safe as a fallback.
+	_, err = e.repo.Order().ExpireOrderPayment(ctx, orderUUID)
+	return err
 }

--- a/config/cfg.go
+++ b/config/cfg.go
@@ -15,10 +15,10 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/mail"
 	"github.com/jekabolt/grbpwr-manager/internal/ordercleanup"
 	"github.com/jekabolt/grbpwr-manager/internal/payment/stripe"
-	"github.com/jekabolt/grbpwr-manager/internal/storefrontcleanup"
 	"github.com/jekabolt/grbpwr-manager/internal/revalidation"
 	"github.com/jekabolt/grbpwr-manager/internal/store"
 	"github.com/jekabolt/grbpwr-manager/internal/storefront"
+	"github.com/jekabolt/grbpwr-manager/internal/storefrontcleanup"
 	"github.com/jekabolt/grbpwr-manager/internal/stripereconcile"
 	"github.com/jekabolt/grbpwr-manager/internal/tiermanagement"
 	"github.com/jekabolt/grbpwr-manager/log"
@@ -32,25 +32,25 @@ type RatesConfig struct {
 
 // Config represents the global configuration for the service.
 type Config struct {
-	DB                store.Config           `mapstructure:"mysql"`
-	Logger            log.Config             `mapstructure:"logger"`
-	HTTP              httpapi.Config         `mapstructure:"http"`
-	Auth              auth.Config            `mapstructure:"auth"`
-	StorefrontAuth    storefront.Config      `mapstructure:"storefront_auth"`
-	Bucket            bucket.Config          `mapstructure:"bucket"`
-	Mailer            mail.Config            `mapstructure:"mailer"`
-	OrderCleanup        ordercleanup.Config        `mapstructure:"order_cleanup"`
-	StorefrontCleanup   storefrontcleanup.Config   `mapstructure:"storefront_cleanup"`
-	TierManagement      tiermanagement.Config      `mapstructure:"tier_management"`
-	StripeReconcile     stripereconcile.Config     `mapstructure:"stripe_reconcile"`
-	Rates             RatesConfig            `mapstructure:"rates"`
-	StripePayment     stripe.Config          `mapstructure:"stripe_payment"`
-	StripePaymentTest stripe.Config          `mapstructure:"stripe_payment_test"`
-	Revalidation      revalidation.Config    `mapstructure:"revalidation"`
-	GA4               ga4.Config             `mapstructure:"ga4"`
-	GA4MP             ga4mp.Config           `mapstructure:"ga4mp"`
-	GA4Sync           ga4sync.Config         `mapstructure:"ga4_sync"`
-	BigQuery          bq.Config              `mapstructure:"bigquery"`
+	DB                store.Config             `mapstructure:"mysql"`
+	Logger            log.Config               `mapstructure:"logger"`
+	HTTP              httpapi.Config           `mapstructure:"http"`
+	Auth              auth.Config              `mapstructure:"auth"`
+	StorefrontAuth    storefront.Config        `mapstructure:"storefront_auth"`
+	Bucket            bucket.Config            `mapstructure:"bucket"`
+	Mailer            mail.Config              `mapstructure:"mailer"`
+	OrderCleanup      ordercleanup.Config      `mapstructure:"order_cleanup"`
+	StorefrontCleanup storefrontcleanup.Config `mapstructure:"storefront_cleanup"`
+	TierManagement    tiermanagement.Config    `mapstructure:"tier_management"`
+	StripeReconcile   stripereconcile.Config   `mapstructure:"stripe_reconcile"`
+	Rates             RatesConfig              `mapstructure:"rates"`
+	StripePayment     stripe.Config            `mapstructure:"stripe_payment"`
+	StripePaymentTest stripe.Config            `mapstructure:"stripe_payment_test"`
+	Revalidation      revalidation.Config      `mapstructure:"revalidation"`
+	GA4               ga4.Config               `mapstructure:"ga4"`
+	GA4MP             ga4mp.Config             `mapstructure:"ga4mp"`
+	GA4Sync           ga4sync.Config           `mapstructure:"ga4_sync"`
+	BigQuery          bq.Config                `mapstructure:"bigquery"`
 }
 
 // LoadConfig loads the configuration from a file and/or environment variables.
@@ -211,11 +211,13 @@ func bindEnvVars() {
 	viper.BindEnv("stripe_payment.secret_key", "STRIPE_PAYMENT_SECRET_KEY")
 	viper.BindEnv("stripe_payment.pub_key", "STRIPE_PAYMENT_PUB_KEY")
 	viper.BindEnv("stripe_payment.invoice_expiration", "STRIPE_PAYMENT_INVOICE_EXPIRATION")
+	viper.BindEnv("stripe_payment.webhook_secret", "STRIPE_PAYMENT_WEBHOOK_SECRET")
 
 	// Stripe Payment Test
 	viper.BindEnv("stripe_payment_test.secret_key", "STRIPE_PAYMENT_TEST_SECRET_KEY")
 	viper.BindEnv("stripe_payment_test.pub_key", "STRIPE_PAYMENT_TEST_PUB_KEY")
 	viper.BindEnv("stripe_payment_test.invoice_expiration", "STRIPE_PAYMENT_TEST_INVOICE_EXPIRATION")
+	viper.BindEnv("stripe_payment_test.webhook_secret", "STRIPE_PAYMENT_TEST_WEBHOOK_SECRET")
 
 	// Revalidation
 	viper.BindEnv("revalidation.project_id", "REVALIDATION_PROJECT_ID")

--- a/config/cfg_env_test.go
+++ b/config/cfg_env_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMasterPasswordFromEnv reproduces the DO runtime (no config file, env only)
+// and verifies AUTH_MASTER_PASSWORD reaches cfg.Auth.MasterPassword intact —
+// i.e. the viper BindEnv->Unmarshal path actually delivers the value.
+func TestMasterPasswordFromEnv(t *testing.T) {
+	t.Setenv("AUTH_MASTER_PASSWORD", "string")
+	t.Setenv("AUTH_JWT_SECRET", "test-secret")
+	t.Setenv("AUTH_PASSWORD_HASHER_SALT_SIZE", "16")
+	t.Setenv("AUTH_PASSWORD_HASHER_ITERATIONS", "100000")
+
+	cfg, err := LoadConfig("")
+	require.NoError(t, err)
+
+	assert.Equal(t, "string", cfg.Auth.MasterPassword, "master password must come through from env")
+	assert.Equal(t, "test-secret", cfg.Auth.JWTSecret)
+	assert.Equal(t, 16, cfg.Auth.PasswordHasherSaltSize)
+	assert.Equal(t, 100000, cfg.Auth.PasswordHasherIterations)
+}

--- a/internal/analytics/bigquery/client.go
+++ b/internal/analytics/bigquery/client.go
@@ -222,18 +222,21 @@ func (c *Client) eventsSourceColumns(startDate, endDate time.Time, columns ...st
 		slog.Bool("use_literal_dates", c.useLiteralDates),
 		slog.String("table_ref", c.tableRef()))
 
-	colList := "*"
-	if len(columns) > 0 {
-		colList = ""
-		for i, col := range columns {
-			if err := validateColumnName(col); err != nil {
-				return "", err
-			}
-			if i > 0 {
-				colList += ", "
-			}
-			colList += col
+	// Require an explicit projection. Falling back to SELECT * over the very wide
+	// events_* export scans every nested column for the range — easily 10–100× the
+	// bytes (and cost) of the columns actually needed.
+	if len(columns) == 0 {
+		return "", fmt.Errorf("eventsSourceColumns: at least one column is required")
+	}
+	colList := ""
+	for i, col := range columns {
+		if err := validateColumnName(col); err != nil {
+			return "", err
 		}
+		if i > 0 {
+			colList += ", "
+		}
+		colList += col
 	}
 
 	var dailyFilter, intradayFilter string
@@ -241,8 +244,13 @@ func (c *Client) eventsSourceColumns(startDate, endDate time.Time, columns ...st
 		dailyFilter = fmt.Sprintf("_TABLE_SUFFIX BETWEEN '%s' AND '%s'", startSuffix, endSuffix)
 		intradayFilter = fmt.Sprintf("_TABLE_SUFFIX BETWEEN 'intraday_%s' AND 'intraday_%s'", startSuffix, endSuffix)
 	} else {
-		dailyFilter = `_TABLE_SUFFIX BETWEEN FORMAT_DATE('%%Y%%m%%d', DATE(@start_date)) AND FORMAT_DATE('%%Y%%m%%d', DATE(@end_date))`
-		intradayFilter = `_TABLE_SUFFIX BETWEEN CONCAT('intraday_', FORMAT_DATE('%%Y%%m%%d', DATE(@start_date))) AND CONCAT('intraday_', FORMAT_DATE('%%Y%%m%%d', DATE(@end_date)))`
+		// Single %Y%m%d: this string is interpolated into queries as a fmt.Sprintf
+		// ARGUMENT (%s), never as a format string, so doubled percent signs survived
+		// verbatim into the SQL as %%Y%%m%%d — the suffix then matched no shard and the
+		// query returned 0 rows (the reason use_literal_dates=true was adopted as a
+		// workaround).
+		dailyFilter = `_TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE(@start_date)) AND FORMAT_DATE('%Y%m%d', DATE(@end_date))`
+		intradayFilter = `_TABLE_SUFFIX BETWEEN CONCAT('intraday_', FORMAT_DATE('%Y%m%d', DATE(@start_date))) AND CONCAT('intraday_', FORMAT_DATE('%Y%m%d', DATE(@end_date)))`
 	}
 
 	if !needsIntraday {

--- a/internal/analytics/bigquery/client_test.go
+++ b/internal/analytics/bigquery/client_test.go
@@ -118,10 +118,10 @@ func TestClient_EventsSourceColumns(t *testing.T) {
 		assert.Contains(t, src, "OR")
 	})
 
-	t.Run("no columns falls back to SELECT *", func(t *testing.T) {
-		src, err := c.eventsSourceColumns(lastWeek, yesterday)
-		require.NoError(t, err)
-		assert.Contains(t, src, "SELECT * FROM")
+	t.Run("no columns is rejected (no SELECT * fallback)", func(t *testing.T) {
+		_, err := c.eventsSourceColumns(lastWeek, yesterday)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one column")
 	})
 
 	t.Run("nested columns preserved", func(t *testing.T) {
@@ -200,6 +200,17 @@ func TestClient_EventsSourceColumns(t *testing.T) {
 		_, err := c.eventsSourceColumns(lastWeek, yesterday, "event_name -- comment")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid")
+	})
+
+	t.Run("parameterized date filter uses a single-percent FORMAT_DATE", func(t *testing.T) {
+		// useLiteralDates is false here, so the parameterized branch runs. The string is
+		// later interpolated as a %s argument, so it must already contain a literal
+		// '%Y%m%d' — doubled percents (%%Y%%m%%d) would survive into the SQL and match no
+		// table shard, returning 0 rows.
+		src, err := c.eventsSourceColumns(lastWeek, today, "event_name")
+		require.NoError(t, err)
+		assert.Contains(t, src, "FORMAT_DATE('%Y%m%d'", "must emit a valid YYYYMMDD format")
+		assert.NotContains(t, src, "%%", "percent signs must not be doubled in the produced SQL")
 	})
 }
 
@@ -384,6 +395,37 @@ func TestClient_GetWebVitals_Integration(t *testing.T) {
 		t.Logf("Found %d/%d rows with non-zero avg_metric_value", nonZeroCount, len(rows))
 		assert.Greater(t, nonZeroCount, 0, "Expected at least some rows with non-zero avg_metric_value (LCP/FCP/TTFB should always be >0)")
 	}
+}
+
+func TestClient_GetCampaignAttribution_Integration(t *testing.T) {
+	credsPath := findBQCreds(t)
+	if credsPath == "" {
+		t.Skip("BigQuery credentials not found - skipping integration test")
+	}
+	projectID := os.Getenv("BIGQUERY_PROJECT_ID")
+	datasetID := os.Getenv("BIGQUERY_DATASET_ID")
+	if projectID == "" || datasetID == "" {
+		t.Skip("BIGQUERY_PROJECT_ID and BIGQUERY_DATASET_ID required")
+	}
+
+	ctx := context.Background()
+	cfg := &Config{
+		ProjectID:       projectID,
+		DatasetID:       datasetID,
+		CredentialsJSON: credsPath,
+	}
+	client, err := NewClient(ctx, cfg)
+	require.NoError(t, err)
+	defer client.Close()
+
+	end := time.Now().AddDate(0, 0, -1)
+	start := end.AddDate(0, 0, -6)
+
+	// Exercises the cross-midnight fix: session_campaigns groups by (user, session)
+	// with MIN(event_date), so a session spanning midnight no longer double-counts.
+	rows, err := client.GetCampaignAttribution(ctx, start, end)
+	require.NoError(t, err)
+	t.Logf("GetCampaignAttribution returned %d rows", len(rows))
 }
 
 func TestClient_GetUserJourneys_Integration(t *testing.T) {

--- a/internal/analytics/bigquery/queries_checkout.go
+++ b/internal/analytics/bigquery/queries_checkout.go
@@ -333,8 +333,8 @@ func (c *Client) getPaymentFailures(
 	sql := fmt.Sprintf(`
 		SELECT
 			DATE(TIMESTAMP_MICROS(event_timestamp)) AS event_date,
-			(SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'error_code') AS error_code,
-			(SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'payment_type') AS payment_type,
+			IFNULL((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'error_code'), '') AS error_code,
+			IFNULL((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'payment_type'), '') AS payment_type,
 			COUNT(*) AS failure_count,
 			COALESCE(SUM((SELECT value.double_value FROM UNNEST(event_params) WHERE key = 'order_value')), 0) AS total_failed_value,
 			COALESCE(AVG((SELECT value.double_value FROM UNNEST(event_params) WHERE key = 'order_value')), 0) AS avg_failed_order_value

--- a/internal/analytics/bigquery/queries_engagement.go
+++ b/internal/analytics/bigquery/queries_engagement.go
@@ -53,21 +53,25 @@ func (c *Client) getWebVitals(
 					(SELECT value.double_value FROM UNNEST(event_params) WHERE key = 'value'),
 					(SELECT CAST(value.int_value AS FLOAT64) FROM UNNEST(event_params) WHERE key = 'value')
 				) AS metric_value,
-				(SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'metric_rating') AS metric_rating
+				IFNULL((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'metric_rating'), '') AS metric_rating
 			FROM %s
 			WHERE %s
 				AND (event_name IN ('LCP','INP','CLS','FCP','TTFB') OR event_name = 'purchase')
 		),
 		vitals AS (
+			-- One representative value per (session, metric): a session that fires the
+			-- same vital several times would otherwise weight that many times in the
+			-- AVG below, biasing the metric toward chatty sessions.
 			SELECT
 				event_date,
 				user_pseudo_id,
 				session_id,
 				event_name AS metric_name,
-				metric_value,
-				metric_rating
+				metric_rating,
+				AVG(metric_value) AS metric_value
 			FROM base_events
 			WHERE event_name IN ('LCP','INP','CLS','FCP','TTFB')
+			GROUP BY event_date, user_pseudo_id, session_id, event_name, metric_rating
 		),
 		session_conversions AS (
 			SELECT
@@ -577,7 +581,11 @@ func (c *Client) getCampaignAttribution(
 		),
 		session_campaigns AS (
 			SELECT
-				DATE(TIMESTAMP_MICROS(event_timestamp)) AS event_date,
+				-- One canonical day per session (its first event day). Grouping by
+				-- event_date too would split a session that spans midnight UTC into two
+				-- rows that then BOTH join the single session_purchases row below,
+				-- double-counting that session's revenue and conversions across days.
+				MIN(DATE(TIMESTAMP_MICROS(event_timestamp))) AS event_date,
 				user_pseudo_id,
 				(SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') AS session_id,
 				COALESCE(
@@ -603,7 +611,7 @@ func (c *Client) getCampaignAttribution(
 				) AS utm_campaign
 			FROM %[1]s
 			WHERE %[2]s
-			GROUP BY event_date, user_pseudo_id, session_id
+			GROUP BY user_pseudo_id, session_id
 		)
 		SELECT
 			sc.event_date,

--- a/internal/analytics/bigquery/queries_funnel.go
+++ b/internal/analytics/bigquery/queries_funnel.go
@@ -570,6 +570,10 @@ func (c *Client) getHeroFunnel(
 	query := c.client.Query(sql)
 	if !c.useLiteralDates {
 		query.Parameters = []bigquery.QueryParameter{
+			// start_date/end_date bind the events_* _TABLE_SUFFIX filter from
+			// eventsSourceColumns(startDate, scanEnd) — its end is scanEnd, not endDate.
+			{Name: "start_date", Value: startDate},
+			{Name: "end_date", Value: scanEnd},
 			{Name: "scan_start", Value: startDate},
 			{Name: "scan_end", Value: scanEnd},
 			{Name: "out_start", Value: startDate},
@@ -733,6 +737,10 @@ func (c *Client) getHeroFunnelAggregate(
 	query := c.client.Query(sql)
 	if !c.useLiteralDates {
 		query.Parameters = []bigquery.QueryParameter{
+			// start_date/end_date bind the events_* _TABLE_SUFFIX filter from
+			// eventsSourceColumns(startDate, scanEnd) — its end is scanEnd, not endDate.
+			{Name: "start_date", Value: startDate},
+			{Name: "end_date", Value: scanEnd},
 			{Name: "scan_start", Value: startDate},
 			{Name: "scan_end", Value: scanEnd},
 			{Name: "out_start", Value: startDate},

--- a/internal/analytics/bigquery/queries_product.go
+++ b/internal/analytics/bigquery/queries_product.go
@@ -338,9 +338,9 @@ func (c *Client) getSizeIntent(
 	sql := fmt.Sprintf(`
 		SELECT
 			DATE(TIMESTAMP_MICROS(event_timestamp)) AS event_date,
-			(SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'product_id') AS product_id,
+			IFNULL((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'product_id'), '') AS product_id,
 			SAFE_CAST((SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'size_id') AS INT64) AS size_id,
-			(SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'size_name') AS size_name,
+			IFNULL((SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'size_name'), '') AS size_name,
 			COUNT(*) AS size_clicks
 		FROM %s
 		WHERE %s

--- a/internal/analytics/bigquery/zz_parampath_smoke_test.go
+++ b/internal/analytics/bigquery/zz_parampath_smoke_test.go
@@ -1,0 +1,66 @@
+package bigquery
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// Param-path coverage guard: exercises a broad spread of Get* methods on the
+// PARAMETERIZED path (UseLiteralDates:false) against live BigQuery, confirming every
+// query binds its @start_date/@end_date (and other) params. This is the only test that
+// covers all queries on the parameterized path; it caught a missing start_date/end_date
+// binding in the hero-funnel queries. Skips without BigQuery creds (normal CI/dev).
+func TestClient_ParamPathSmoke_Integration(t *testing.T) {
+	credsPath := findBQCreds(t)
+	if credsPath == "" {
+		t.Skip("no creds")
+	}
+	projectID := os.Getenv("BIGQUERY_PROJECT_ID")
+	datasetID := os.Getenv("BIGQUERY_DATASET_ID")
+	if projectID == "" || datasetID == "" {
+		t.Skip("need project/dataset")
+	}
+	ctx := context.Background()
+	c, err := NewClient(ctx, &Config{ProjectID: projectID, DatasetID: datasetID, CredentialsJSON: credsPath /* UseLiteralDates defaults false → parameterized */})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close()
+
+	end := time.Now().AddDate(0, 0, -1)
+	start := end.AddDate(0, 0, -6)
+
+	run := func(name string, fn func() error) {
+		if err := fn(); err != nil {
+			t.Errorf("FAIL %s: %v", name, err)
+		} else {
+			t.Logf("ok   %s", name)
+		}
+	}
+
+	run("GetFunnelAnalysis", func() error { _, e := c.GetFunnelAnalysis(ctx, start, end); return e })
+	run("GetOOSImpact", func() error { _, e := c.GetOOSImpact(ctx, start, end); return e })
+	run("GetDeviceFunnel", func() error { _, e := c.GetDeviceFunnel(ctx, start, end); return e })
+	run("GetProductEngagement", func() error { _, e := c.GetProductEngagement(ctx, start, end); return e })
+	run("GetFormErrors", func() error { _, e := c.GetFormErrors(ctx, start, end); return e })
+	run("GetExceptions", func() error { _, e := c.GetExceptions(ctx, start, end); return e })
+	run("Get404Pages", func() error { _, e := c.Get404Pages(ctx, start, end); return e })
+	run("GetHeroFunnel", func() error { _, e := c.GetHeroFunnel(ctx, start, end); return e })
+	run("GetSizeConfidence", func() error { _, e := c.GetSizeConfidence(ctx, start, end); return e })
+	run("GetPaymentRecovery", func() error { _, e := c.GetPaymentRecovery(ctx, start, end); return e })
+	run("GetCheckoutTimings", func() error { _, e := c.GetCheckoutTimings(ctx, start, end); return e })
+	run("GetAddToCartRate", func() error { _, e := c.GetAddToCartRate(ctx, start, end); return e })
+	run("GetBrowserBreakdown", func() error { _, e := c.GetBrowserBreakdown(ctx, start, end); return e })
+	run("GetNewsletterSignups", func() error { _, e := c.GetNewsletterSignups(ctx, start, end); return e })
+	run("GetAbandonedCart", func() error { _, e := c.GetAbandonedCart(ctx, start, end); return e })
+	run("GetTimeOnPage", func() error { _, e := c.GetTimeOnPage(ctx, start, end); return e })
+	run("GetProductZoom", func() error { _, e := c.GetProductZoom(ctx, start, end); return e })
+	run("GetImageSwipes", func() error { _, e := c.GetImageSwipes(ctx, start, end); return e })
+	run("GetSizeGuideClicks", func() error { _, e := c.GetSizeGuideClicks(ctx, start, end); return e })
+	run("GetDetailsExpansion", func() error { _, e := c.GetDetailsExpansion(ctx, start, end); return e })
+	run("GetNotifyMeIntent", func() error { _, e := c.GetNotifyMeIntent(ctx, start, end); return e })
+	run("GetHeroFunnelAggregate", func() error { _, e := c.GetHeroFunnelAggregate(ctx, start, end); return e })
+	run("GetUserJourneys", func() error { _, e := c.GetUserJourneys(ctx, start, end, 100); return e })
+}

--- a/internal/analytics/ga4/client.go
+++ b/internal/analytics/ga4/client.go
@@ -200,72 +200,82 @@ func (c *Client) GetProductPageMetrics(ctx context.Context, startDate, endDate t
 }
 
 func (c *Client) getProductPageMetrics(ctx context.Context, startDate, endDate time.Time) ([]ProductPageMetrics, error) {
-	req := &analyticsdata.RunReportRequest{
-		DateRanges: []*analyticsdata.DateRange{
-			{
-				StartDate: startDate.Format("2006-01-02"),
-				EndDate:   endDate.Format("2006-01-02"),
-			},
-		},
-		Dimensions: []*analyticsdata.Dimension{
-			{Name: "date"},
-			{Name: "pagePath"},
-		},
-		Metrics: []*analyticsdata.Metric{
-			{Name: "screenPageViews"},
-			{Name: "sessions"},
-			{Name: "addToCarts"},
-		},
-		DimensionFilter: &analyticsdata.FilterExpression{
-			Filter: &analyticsdata.Filter{
-				FieldName: "pagePath",
-				StringFilter: &analyticsdata.StringFilter{
-					MatchType: "CONTAINS",
-					Value:     "/product/", // Adjust based on your URL structure
-				},
-			},
-		},
-		OrderBys: []*analyticsdata.OrderBy{
-			{
-				Metric: &analyticsdata.MetricOrderBy{MetricName: "screenPageViews"},
-				Desc:   true,
-			},
-		},
-		Limit: 1000,
-	}
-
-	resp, err := c.service.Properties.RunReport(fmt.Sprintf("properties/%s", c.propertyID), req).Context(ctx).Do()
-	if err != nil {
-		return nil, fmt.Errorf("failed to run GA4 product report: %w", err)
-	}
+	const pageSize = int64(10000)
+	sd := startDate.Format("2006-01-02")
+	ed := endDate.Format("2006-01-02")
 
 	var metrics []ProductPageMetrics
-	for _, row := range resp.Rows {
-		if len(row.DimensionValues) < 2 || len(row.MetricValues) < 3 {
-			continue
+	// Paginate: a single request returns at most Limit rows, so without an offset loop
+	// the low-traffic tail of products is silently dropped (a 7-day window multiplies
+	// rows by day). Stop once a short page comes back.
+	for offset := int64(0); ; offset += pageSize {
+		req := &analyticsdata.RunReportRequest{
+			DateRanges: []*analyticsdata.DateRange{
+				{StartDate: sd, EndDate: ed},
+			},
+			Dimensions: []*analyticsdata.Dimension{
+				{Name: "date"},
+				{Name: "pagePath"},
+			},
+			Metrics: []*analyticsdata.Metric{
+				{Name: "screenPageViews"},
+				{Name: "sessions"},
+				{Name: "addToCarts"},
+			},
+			DimensionFilter: &analyticsdata.FilterExpression{
+				Filter: &analyticsdata.Filter{
+					FieldName: "pagePath",
+					StringFilter: &analyticsdata.StringFilter{
+						MatchType: "CONTAINS",
+						Value:     "/product/", // Adjust based on your URL structure
+					},
+				},
+			},
+			OrderBys: []*analyticsdata.OrderBy{
+				{
+					Metric: &analyticsdata.MetricOrderBy{MetricName: "screenPageViews"},
+					Desc:   true,
+				},
+			},
+			Limit:  pageSize,
+			Offset: offset,
 		}
 
-		dateStr := row.DimensionValues[0].Value
-		date, err := time.Parse("20060102", dateStr)
+		resp, err := c.service.Properties.RunReport(fmt.Sprintf("properties/%s", c.propertyID), req).Context(ctx).Do()
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("failed to run GA4 product report: %w", err)
 		}
 
-		pagePath := row.DimensionValues[1].Value
-		productID := extractProductIDFromPath(pagePath)
-		if productID == 0 {
-			continue
+		for _, row := range resp.Rows {
+			if len(row.DimensionValues) < 2 || len(row.MetricValues) < 3 {
+				continue
+			}
+
+			dateStr := row.DimensionValues[0].Value
+			date, err := time.Parse("20060102", dateStr)
+			if err != nil {
+				continue
+			}
+
+			pagePath := row.DimensionValues[1].Value
+			productID := extractProductIDFromPath(pagePath)
+			if productID == 0 {
+				continue
+			}
+
+			metrics = append(metrics, ProductPageMetrics{
+				Date:       date,
+				ProductID:  strconv.Itoa(productID),
+				PagePath:   pagePath,
+				PageViews:  parseInt(row.MetricValues[0].Value),
+				Sessions:   parseInt(row.MetricValues[1].Value),
+				AddToCarts: parseInt(row.MetricValues[2].Value),
+			})
 		}
 
-		m := ProductPageMetrics{
-			Date:       date,
-			ProductID:  strconv.Itoa(productID),
-			PagePath:   pagePath,
-			PageViews:  parseInt(row.MetricValues[0].Value),
-			Sessions:   parseInt(row.MetricValues[1].Value),
-			AddToCarts: parseInt(row.MetricValues[2].Value),
+		if int64(len(resp.Rows)) < pageSize {
+			break
 		}
-		metrics = append(metrics, m)
 	}
 
 	return metrics, nil
@@ -290,54 +300,62 @@ func (c *Client) GetCountryMetrics(ctx context.Context, startDate, endDate time.
 }
 
 func (c *Client) getCountryMetrics(ctx context.Context, startDate, endDate time.Time) ([]CountryMetrics, error) {
-	req := &analyticsdata.RunReportRequest{
-		DateRanges: []*analyticsdata.DateRange{
-			{
-				StartDate: startDate.Format("2006-01-02"),
-				EndDate:   endDate.Format("2006-01-02"),
-			},
-		},
-		Dimensions: []*analyticsdata.Dimension{
-			{Name: "date"},
-			{Name: "country"},
-		},
-		Metrics: []*analyticsdata.Metric{
-			{Name: "sessions"},
-			{Name: "totalUsers"},
-		},
-		OrderBys: []*analyticsdata.OrderBy{
-			{
-				Metric: &analyticsdata.MetricOrderBy{MetricName: "sessions"},
-				Desc:   true,
-			},
-		},
-		Limit: 500,
-	}
-
-	resp, err := c.service.Properties.RunReport(fmt.Sprintf("properties/%s", c.propertyID), req).Context(ctx).Do()
-	if err != nil {
-		return nil, fmt.Errorf("failed to run GA4 country report: %w", err)
-	}
+	const pageSize = int64(10000)
+	sd := startDate.Format("2006-01-02")
+	ed := endDate.Format("2006-01-02")
 
 	var metrics []CountryMetrics
-	for _, row := range resp.Rows {
-		if len(row.DimensionValues) < 2 || len(row.MetricValues) < 2 {
-			continue
+	// Paginate so country-days beyond the first page are not silently truncated.
+	for offset := int64(0); ; offset += pageSize {
+		req := &analyticsdata.RunReportRequest{
+			DateRanges: []*analyticsdata.DateRange{
+				{StartDate: sd, EndDate: ed},
+			},
+			Dimensions: []*analyticsdata.Dimension{
+				{Name: "date"},
+				{Name: "country"},
+			},
+			Metrics: []*analyticsdata.Metric{
+				{Name: "sessions"},
+				{Name: "totalUsers"},
+			},
+			OrderBys: []*analyticsdata.OrderBy{
+				{
+					Metric: &analyticsdata.MetricOrderBy{MetricName: "sessions"},
+					Desc:   true,
+				},
+			},
+			Limit:  pageSize,
+			Offset: offset,
 		}
 
-		dateStr := row.DimensionValues[0].Value
-		date, err := time.Parse("20060102", dateStr)
+		resp, err := c.service.Properties.RunReport(fmt.Sprintf("properties/%s", c.propertyID), req).Context(ctx).Do()
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("failed to run GA4 country report: %w", err)
 		}
 
-		m := CountryMetrics{
-			Date:     date,
-			Country:  row.DimensionValues[1].Value,
-			Sessions: parseInt(row.MetricValues[0].Value),
-			Users:    parseInt(row.MetricValues[1].Value),
+		for _, row := range resp.Rows {
+			if len(row.DimensionValues) < 2 || len(row.MetricValues) < 2 {
+				continue
+			}
+
+			dateStr := row.DimensionValues[0].Value
+			date, err := time.Parse("20060102", dateStr)
+			if err != nil {
+				continue
+			}
+
+			metrics = append(metrics, CountryMetrics{
+				Date:     date,
+				Country:  row.DimensionValues[1].Value,
+				Sessions: parseInt(row.MetricValues[0].Value),
+				Users:    parseInt(row.MetricValues[1].Value),
+			})
 		}
-		metrics = append(metrics, m)
+
+		if int64(len(resp.Rows)) < pageSize {
+			break
+		}
 	}
 
 	return metrics, nil
@@ -619,6 +637,9 @@ func (c *Client) getEcommerceBatch(
 		if more0 {
 			r := resp.Reports[reqIdx]
 			for _, row := range r.Rows {
+				if len(row.DimensionValues) < 1 || len(row.MetricValues) < 5 {
+					continue
+				}
 				date, err := time.Parse("20060102", row.DimensionValues[0].Value)
 				if err != nil {
 					slog.Default().WarnContext(ctx, "ga4: skipping ecom row with bad date",
@@ -646,6 +667,9 @@ func (c *Client) getEcommerceBatch(
 		if more1 {
 			r := resp.Reports[reqIdx]
 			for _, row := range r.Rows {
+				if len(row.DimensionValues) < 4 || len(row.MetricValues) < 3 {
+					continue
+				}
 				date, err := time.Parse("20060102", row.DimensionValues[0].Value)
 				if err != nil {
 					slog.Default().WarnContext(ctx, "ga4: skipping rev row with bad date",
@@ -678,6 +702,9 @@ func (c *Client) getEcommerceBatch(
 		if more2 {
 			r := resp.Reports[reqIdx]
 			for _, row := range r.Rows {
+				if len(row.DimensionValues) < 3 || len(row.MetricValues) < 4 {
+					continue
+				}
 				date, err := time.Parse("20060102", row.DimensionValues[0].Value)
 				if err != nil {
 					slog.Default().WarnContext(ctx, "ga4: skipping prod row with bad date",

--- a/internal/analytics/ga4mp/client.go
+++ b/internal/analytics/ga4mp/client.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
 )
 
@@ -19,6 +19,7 @@ const (
 )
 
 type Config struct {
+	Enabled       bool   `mapstructure:"enabled"`
 	MeasurementID string `mapstructure:"measurement_id"` // G-XXXXXXX
 	APISecret     string `mapstructure:"api_secret"`
 }
@@ -43,7 +44,28 @@ func New(cfg *Config) *Client {
 // stitches into the same GA4 session/funnel. Falls back to a deterministic UUID from buyer email.
 // Non-blocking: errors are logged but never propagated to callers.
 func (c *Client) TrackPurchase(ctx context.Context, order entity.OrderFull) {
+	// Honor the GA4MP_ENABLED switch and never POST with blank credentials (e.g. on
+	// beta where analytics is off). GA4's /mp/collect returns 2xx even for garbage, so
+	// a misconfigured send would otherwise silently look successful.
+	if c.cfg == nil || !c.cfg.Enabled || c.cfg.MeasurementID == "" || c.cfg.APISecret == "" {
+		return
+	}
+	// Detach from the caller's context. The payment monitor cancels its context via
+	// defer cancel() the moment it returns, which would abort this in-flight send and
+	// silently drop the purchase event. We keep the context values (trace/log IDs) but
+	// drop cancellation; sendPurchaseEvent applies its own requestTimeout.
+	ctx = context.WithoutCancel(ctx)
 	go func() {
+		// A panic in this best-effort analytics goroutine must never take down the
+		// payment-processing process.
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Default().ErrorContext(ctx, "ga4mp: panic while tracking purchase",
+					slog.String("orderUUID", order.Order.UUID),
+					slog.Any("panic", r),
+				)
+			}
+		}()
 		if err := c.sendPurchaseEvent(ctx, order); err != nil {
 			slog.Default().ErrorContext(ctx, "ga4mp: failed to send purchase event",
 				slog.String("orderUUID", order.Order.UUID),
@@ -51,10 +73,7 @@ func (c *Client) TrackPurchase(ctx context.Context, order entity.OrderFull) {
 				slog.String("clientID", order.Order.GAClientID.String),
 			)
 		}
-		slog.Default().InfoContext(ctx, "ga4mp: purchase event sent",
-			slog.String("orderUUID", order.Order.UUID),
-			slog.String("clientID", order.Order.GAClientID.String),
-		)
+		// success is logged inside sendPurchaseEvent
 	}()
 }
 
@@ -64,7 +83,10 @@ func (c *Client) sendPurchaseEvent(ctx context.Context, order entity.OrderFull) 
 
 	clientID := order.Order.GAClientID.String
 	if !order.Order.GAClientID.Valid || clientID == "" {
-		clientID = deterministicClientID(order.Buyer.Email)
+		// No GA cookie on the order (e.g. admin/custom order): fall back to the order
+		// UUID. Do NOT derive the client_id from the buyer's email — a hash of an email
+		// is still a PII-derived identifier and must not be sent to GA without consent.
+		clientID = order.Order.UUID
 	}
 	val, _ := order.Order.TotalPrice.Float64()
 
@@ -112,7 +134,8 @@ func (c *Client) sendPurchaseEvent(ctx context.Context, order entity.OrderFull) 
 	if err != nil {
 		return fmt.Errorf("send request: %w", err)
 	}
-	defer resp.Body.Close()
+	// Drain before close so the keep-alive connection can be reused.
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
@@ -123,10 +146,6 @@ func (c *Client) sendPurchaseEvent(ctx context.Context, order entity.OrderFull) 
 		slog.String("clientID", clientID),
 	)
 	return nil
-}
-
-func deterministicClientID(email string) string {
-	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte(email)).String()
 }
 
 type mpPayload struct {

--- a/internal/analytics/ga4sync/worker.go
+++ b/internal/analytics/ga4sync/worker.go
@@ -16,6 +16,24 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// ga4FinalizationDays is the trailing window (in days) the GA4 API tier always
+// re-fetches on every run. GA4's Data API keeps restating a day's metrics for ~48h
+// after it first lands, so the last couple of days are re-pulled to correct partial,
+// empty, or late-arriving data. Without this a day fetched while still empty would be
+// marked synced and frozen, leaving a permanent silent gap. Re-fetching is safe
+// because all GA4 saves are UPSERT (idempotent).
+const ga4FinalizationDays = 2
+
+// stopTimeout bounds how long Stop waits for in-flight syncs to drain after the
+// context is cancelled, so shutdown can't hang on a query that's slow to cancel.
+const stopTimeout = 30 * time.Second
+
+// ga4APISyncTypes are the GA4 Data API sub-syncs whose success high-water-marks gate
+// the API tier's fetch window. These are exactly the types that receive a success=1
+// status write (revenue_by_source/product_conversion are saved together with and gated
+// by "ecommerce"; the bq_* cache types sync on a separate cadence and are excluded).
+var ga4APISyncTypes = []string{"daily_metrics", "product_page_metrics", "country_metrics", "ecommerce"}
+
 // Config holds configuration for the GA4 sync worker.
 type Config struct {
 	WorkerInterval    time.Duration `mapstructure:"worker_interval"`
@@ -60,8 +78,10 @@ type Worker struct {
 	c                 *Config
 	ctx               context.Context
 	stop              context.CancelFunc
-	runMu             sync.Mutex // protects ctx, stop for Start/Stop
-	consecutiveErrors atomic.Int32
+	runMu             sync.Mutex     // protects ctx, stop for Start/Stop
+	wg                sync.WaitGroup // tracks the worker loop + in-flight async syncs
+	ga4Errors         atomic.Int32   // consecutive GA4 API tier errors
+	bqErrors          atomic.Int32   // consecutive BQ tier errors
 	ga4SyncMu         sync.Mutex
 	ga4SyncInProgress bool
 	bqSyncMu          sync.Mutex
@@ -119,29 +139,47 @@ func (w *Worker) Start(ctx context.Context) error {
 		return fmt.Errorf("ga4 sync worker already started")
 	}
 	w.ctx, w.stop = context.WithCancel(ctx)
-	go w.worker(w.ctx)
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		w.worker(w.ctx)
+	}()
 	return nil
 }
 
-// Stop stops the worker gracefully.
+// Stop stops the worker gracefully. It cancels the context and waits (bounded by
+// stopTimeout) for the worker loop and any in-flight async syncs to finish, so they
+// don't write to a DB connection the app is about to close.
 func (w *Worker) Stop() error {
 	w.runMu.Lock()
-	defer w.runMu.Unlock()
 	if w.stop == nil {
+		w.runMu.Unlock()
 		return fmt.Errorf("ga4 sync worker already stopped or not started")
 	}
 	w.stop()
 	w.ctx = nil
 	w.stop = nil
+	w.runMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(stopTimeout):
+		slog.Default().Warn("ga4 sync worker: timed out waiting for in-flight syncs to stop")
+	}
 	return nil
 }
 
 func (w *Worker) worker(ctx context.Context) {
-	if err := w.runWithBackoff(ctx, "ga4 api", w.syncGA4API); err != nil {
+	if err := w.runWithBackoff(ctx, "ga4 api", &w.ga4Errors, w.syncGA4API); err != nil {
 		slog.Default().ErrorContext(ctx, "ga4 api sync failed on startup",
 			slog.String("err", err.Error()))
 	}
-	if err := w.runWithBackoff(ctx, "bq", w.syncBQ); err != nil {
+	if err := w.runWithBackoff(ctx, "bq", &w.bqErrors, w.syncBQ); err != nil {
 		slog.Default().ErrorContext(ctx, "bq sync failed on startup",
 			slog.String("err", err.Error()))
 	}
@@ -158,9 +196,9 @@ func (w *Worker) worker(ctx context.Context) {
 	for {
 		select {
 		case <-ga4Ticker.C:
-			w.tryRunAsync(ctx, &w.ga4SyncMu, &w.ga4SyncInProgress, "ga4 api", w.syncGA4API)
+			w.tryRunAsync(ctx, &w.ga4SyncMu, &w.ga4SyncInProgress, "ga4 api", &w.ga4Errors, w.syncGA4API)
 		case <-bqTicker.C:
-			w.tryRunAsync(ctx, &w.bqSyncMu, &w.bqSyncInProgress, "bq", w.syncBQ)
+			w.tryRunAsync(ctx, &w.bqSyncMu, &w.bqSyncInProgress, "bq", &w.bqErrors, w.syncBQ)
 		case <-healthTicker.C:
 			w.logHealthStatus(ctx)
 		case <-ctx.Done():
@@ -170,7 +208,7 @@ func (w *Worker) worker(ctx context.Context) {
 }
 
 // tryRunAsync launches fn in a goroutine if a previous run isn't still in progress.
-func (w *Worker) tryRunAsync(ctx context.Context, mu *sync.Mutex, inProgress *bool, name string, fn func(context.Context) error) {
+func (w *Worker) tryRunAsync(ctx context.Context, mu *sync.Mutex, inProgress *bool, name string, counter *atomic.Int32, fn func(context.Context) error) {
 	mu.Lock()
 	if *inProgress {
 		slog.Default().WarnContext(ctx, name+" sync skipped: previous still in progress")
@@ -180,13 +218,15 @@ func (w *Worker) tryRunAsync(ctx context.Context, mu *sync.Mutex, inProgress *bo
 	*inProgress = true
 	mu.Unlock()
 
+	w.wg.Add(1)
 	go func() {
+		defer w.wg.Done()
 		defer func() {
 			mu.Lock()
 			*inProgress = false
 			mu.Unlock()
 		}()
-		if err := w.runWithBackoff(ctx, name, fn); err != nil {
+		if err := w.runWithBackoff(ctx, name, counter, fn); err != nil {
 			slog.Default().ErrorContext(ctx, name+" sync failed",
 				slog.String("err", err.Error()))
 		}
@@ -196,10 +236,12 @@ func (w *Worker) tryRunAsync(ctx context.Context, mu *sync.Mutex, inProgress *bo
 // logHealthStatus logs circuit breaker health and data staleness for monitoring/alerting.
 func (w *Worker) logHealthStatus(ctx context.Context) {
 	ga4State := w.ga4Client.CircuitBreakerState()
-	consecutiveErrors := w.consecutiveErrors.Load()
+	ga4Errors := w.ga4Errors.Load()
+	bqErrors := w.bqErrors.Load()
 	attrs := []any{
 		slog.String("ga4_circuit", ga4State.String()),
-		slog.Int("consecutive_errors", int(consecutiveErrors)),
+		slog.Int("ga4_consecutive_errors", int(ga4Errors)),
+		slog.Int("bq_consecutive_errors", int(bqErrors)),
 	}
 
 	if w.bqClient != nil {
@@ -260,7 +302,7 @@ func (w *Worker) logHealthStatus(ctx context.Context) {
 
 	if circuitOpen {
 		slog.Default().ErrorContext(ctx, "ga4sync health check: circuit breaker(s) open", attrs...)
-	} else if consecutiveErrors > 0 {
+	} else if ga4Errors > 0 || bqErrors > 0 {
 		slog.Default().WarnContext(ctx, "ga4sync health check: recent errors", attrs...)
 	} else {
 		slog.Default().InfoContext(ctx, "ga4sync health check: ok", attrs...)
@@ -269,30 +311,31 @@ func (w *Worker) logHealthStatus(ctx context.Context) {
 
 // runWithBackoff attempts fn with exponential backoff on transient errors.
 // Circuit breaker errors skip backoff since the circuit handles retry timing.
-func (w *Worker) runWithBackoff(ctx context.Context, name string, fn func(context.Context) error) error {
+func (w *Worker) runWithBackoff(ctx context.Context, name string, counter *atomic.Int32, fn func(context.Context) error) error {
 	backoff := w.c.InitialBackoff
+	var lastErr error
 
 	for attempt := 0; attempt <= w.c.MaxBackoffRetries; attempt++ {
-		err := fn(ctx)
-		if err == nil {
-			w.consecutiveErrors.Store(0)
+		lastErr = fn(ctx)
+		if lastErr == nil {
+			counter.Store(0)
 			return nil
 		}
 
-		if errors.Is(err, circuitbreaker.ErrCircuitOpen) {
+		if errors.Is(lastErr, circuitbreaker.ErrCircuitOpen) {
 			slog.Default().WarnContext(ctx, name+" sync skipped: circuit breaker open",
-				slog.Int("consecutive_errors", int(w.consecutiveErrors.Load())))
-			w.consecutiveErrors.Add(1)
-			return err
+				slog.Int("consecutive_errors", int(counter.Load())))
+			counter.Add(1)
+			return lastErr
 		}
 
-		w.consecutiveErrors.Add(1)
+		counter.Add(1)
 		if attempt < w.c.MaxBackoffRetries {
 			slog.Default().WarnContext(ctx, name+" sync failed, retrying with backoff",
 				slog.Int("attempt", attempt+1),
 				slog.Int("max_retries", w.c.MaxBackoffRetries),
 				slog.Duration("backoff", backoff),
-				slog.String("err", err.Error()))
+				slog.String("err", lastErr.Error()))
 
 			select {
 			case <-time.After(backoff):
@@ -306,24 +349,55 @@ func (w *Worker) runWithBackoff(ctx context.Context, name string, fn func(contex
 		}
 	}
 
-	return fmt.Errorf("%s sync failed after %d retries", name, w.c.MaxBackoffRetries)
+	return fmt.Errorf("%s sync failed after %d retries: %w", name, w.c.MaxBackoffRetries, lastErr)
+}
+
+// recordSyncStatus persists a sync-status row and logs (without propagating) a
+// status-write failure. The data write and the status write are separate statements,
+// so a dropped status error would otherwise silently desync the freshness/health view
+// from what was actually written.
+func (w *Worker) recordSyncStatus(ctx context.Context, syncType string, lastSyncDate time.Time, success bool, recordsSynced int, errMsg string) {
+	if err := w.syncStatus.UpdateGA4SyncStatus(ctx, syncType, lastSyncDate, success, recordsSynced, errMsg); err != nil {
+		slog.Default().ErrorContext(ctx, "ga4sync: failed to record sync status",
+			slog.String("sync_type", syncType),
+			slog.Bool("success", success),
+			slog.String("err", err.Error()))
+	}
 }
 
 // syncGA4API fetches from the GA4 Data API (daily_metrics, product_page, country, ecommerce).
-// Skips when already synced through yesterday — the GA4 Data API has ~24h lag so there's
-// nothing new to fetch until the next daily export lands.
+// The fetch window resumes from the minimum high-water-mark across the sub-syncs and always
+// includes the trailing finalization window, so late-arriving or restated GA4 data and any
+// sub-sync that fell behind are picked up. Re-fetching is idempotent (saves are UPSERT).
 func (w *Worker) syncGA4API(ctx context.Context) error {
 	now := time.Now().UTC()
 	endDate := now.AddDate(0, 0, -1) // yesterday
 
-	startDate := endDate.AddDate(0, 0, -w.c.LookbackDays)
-	if lastSync, err := w.syncStatus.GetGA4LastSyncDate(ctx, "daily_metrics"); err == nil && !lastSync.IsZero() {
-		candidateStart := lastSync.AddDate(0, 0, 1)
-		if candidateStart.After(endDate) {
-			slog.Default().InfoContext(ctx, "ga4 api sync skipped: already synced through yesterday")
-			return nil
+	lookbackStart := endDate.AddDate(0, 0, -w.c.LookbackDays)
+
+	// Window start = the earliest day any GA4 API sub-sync still needs. Each sub-sync can
+	// fail independently, so we take the minimum of their high-water-marks rather than
+	// gating the whole tier on daily_metrics alone — otherwise a sub-sync that fell behind
+	// would never be backfilled (#8). A type whose last attempt failed or never ran reads
+	// as zero and pulls the window back to the lookback floor so it re-syncs.
+	startDate := endDate
+	for _, syncType := range ga4APISyncTypes {
+		typeStart := lookbackStart
+		if ls, err := w.syncStatus.GetGA4LastSyncDate(ctx, syncType); err == nil && !ls.IsZero() {
+			typeStart = ls.AddDate(0, 0, 1)
 		}
-		startDate = candidateStart
+		if typeStart.Before(startDate) {
+			startDate = typeStart
+		}
+	}
+	// Always re-fetch the trailing finalization window (GA4 restates data for ~48h), so a
+	// day fetched while still empty/partial gets corrected instead of frozen (#3).
+	if reFetch := endDate.AddDate(0, 0, -ga4FinalizationDays); reFetch.Before(startDate) {
+		startDate = reFetch
+	}
+	if startDate.After(endDate) {
+		slog.Default().InfoContext(ctx, "ga4 api sync skipped: nothing in range")
+		return nil
 	}
 
 	slog.Default().InfoContext(ctx, "starting ga4 api sync",
@@ -405,16 +479,16 @@ func (w *Worker) purgeOldData(ctx context.Context, now time.Time) {
 func (w *Worker) syncDailyMetrics(ctx context.Context, startDate, endDate time.Time) error {
 	metrics, err := w.ga4Client.GetDailyMetrics(ctx, startDate, endDate)
 	if err != nil {
-		w.syncStatus.UpdateGA4SyncStatus(ctx, "daily_metrics", endDate, false, 0, err.Error())
+		w.recordSyncStatus(ctx, "daily_metrics", endDate, false, 0, err.Error())
 		return fmt.Errorf("failed to fetch daily metrics: %w", err)
 	}
 
 	if err := w.ga4Data.SaveGA4DailyMetrics(ctx, metrics); err != nil {
-		w.syncStatus.UpdateGA4SyncStatus(ctx, "daily_metrics", endDate, false, 0, err.Error())
+		w.recordSyncStatus(ctx, "daily_metrics", endDate, false, 0, err.Error())
 		return fmt.Errorf("failed to save daily metrics: %w", err)
 	}
 
-	w.syncStatus.UpdateGA4SyncStatus(ctx, "daily_metrics", endDate, true, len(metrics), "")
+	w.recordSyncStatus(ctx, "daily_metrics", endDate, true, len(metrics), "")
 	slog.Default().InfoContext(ctx, "synced daily metrics",
 		slog.Int("count", len(metrics)))
 	return nil
@@ -423,16 +497,16 @@ func (w *Worker) syncDailyMetrics(ctx context.Context, startDate, endDate time.T
 func (w *Worker) syncProductPageMetrics(ctx context.Context, startDate, endDate time.Time) error {
 	metrics, err := w.ga4Client.GetProductPageMetrics(ctx, startDate, endDate)
 	if err != nil {
-		w.syncStatus.UpdateGA4SyncStatus(ctx, "product_page_metrics", endDate, false, 0, err.Error())
+		w.recordSyncStatus(ctx, "product_page_metrics", endDate, false, 0, err.Error())
 		return fmt.Errorf("failed to fetch product page metrics: %w", err)
 	}
 
 	if err := w.ga4Data.SaveGA4ProductPageMetrics(ctx, metrics); err != nil {
-		w.syncStatus.UpdateGA4SyncStatus(ctx, "product_page_metrics", endDate, false, 0, err.Error())
+		w.recordSyncStatus(ctx, "product_page_metrics", endDate, false, 0, err.Error())
 		return fmt.Errorf("failed to save product page metrics: %w", err)
 	}
 
-	w.syncStatus.UpdateGA4SyncStatus(ctx, "product_page_metrics", endDate, true, len(metrics), "")
+	w.recordSyncStatus(ctx, "product_page_metrics", endDate, true, len(metrics), "")
 	slog.Default().InfoContext(ctx, "synced product page metrics",
 		slog.Int("count", len(metrics)))
 	return nil
@@ -441,16 +515,16 @@ func (w *Worker) syncProductPageMetrics(ctx context.Context, startDate, endDate 
 func (w *Worker) syncCountryMetrics(ctx context.Context, startDate, endDate time.Time) error {
 	metrics, err := w.ga4Client.GetCountryMetrics(ctx, startDate, endDate)
 	if err != nil {
-		w.syncStatus.UpdateGA4SyncStatus(ctx, "country_metrics", endDate, false, 0, err.Error())
+		w.recordSyncStatus(ctx, "country_metrics", endDate, false, 0, err.Error())
 		return fmt.Errorf("failed to fetch country metrics: %w", err)
 	}
 
 	if err := w.ga4Data.SaveGA4CountryMetrics(ctx, metrics); err != nil {
-		w.syncStatus.UpdateGA4SyncStatus(ctx, "country_metrics", endDate, false, 0, err.Error())
+		w.recordSyncStatus(ctx, "country_metrics", endDate, false, 0, err.Error())
 		return fmt.Errorf("failed to save country metrics: %w", err)
 	}
 
-	w.syncStatus.UpdateGA4SyncStatus(ctx, "country_metrics", endDate, true, len(metrics), "")
+	w.recordSyncStatus(ctx, "country_metrics", endDate, true, len(metrics), "")
 	slog.Default().InfoContext(ctx, "synced country metrics",
 		slog.Int("count", len(metrics)))
 	return nil
@@ -460,25 +534,25 @@ func (w *Worker) syncCountryMetrics(ctx context.Context, startDate, endDate time
 func (w *Worker) syncEcommerce(ctx context.Context, startDate, endDate time.Time) error {
 	ecom, revSrc, prodConv, err := w.ga4Client.GetEcommerceBatch(ctx, startDate, endDate)
 	if err != nil {
-		w.syncStatus.UpdateGA4SyncStatus(ctx, "ecommerce", endDate, false, 0, err.Error())
+		w.recordSyncStatus(ctx, "ecommerce", endDate, false, 0, err.Error())
 		return fmt.Errorf("fetch ecommerce batch: %w", err)
 	}
 
 	if err := w.ga4Data.SaveGA4EcommerceMetrics(ctx, ecom); err != nil {
-		w.syncStatus.UpdateGA4SyncStatus(ctx, "ecommerce", endDate, false, 0, err.Error())
+		w.recordSyncStatus(ctx, "ecommerce", endDate, false, 0, err.Error())
 		return fmt.Errorf("save ecommerce metrics: %w", err)
 	}
 	if err := w.ga4Data.SaveGA4RevenueBySource(ctx, revSrc); err != nil {
-		w.syncStatus.UpdateGA4SyncStatus(ctx, "revenue_by_source", endDate, false, 0, err.Error())
+		w.recordSyncStatus(ctx, "revenue_by_source", endDate, false, 0, err.Error())
 		return fmt.Errorf("save revenue by source: %w", err)
 	}
 	if err := w.ga4Data.SaveGA4ProductConversion(ctx, prodConv); err != nil {
-		w.syncStatus.UpdateGA4SyncStatus(ctx, "product_conversion", endDate, false, 0, err.Error())
+		w.recordSyncStatus(ctx, "product_conversion", endDate, false, 0, err.Error())
 		return fmt.Errorf("save product conversion: %w", err)
 	}
 
 	total := len(ecom) + len(revSrc) + len(prodConv)
-	w.syncStatus.UpdateGA4SyncStatus(ctx, "ecommerce", endDate, true, total, "")
+	w.recordSyncStatus(ctx, "ecommerce", endDate, true, total, "")
 	slog.Default().InfoContext(ctx, "synced ecommerce metrics",
 		slog.Int("ecom", len(ecom)), slog.Int("rev_src", len(revSrc)), slog.Int("prod_conv", len(prodConv)))
 	return nil
@@ -499,19 +573,27 @@ func (w *Worker) runBQPrecompute(ctx context.Context, startDate, endDate time.Ti
 
 	syncs := []syncFn{
 		{"bq_funnel", func() error {
-			if err := w.bqCache.DeleteBQFunnelAnalysisByDateRange(ctx, startDate, endDate); err != nil {
-				return fmt.Errorf("delete funnel: %w", err)
+			// Collect the whole stream, then replace the date range in ONE atomic
+			// transaction via SaveBQFunnelAnalysis (BulkReplaceByDate deletes the
+			// affected dates and re-inserts them together). The previous standalone
+			// range-DELETE followed by per-batch inserts left bq_funnel_analysis empty
+			// for concurrent dashboard reads, and lost the range entirely if the stream
+			// errored or the process died mid-sync. This now matches every other metric.
+			var rows []entity.DailyFunnel
+			if err := w.bqClient.GetFunnelAnalysisStream(ctx, startDate, endDate, 500, func(batch []entity.DailyFunnel) error {
+				rows = append(rows, batch...)
+				return nil
+			}); err != nil {
+				return fmt.Errorf("fetch funnel: %w", err)
 			}
-			var totalRows int
-			err := w.bqClient.GetFunnelAnalysisStream(ctx, startDate, endDate, 500, func(batch []entity.DailyFunnel) error {
-				totalRows += len(batch)
-				return w.bqCache.SaveBQFunnelAnalysis(ctx, batch)
-			})
+			if err := w.bqCache.SaveBQFunnelAnalysis(ctx, rows); err != nil {
+				return fmt.Errorf("save funnel: %w", err)
+			}
 			slog.Default().InfoContext(ctx, "bq_funnel sync completed",
 				slog.String("start_date", startDate.Format("2006-01-02")),
 				slog.String("end_date", endDate.Format("2006-01-02")),
-				slog.Int("rows_synced", totalRows))
-			return err
+				slog.Int("rows_synced", len(rows)))
+			return nil
 		}},
 		{"bq_oos_impact", func() error {
 			rows, err := w.bqClient.GetOOSImpact(ctx, startDate, endDate)
@@ -716,13 +798,13 @@ func (w *Worker) runBQPrecompute(ctx context.Context, startDate, endDate time.Ti
 			if err := s.fn(); err != nil {
 				slog.Default().ErrorContext(ctx, "bq precompute failed",
 					slog.String("sync", s.name), slog.String("err", err.Error()))
-				w.syncStatus.UpdateGA4SyncStatus(ctx, s.name, endDate, false, 0, err.Error())
+				w.recordSyncStatus(ctx, s.name, endDate, false, 0, err.Error())
 				mu.Lock()
 				syncErrs = append(syncErrs, fmt.Errorf("%s: %w", s.name, err))
 				mu.Unlock()
 				return nil
 			}
-			w.syncStatus.UpdateGA4SyncStatus(ctx, s.name, endDate, true, 0, "")
+			w.recordSyncStatus(ctx, s.name, endDate, true, 0, "")
 			slog.Default().InfoContext(ctx, "bq precompute done", slog.String("sync", s.name))
 			return nil
 		})

--- a/internal/api/http/http.go
+++ b/internal/api/http/http.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"strings"
 	"text/template"
 	"time"
@@ -18,9 +19,12 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	grpcSlog "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	grpcRecovery "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 
 	"github.com/jekabolt/grbpwr-manager/internal/apisrv/admin"
 	"github.com/jekabolt/grbpwr-manager/internal/apisrv/auth"
@@ -80,14 +84,20 @@ type WebhookHandler interface {
 	HandleListUnsubscribe(w http.ResponseWriter, r *http.Request)
 }
 
+// StripeWebhookHandler handles inbound Stripe webhook events (signature-verified).
+type StripeWebhookHandler interface {
+	HandleStripeEvent(w http.ResponseWriter, r *http.Request)
+}
+
 // Server is the http server
 type Server struct {
-	hs             *http.Server
-	gs             *grpc.Server
-	c              *Config
-	done           chan struct{}
-	healthChecker  HealthChecker
-	webhookHandler WebhookHandler
+	hs                   *http.Server
+	gs                   *grpc.Server
+	c                    *Config
+	done                 chan struct{}
+	healthChecker        HealthChecker
+	webhookHandler       WebhookHandler
+	stripeWebhookHandler StripeWebhookHandler
 }
 
 // New creates a new server
@@ -108,9 +118,39 @@ func (s *Server) SetWebhookHandler(h WebhookHandler) {
 	s.webhookHandler = h
 }
 
+// SetStripeWebhookHandler registers the handler for Stripe webhook events.
+func (s *Server) SetStripeWebhookHandler(h StripeWebhookHandler) {
+	s.stripeWebhookHandler = h
+}
+
 // Done returns a channel that is closed when gRPC server exits
 func (s *Server) Done() <-chan struct{} {
 	return s.done
+}
+
+// Shutdown gracefully drains in-flight requests and stops the listener. It must
+// be called before the database is closed so handlers do not race against a
+// closed connection pool. The drain is bounded by ctx.
+//
+// gRPC is served over h2c through the HTTP server (s.gs.ServeHTTP), not via a
+// dedicated gRPC listener, so draining the HTTP server is what finishes in-flight
+// unary RPCs and closes the connections. We therefore drain s.hs first, then hard
+// Stop the gRPC server to release its resources — GracefulStop would block on
+// keep-alive HTTP/2 connections that only close once s.hs has shut down.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+
+	var err error
+	if s.hs != nil {
+		// Returns http.ErrServerClosed from ListenAndServe, which closes s.done.
+		err = s.hs.Shutdown(ctx)
+	}
+	if s.gs != nil {
+		s.gs.Stop()
+	}
+	return err
 }
 
 func corsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
@@ -245,6 +285,9 @@ func (s *Server) setupHTTPAPI(ctx context.Context, auth *auth.Server) (http.Hand
 		r.Post("/api/webhooks/resend", s.webhookHandler.HandleResendEvent)
 		r.Post("/api/webhooks/list-unsubscribe/{email_b64}", s.webhookHandler.HandleListUnsubscribe)
 	}
+	if s.stripeWebhookHandler != nil {
+		r.Post("/api/webhooks/stripe", s.stripeWebhookHandler.HandleStripeEvent)
+	}
 
 	r.Mount("/", http.FileServer(http.FS(fs)))
 
@@ -320,6 +363,17 @@ func (s *Server) authJSONGateway(ctx context.Context) (http.Handler, error) {
 	return mux, nil
 }
 
+// panicRecoveryHandler logs a recovered panic with its stack trace and returns a
+// generic Internal error, so a single malformed request cannot crash the process
+// and panic internals are never leaked to the caller.
+func panicRecoveryHandler(ctx context.Context, p any) error {
+	slog.Default().ErrorContext(ctx, "recovered from panic in gRPC handler",
+		slog.Any("panic", p),
+		slog.String("stack", string(debug.Stack())),
+	)
+	return status.Error(codes.Internal, "internal server error")
+}
+
 // Start starts the server
 func (s *Server) Start(ctx context.Context,
 	adminServer *admin.Server,
@@ -332,16 +386,23 @@ func (s *Server) Start(ctx context.Context,
 		// Add any other option (check functions starting with logging.With).
 	}
 
+	// Recovery must be the outermost interceptor so it catches panics from the
+	// logging/auth interceptors and the handlers alike; grpc-go runs each call in
+	// its own goroutine with no recover, so an unhandled panic kills the process.
+	recoveryOpts := []grpcRecovery.Option{
+		grpcRecovery.WithRecoveryHandlerContext(panicRecoveryHandler),
+	}
+
 	s.gs = grpc.NewServer(
 		grpc.MaxRecvMsgSize(50*1024*1024), // 50MB
 		grpc.ChainUnaryInterceptor(
+			grpcRecovery.UnaryServerInterceptor(recoveryOpts...),
 			grpcSlog.UnaryServerInterceptor(log.InterceptorLogger(slog.Default()), opts...),
 			authServer.UnaryAdminAuthInterceptor(),
-			// grpcRecovery.UnaryServerInterceptor(),
 		),
 		grpc.ChainStreamInterceptor(
+			grpcRecovery.StreamServerInterceptor(recoveryOpts...),
 			grpcSlog.StreamServerInterceptor(log.InterceptorLogger(slog.Default()), opts...),
-			// grpcRecovery.StreamServerInterceptor(),
 		),
 	)
 	pb_admin.RegisterAdminServiceServer(s.gs, adminServer)

--- a/internal/apisrv/admin/archive.go
+++ b/internal/apisrv/admin/archive.go
@@ -29,16 +29,9 @@ func (s *Server) AddArchive(ctx context.Context, req *pb_admin.AddArchiveRequest
 		return nil, status.Errorf(codes.Internal, "can't add archive")
 	}
 
-	err = s.re.RevalidateAll(ctx, &dto.RevalidationData{
+	s.revalidateAsync(&dto.RevalidationData{
 		Archive: archiveId,
 	})
-
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "can't revalidate archive",
-			slog.String("err", err.Error()),
-		)
-		return nil, status.Errorf(codes.Internal, "can't revalidate archive")
-	}
 
 	return &pb_admin.AddArchiveResponse{
 		Id: int32(archiveId),
@@ -66,16 +59,10 @@ func (s *Server) UpdateArchive(ctx context.Context, req *pb_admin.UpdateArchiveR
 		return nil, status.Errorf(codes.Internal, "can't update archive")
 	}
 
-	err = s.re.RevalidateAll(ctx, &dto.RevalidationData{
+	s.revalidateAsync(&dto.RevalidationData{
 		Archive: int(req.Id),
 		Hero:    true,
 	})
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "can't revalidate archive",
-			slog.String("err", err.Error()),
-		)
-		return nil, status.Errorf(codes.Internal, "can't revalidate archive")
-	}
 
 	return &pb_admin.UpdateArchiveResponse{}, nil
 }
@@ -89,17 +76,10 @@ func (s *Server) DeleteArchiveById(ctx context.Context, req *pb_admin.DeleteArch
 		return nil, status.Errorf(codes.Internal, "failed to delete archive: %v", err)
 	}
 
-	err = s.re.RevalidateAll(ctx, &dto.RevalidationData{
+	s.revalidateAsync(&dto.RevalidationData{
 		Archive: int(req.Id),
 		Hero:    true,
 	})
-
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "can't revalidate archive",
-			slog.String("err", err.Error()),
-		)
-		return nil, status.Errorf(codes.Internal, "can't revalidate archive")
-	}
 
 	return &pb_admin.DeleteArchiveByIdResponse{}, nil
 }

--- a/internal/apisrv/admin/hero.go
+++ b/internal/apisrv/admin/hero.go
@@ -22,15 +22,8 @@ func (s *Server) AddHero(ctx context.Context, req *pb_admin.AddHeroRequest) (*pb
 		return nil, status.Errorf(codes.Internal, "can't add hero")
 	}
 
-	err = s.re.RevalidateAll(ctx, &dto.RevalidationData{
+	s.revalidateAsync(&dto.RevalidationData{
 		Hero: true,
 	})
-
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "can't revalidate hero",
-			slog.String("err", err.Error()),
-		)
-		return nil, status.Errorf(codes.Internal, "can't revalidate hero")
-	}
 	return &pb_admin.AddHeroResponse{}, nil
 }

--- a/internal/apisrv/admin/metrics.go
+++ b/internal/apisrv/admin/metrics.go
@@ -657,18 +657,24 @@ func funnelReconciliation(ctx context.Context, repo dependency.Repository, from,
 //
 // Note: GetMetrics calls computePeriodBounds first, so the special-period branch below
 // is unreachable in normal flows. Kept as a safety net for direct callers.
+// Metric-period parsers, compiled once at package init rather than per call.
+var (
+	metricsPeriodDaysRe    = regexp.MustCompile(`^(\d+)[dD]$`)
+	metricsPeriodISODaysRe = regexp.MustCompile(`^[pP](\d+)[dD]$`)
+)
+
 func parseMetricsPeriod(s string) (time.Duration, error) {
 	s = strings.TrimSpace(s)
 	sl := strings.ToLower(s)
-	
+
 	// Special: today or "to date" periods — handled in GetMetrics via computePeriodBounds
 	// This branch is unreachable from GetMetrics but preserved for direct callers.
 	if sl == "today" || sl == "1d" || sl == "wtd" || sl == "mtd" || sl == "qtd" || sl == "ytd" {
 		return 0, nil // signal: use computePeriodBounds
 	}
-	
+
 	// Shorthand: Nd
-	if m := regexp.MustCompile(`^(\d+)[dD]$`).FindStringSubmatch(s); len(m) == 2 {
+	if m := metricsPeriodDaysRe.FindStringSubmatch(s); len(m) == 2 {
 		days, err := strconv.Atoi(m[1])
 		if err != nil {
 			return 0, fmt.Errorf("invalid days value: %w", err)
@@ -679,7 +685,7 @@ func parseMetricsPeriod(s string) (time.Duration, error) {
 		return time.Duration(days) * 24 * time.Hour, nil
 	}
 	// ISO8601: P{n}D
-	if m := regexp.MustCompile(`^[pP](\d+)[dD]$`).FindStringSubmatch(s); len(m) == 2 {
+	if m := metricsPeriodISODaysRe.FindStringSubmatch(s); len(m) == 2 {
 		days, err := strconv.Atoi(m[1])
 		if err != nil {
 			return 0, fmt.Errorf("invalid days value: %w", err)

--- a/internal/apisrv/admin/order.go
+++ b/internal/apisrv/admin/order.go
@@ -59,6 +59,10 @@ func (s *Server) GetOrderByUUID(ctx context.Context, req *pb_admin.GetOrderByUUI
 			)
 			return nil, status.Errorf(codes.Internal, "can't check for transactions")
 		}
+		if payment == nil {
+			slog.Default().ErrorContext(ctx, "check for transactions returned no payment")
+			return nil, status.Errorf(codes.Internal, "can't check for transactions")
+		}
 
 		o.Payment = *payment
 	}

--- a/internal/apisrv/admin/product.go
+++ b/internal/apisrv/admin/product.go
@@ -79,17 +79,10 @@ func (s *Server) UpsertProduct(ctx context.Context, req *pb_admin.UpsertProductR
 		cache.RefreshDictionary(di)
 	}
 
-	err = s.re.RevalidateAll(ctx, &dto.RevalidationData{
+	s.revalidateAsync(&dto.RevalidationData{
 		Products: []int{id},
 		Hero:     true,
 	})
-
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "can't revalidate product",
-			slog.String("err", err.Error()),
-		)
-		return nil, status.Errorf(codes.Internal, "can't revalidate product: %v", err)
-	}
 
 	return &pb_admin.UpsertProductResponse{
 		Id: int32(id),
@@ -117,16 +110,10 @@ func (s *Server) DeleteProductByID(ctx context.Context, req *pb_admin.DeleteProd
 		cache.RefreshDictionary(di)
 	}
 
-	err = s.re.RevalidateAll(ctx, &dto.RevalidationData{
+	s.revalidateAsync(&dto.RevalidationData{
 		Products: []int{int(req.Id)},
 		Hero:     true,
 	})
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "can't revalidate product",
-			slog.String("err", err.Error()),
-		)
-		return nil, status.Errorf(codes.Internal, "can't revalidate product")
-	}
 	return &pb_admin.DeleteProductByIDResponse{}, nil
 }
 
@@ -391,16 +378,10 @@ func (s *Server) UpdateProductSizeStock(ctx context.Context, req *pb_admin.Updat
 		go s.notifyWaitlist(ctx, productId, sizeId)
 	}
 
-	err = s.re.RevalidateAll(ctx, &dto.RevalidationData{
+	s.revalidateAsync(&dto.RevalidationData{
 		Products: []int{productId},
 		Hero:     true,
 	})
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "can't revalidate product",
-			slog.String("err", err.Error()),
-		)
-		return nil, status.Errorf(codes.Internal, "can't revalidate product")
-	}
 	return &pb_admin.UpdateProductSizeStockResponse{}, nil
 }
 

--- a/internal/apisrv/admin/server.go
+++ b/internal/apisrv/admin/server.go
@@ -2,9 +2,11 @@ package admin
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/jekabolt/grbpwr-manager/internal/analytics/ga4mp"
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
+	"github.com/jekabolt/grbpwr-manager/internal/dto"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
 	pb_admin "github.com/jekabolt/grbpwr-manager/proto/gen/admin"
 	"google.golang.org/grpc/codes"
@@ -45,6 +47,23 @@ func New(
 		reservationMgr:    reservationMgr,
 		ga4mp:             ga4mpClient,
 	}
+}
+
+// revalidateAsync triggers storefront ISR revalidation in the background. Revalidation
+// is a cache-freshness side effect, not part of the admin operation's success: blocking
+// the RPC on it — and returning codes.Internal when Vercel is briefly unreachable — made
+// successful admin writes look failed and could hang the admin UI for many seconds while
+// RevalidateAll retried each deployment. Uses context.Background() so the in-flight
+// revalidation survives the request returning. Mirrors the frontend order-submit path.
+func (s *Server) revalidateAsync(data *dto.RevalidationData) {
+	go func() {
+		ctx := context.Background()
+		if err := s.re.RevalidateAll(ctx, data); err != nil {
+			slog.Default().ErrorContext(ctx, "async storefront revalidation failed",
+				slog.String("err", err.Error()),
+			)
+		}
+	}()
 }
 
 func (s *Server) getPaymentHandler(ctx context.Context, pm entity.PaymentMethodName) (dependency.Invoicer, error) {

--- a/internal/apisrv/admin/settings.go
+++ b/internal/apisrv/admin/settings.go
@@ -150,16 +150,9 @@ func (s *Server) UpdateSettings(ctx context.Context, req *pb_admin.UpdateSetting
 		}
 	}
 
-	err = s.re.RevalidateAll(ctx, &dto.RevalidationData{
+	s.revalidateAsync(&dto.RevalidationData{
 		Hero: true,
 	})
-
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "can't revalidate hero",
-			slog.String("err", err.Error()),
-		)
-		return nil, status.Errorf(codes.Internal, "can't revalidate hero")
-	}
 	return &pb_admin.UpdateSettingsResponse{}, nil
 }
 
@@ -196,15 +189,9 @@ func (s *Server) SetBackgroundHeroColor(ctx context.Context, req *pb_admin.SetBa
 
 	cache.SetBackgroundHeroColor(req.Color)
 
-	err = s.re.RevalidateAll(ctx, &dto.RevalidationData{
+	s.revalidateAsync(&dto.RevalidationData{
 		Hero: true,
 	})
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "can't revalidate hero after background color change",
-			slog.String("err", err.Error()),
-		)
-		return nil, status.Errorf(codes.Internal, "can't revalidate hero")
-	}
 
 	return &pb_admin.SetBackgroundHeroColorResponse{}, nil
 }

--- a/internal/apisrv/auth/auth.go
+++ b/internal/apisrv/auth/auth.go
@@ -2,7 +2,9 @@ package auth
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -52,16 +54,30 @@ type Config struct {
 // New creates a new auth server.
 func New(c *Config, ar dependency.Admin) (*Server, error) {
 
+	// An empty HS256 secret would validate any token signed with an empty key,
+	// allowing trivial admin token forgery. Fail closed at startup.
+	if c.JWTSecret == "" {
+		return nil, fmt.Errorf("auth.jwt_secret is required")
+	}
+
+	// Trim surrounding whitespace: secret managers / env injection frequently add
+	// a trailing newline, which would otherwise make the master password never
+	// match what callers send. Also fail closed if it's unset.
+	masterPassword := strings.TrimSpace(c.MasterPassword)
+	if masterPassword == "" {
+		return nil, fmt.Errorf("auth.master_password is required")
+	}
+
 	ph, err := pwhash.New(c.PasswordHasherSaltSize, c.PasswordHasherIterations)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create password hasher: %w", err)
 	}
-	hash, err := ph.HashPassword(c.MasterPassword)
+	hash, err := ph.HashPassword(masterPassword)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash master password: %w", err)
 	}
 
-	if err := ph.Validate(c.MasterPassword, hash); err != nil {
+	if err := ph.Validate(masterPassword, hash); err != nil {
 		return nil, fmt.Errorf("failed to validate master password: %w", err)
 	}
 
@@ -99,16 +115,27 @@ func (s *Server) Login(ctx context.Context, req *auth.LoginRequest) (*auth.Login
 
 	pwHash, err := s.adminRepository.PasswordHashByUsername(ctx, username)
 	if err != nil {
-		slog.Default().ErrorContext(ctx, "failed to get password hash by username",
-			slog.String("err", err.Error()),
-		)
+		// Unknown username is an expected failed login (client 401), not a server
+		// error — log at warn to keep it out of error dashboards. A genuine DB
+		// failure still logs at error so ops can tell the two apart.
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.Default().WarnContext(ctx, "login attempt for unknown username",
+				slog.String("username", username),
+			)
+		} else {
+			slog.Default().ErrorContext(ctx, "failed to get password hash by username",
+				slog.String("username", username),
+				slog.String("err", err.Error()),
+			)
+		}
 		return nil, status.Errorf(codes.Unauthenticated, "not authenticated")
 	}
 
 	err = s.pwhash.Validate(req.Password, pwHash)
 	if err != nil {
-		slog.Default().ErrorContext(ctx, "failed to validate password",
-			slog.String("err", err.Error()),
+		// Wrong password is also an expected failed login, not a server error.
+		slog.Default().WarnContext(ctx, "login attempt with invalid password",
+			slog.String("username", username),
 		)
 		return nil, status.Errorf(codes.Unauthenticated, "not authenticated")
 	}
@@ -129,12 +156,16 @@ func (s *Server) Login(ctx context.Context, req *auth.LoginRequest) (*auth.Login
 // Create creates a new user requires an admin password.
 func (s *Server) Create(ctx context.Context, req *auth.CreateRequest) (*auth.CreateResponse, error) {
 
-	err := s.pwhash.Validate(req.MasterPassword, s.masterHash)
+	err := s.pwhash.Validate(strings.TrimSpace(req.MasterPassword), s.masterHash)
 	if err != nil {
 		slog.Default().ErrorContext(ctx, "failed to validate master password",
 			slog.String("err", err.Error()),
 		)
 		return nil, status.Errorf(codes.Unauthenticated, "not authenticated")
+	}
+
+	if req.GetUser() == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "user is required")
 	}
 
 	username := strings.ToLower(req.User.Username)
@@ -170,7 +201,7 @@ func (s *Server) Create(ctx context.Context, req *auth.CreateRequest) (*auth.Cre
 
 // Delete deletes a user.
 func (s *Server) Delete(ctx context.Context, req *auth.DeleteRequest) (*auth.DeleteResponse, error) {
-	err := s.pwhash.Validate(req.MasterPassword, s.masterHash)
+	err := s.pwhash.Validate(strings.TrimSpace(req.MasterPassword), s.masterHash)
 	if err != nil {
 		slog.Default().ErrorContext(ctx, "failed to validate master password",
 			slog.String("err", err.Error()),

--- a/internal/apisrv/frontend/archive.go
+++ b/internal/apisrv/frontend/archive.go
@@ -15,9 +15,11 @@ import (
 
 func (s *Server) GetArchivesPaged(ctx context.Context, req *pb_frontend.GetArchivesPagedRequest) (*pb_frontend.GetArchivesPagedResponse, error) {
 
+	limit, offset := clampPagination(int(req.Limit), int(req.Offset), 30, 100)
+
 	afs, count, err := s.repo.Archive().GetArchivesPaged(ctx,
-		int(req.Limit),
-		int(req.Offset),
+		limit,
+		offset,
 		dto.ConvertPBCommonOrderFactorToEntity(req.OrderFactor),
 	)
 	if err != nil {

--- a/internal/apisrv/frontend/order_helpers.go
+++ b/internal/apisrv/frontend/order_helpers.go
@@ -65,6 +65,10 @@ func (s *Server) ensurePaymentIntentAmountMatchesOrder(ctx context.Context, hand
 	if err != nil {
 		return fmt.Errorf("get payment intent: %w", err)
 	}
+	// A succeeded PaymentIntent can't (and must not) have its amount updated.
+	if stripe.PaymentIntentSucceeded(stripePi) {
+		return nil
+	}
 	piAmount := stripe.AmountFromSmallestUnit(stripePi.Amount, string(stripePi.Currency))
 	orderTotal := orderFull.Order.TotalPriceDecimal()
 	if piAmount.Equal(orderTotal) {

--- a/internal/apisrv/frontend/order_post_purchase.go
+++ b/internal/apisrv/frontend/order_post_purchase.go
@@ -64,6 +64,10 @@ func (s *Server) GetOrderByUUIDAndEmail(ctx context.Context, req *pb_frontend.Ge
 			)
 			return nil, status.Errorf(codes.Internal, "can't check for transactions")
 		}
+		if payment == nil {
+			slog.Default().ErrorContext(ctx, "check for transactions returned no payment")
+			return nil, status.Errorf(codes.Internal, "can't check for transactions")
+		}
 
 		o.Payment = *payment
 	}

--- a/internal/apisrv/frontend/order_submit.go
+++ b/internal/apisrv/frontend/order_submit.go
@@ -8,6 +8,7 @@ import (
 
 	v "github.com/asaskevich/govalidator"
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
+	"github.com/jekabolt/grbpwr-manager/internal/dependency"
 	"github.com/jekabolt/grbpwr-manager/internal/dto"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
 	"github.com/jekabolt/grbpwr-manager/internal/middleware"
@@ -18,7 +19,47 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// existingOrderResponse builds the idempotent SubmitOrder response for an order
+// that already exists for the request's PaymentIntent (a retry, or the winner of
+// a concurrent-submit race). It syncs the PaymentIntent amount to the order total
+// (in case the order was updated) and returns the order's current status.
+func (s *Server) existingOrderResponse(ctx context.Context, handler dependency.Invoicer, req *pb_frontend.SubmitOrderRequest, existingOrder *entity.OrderFull) (*pb_frontend.SubmitOrderResponse, error) {
+	// Ensure PaymentIntent amount matches order total (order may have been updated on ErrOrderItemsUpdated)
+	if err := s.ensurePaymentIntentAmountMatchesOrder(ctx, handler, req.PaymentIntentId, existingOrder); err != nil {
+		slog.Default().ErrorContext(ctx, "can't sync payment intent amount on idempotent retry", slog.String("err", err.Error()))
+		return nil, status.Errorf(codes.Internal, "can't sync payment intent amount")
+	}
+
+	eos, ok := cache.GetOrderStatusById(existingOrder.Order.OrderStatusId)
+	if !ok {
+		slog.Default().ErrorContext(ctx, "failed to retrieve order status")
+		return nil, status.Errorf(codes.Internal, "order status not found")
+	}
+
+	os, ok := dto.ConvertEntityToPbOrderStatus(eos.Status.Name)
+	if !ok {
+		slog.Default().ErrorContext(ctx, "failed to convert order status")
+		return nil, status.Errorf(codes.Internal, "invalid order status")
+	}
+
+	pbPi, err := dto.ConvertEntityToPbPaymentInsert(&existingOrder.Payment.PaymentInsert)
+	if err != nil {
+		slog.Default().ErrorContext(ctx, "can't convert entity payment insert to pb payment insert", slog.String("err", err.Error()))
+		return nil, status.Errorf(codes.Internal, "can't convert entity payment insert to pb payment insert")
+	}
+	pbPi.PaymentMethod = req.Order.PaymentMethod
+
+	return &pb_frontend.SubmitOrderResponse{
+		OrderUuid:   existingOrder.Order.UUID,
+		OrderStatus: os,
+		Payment:     pbPi,
+	}, nil
+}
+
 func (s *Server) SubmitOrder(ctx context.Context, req *pb_frontend.SubmitOrderRequest) (*pb_frontend.SubmitOrderResponse, error) {
+	if req.GetOrder() == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "order is required")
+	}
 	slog.Default().InfoContext(ctx, "SubmitOrder started",
 		slog.String("payment_intent_id", req.PaymentIntentId),
 		slog.String("payment_method", string(dto.ConvertPbPaymentMethodToEntity(req.Order.PaymentMethod))),
@@ -92,37 +133,7 @@ func (s *Server) SubmitOrder(ctx context.Context, req *pb_frontend.SubmitOrderRe
 				slog.String("orderUUID", existingOrder.Order.UUID),
 				slog.String("paymentIntentId", req.PaymentIntentId),
 			)
-
-			// Ensure PaymentIntent amount matches order total (order may have been updated on ErrOrderItemsUpdated)
-			if err := s.ensurePaymentIntentAmountMatchesOrder(ctx, handler, req.PaymentIntentId, existingOrder); err != nil {
-				slog.Default().ErrorContext(ctx, "can't sync payment intent amount on idempotent retry", slog.String("err", err.Error()))
-				return nil, status.Errorf(codes.Internal, "can't sync payment intent amount")
-			}
-
-			eos, ok := cache.GetOrderStatusById(existingOrder.Order.OrderStatusId)
-			if !ok {
-				slog.Default().ErrorContext(ctx, "failed to retrieve order status")
-				return nil, status.Errorf(codes.Internal, "order status not found")
-			}
-
-			os, ok := dto.ConvertEntityToPbOrderStatus(eos.Status.Name)
-			if !ok {
-				slog.Default().ErrorContext(ctx, "failed to convert order status")
-				return nil, status.Errorf(codes.Internal, "invalid order status")
-			}
-
-			pbPi, err := dto.ConvertEntityToPbPaymentInsert(&existingOrder.Payment.PaymentInsert)
-			if err != nil {
-				slog.Default().ErrorContext(ctx, "can't convert entity payment insert to pb payment insert", slog.String("err", err.Error()))
-				return nil, status.Errorf(codes.Internal, "can't convert entity payment insert to pb payment insert")
-			}
-			pbPi.PaymentMethod = req.Order.PaymentMethod
-
-			return &pb_frontend.SubmitOrderResponse{
-				OrderUuid:   existingOrder.Order.UUID,
-				OrderStatus: os,
-				Payment:     pbPi,
-			}, nil
+			return s.existingOrderResponse(ctx, handler, req, existingOrder)
 		}
 	}
 
@@ -149,6 +160,32 @@ func (s *Server) SubmitOrder(ctx context.Context, req *pb_frontend.SubmitOrderRe
 	// Associate PaymentIntent with order BEFORE InsertFiatInvoice so retries find the order
 	// when InsertFiatInvoice returns ErrOrderItemsUpdated (prevents duplicate orders)
 	if err = s.repo.Order().AssociatePaymentIntentWithOrder(ctx, order.UUID, req.PaymentIntentId); err != nil {
+		// A concurrent SubmitOrder already claimed this PaymentIntent (UNIQUE on
+		// payment.client_secret). Drop our duplicate order and return the order
+		// that won the race, idempotently.
+		if errors.Is(err, store.ErrPaymentIntentAlreadyAssociated) {
+			slog.Default().InfoContext(ctx, "payment intent already associated with another order, returning winner",
+				slog.String("order_uuid", order.UUID),
+				slog.String("payment_intent_id", req.PaymentIntentId),
+			)
+			if cancelErr := s.repo.Order().CancelOrder(ctx, order.UUID); cancelErr != nil {
+				slog.Default().ErrorContext(ctx, "failed to cancel duplicate order after associate race",
+					slog.String("err", cancelErr.Error()),
+					slog.String("order_uuid", order.UUID),
+				)
+			}
+			s.reservationMgr.Release(ctx, order.UUID)
+
+			existingOrder, lookupErr := s.repo.Order().GetOrderByPaymentIntentId(ctx, req.PaymentIntentId)
+			if lookupErr != nil || existingOrder == nil {
+				slog.Default().ErrorContext(ctx, "can't load winning order after associate race",
+					slog.String("payment_intent_id", req.PaymentIntentId),
+				)
+				return nil, status.Errorf(codes.Aborted, "order is being processed, please retry")
+			}
+			return s.existingOrderResponse(ctx, handler, req, existingOrder)
+		}
+
 		slog.Default().ErrorContext(ctx, "can't associate payment intent with order",
 			slog.String("err", err.Error()),
 			slog.String("order_uuid", order.UUID),
@@ -164,21 +201,33 @@ func (s *Server) SubmitOrder(ctx context.Context, req *pb_frontend.SubmitOrderRe
 		return nil, status.Errorf(codes.Internal, "can't associate payment intent with order")
 	}
 
+	// The client may have already confirmed the card payment before SubmitOrder
+	// finished (the client_secret is handed out by ValidateOrderItemsInsert). A
+	// succeeded PaymentIntent can no longer have its shipping/amount updated, so
+	// skip those Stripe mutations to avoid failing the request (and cancelling a
+	// paid order). The payment is reconciled below via CheckForTransactions.
+	paymentAlreadySucceeded := false
+	if existingPi, piErr := handler.GetPaymentIntentByID(ctx, req.PaymentIntentId); piErr == nil {
+		paymentAlreadySucceeded = stripe.PaymentIntentSucceeded(existingPi)
+	}
+
 	// Update existing PaymentIntent with order details (using data we already have - no DB query!)
-	err = handler.UpdatePaymentIntentWithOrderNew(ctx, req.PaymentIntentId, order.UUID, orderNew)
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "can't update payment intent with order",
-			slog.String("err", err.Error()),
-			slog.String("order_uuid", order.UUID),
-		)
-		if cancelErr := s.repo.Order().CancelOrder(ctx, order.UUID); cancelErr != nil {
-			slog.Default().ErrorContext(ctx, "failed to cancel order after update failure",
-				slog.String("err", cancelErr.Error()),
+	if !paymentAlreadySucceeded {
+		err = handler.UpdatePaymentIntentWithOrderNew(ctx, req.PaymentIntentId, order.UUID, orderNew)
+		if err != nil {
+			slog.Default().ErrorContext(ctx, "can't update payment intent with order",
+				slog.String("err", err.Error()),
 				slog.String("order_uuid", order.UUID),
 			)
+			if cancelErr := s.repo.Order().CancelOrder(ctx, order.UUID); cancelErr != nil {
+				slog.Default().ErrorContext(ctx, "failed to cancel order after update failure",
+					slog.String("err", cancelErr.Error()),
+					slog.String("order_uuid", order.UUID),
+				)
+			}
+			s.reservationMgr.Release(ctx, order.UUID)
+			return nil, status.Errorf(codes.Internal, "can't update payment intent with order")
 		}
-		s.reservationMgr.Release(ctx, order.UUID)
-		return nil, status.Errorf(codes.Internal, "can't update payment intent with order")
 	}
 
 	var orderFull *entity.OrderFull
@@ -221,35 +270,57 @@ func (s *Server) SubmitOrder(ctx context.Context, req *pb_frontend.SubmitOrderRe
 		return nil, status.Errorf(codes.Internal, "can't get payment intent for validation")
 	}
 
-	// Convert PaymentIntent amount from smallest currency unit to decimal
-	// For zero-decimal currencies (like JPY, KRW), amount is already in decimal
-	// For other currencies, convert from cents
-	piAmount := stripe.AmountFromSmallestUnit(stripePi.Amount, string(stripePi.Currency))
-	orderTotal := orderFull.Order.TotalPriceDecimal()
+	// A succeeded PaymentIntent (customer paid during submit) can't have its
+	// amount updated — and must not be touched. Skip the sync and reconcile below.
+	if stripe.PaymentIntentSucceeded(stripePi) {
+		paymentAlreadySucceeded = true
+	} else {
+		// Convert PaymentIntent amount from smallest currency unit to decimal
+		// For zero-decimal currencies (like JPY, KRW), amount is already in decimal
+		// For other currencies, convert from cents
+		piAmount := stripe.AmountFromSmallestUnit(stripePi.Amount, string(stripePi.Currency))
+		orderTotal := orderFull.Order.TotalPriceDecimal()
 
-	// Check if amounts match (with small tolerance for rounding)
-	if !piAmount.Equal(orderTotal) {
-		slog.Default().InfoContext(ctx, "PaymentIntent amount mismatch, updating",
-			slog.String("payment_intent_id", req.PaymentIntentId),
-			slog.String("pi_amount", piAmount.String()),
-			slog.String("order_total", orderTotal.String()),
-		)
-
-		// Update PaymentIntent amount to match order total
-		err = handler.UpdatePaymentIntentAmount(ctx, req.PaymentIntentId, orderTotal, orderFull.Order.Currency)
-		if err != nil {
-			slog.Default().ErrorContext(ctx, "can't update payment intent amount",
-				slog.String("err", err.Error()),
+		// Check if amounts match (with small tolerance for rounding)
+		if !piAmount.Equal(orderTotal) {
+			slog.Default().InfoContext(ctx, "PaymentIntent amount mismatch, updating",
 				slog.String("payment_intent_id", req.PaymentIntentId),
-				slog.String("expected_amount", orderTotal.String()),
+				slog.String("pi_amount", piAmount.String()),
+				slog.String("order_total", orderTotal.String()),
 			)
-			return nil, status.Errorf(codes.Internal, "payment amount mismatch")
-		}
 
-		slog.Default().InfoContext(ctx, "PaymentIntent amount updated successfully",
+			// Update PaymentIntent amount to match order total
+			err = handler.UpdatePaymentIntentAmount(ctx, req.PaymentIntentId, orderTotal, orderFull.Order.Currency)
+			if err != nil {
+				slog.Default().ErrorContext(ctx, "can't update payment intent amount",
+					slog.String("err", err.Error()),
+					slog.String("payment_intent_id", req.PaymentIntentId),
+					slog.String("expected_amount", orderTotal.String()),
+				)
+				return nil, status.Errorf(codes.Internal, "payment amount mismatch")
+			}
+
+			slog.Default().InfoContext(ctx, "PaymentIntent amount updated successfully",
+				slog.String("payment_intent_id", req.PaymentIntentId),
+				slog.String("new_amount", orderTotal.String()),
+			)
+		}
+	}
+
+	// If the customer already paid, reconcile immediately so the order is
+	// confirmed (status, email, analytics, reservation release) and the response
+	// reflects it, instead of waiting for the expiration-time monitor.
+	if paymentAlreadySucceeded {
+		slog.Default().InfoContext(ctx, "payment already succeeded during submit, reconciling",
+			slog.String("order_uuid", order.UUID),
 			slog.String("payment_intent_id", req.PaymentIntentId),
-			slog.String("new_amount", orderTotal.String()),
 		)
+		if _, cerr := handler.CheckForTransactions(ctx, order.UUID, orderFull.Payment); cerr != nil {
+			slog.Default().ErrorContext(ctx, "can't reconcile already-succeeded payment",
+				slog.String("err", cerr.Error()),
+				slog.String("order_uuid", order.UUID),
+			)
+		}
 	}
 
 	pi := &orderFull.Payment.PaymentInsert

--- a/internal/apisrv/frontend/product.go
+++ b/internal/apisrv/frontend/product.go
@@ -91,7 +91,9 @@ func (s *Server) GetProductsPaged(ctx context.Context, req *pb_frontend.GetProdu
 	}
 	fc.ViewerTier = s.viewerTier(ctx)
 
-	prds, count, err := s.repo.Products().GetProductsPaged(ctx, int(req.Limit), int(req.Offset), sfs, of, fc, false)
+	limit, offset := clampPagination(int(req.Limit), int(req.Offset), 30, 100)
+
+	prds, count, err := s.repo.Products().GetProductsPaged(ctx, limit, offset, sfs, of, fc, false)
 	if err != nil {
 		// Check if it's a validation error (should return 4xx, not 5xx)
 		if err.Error() == "price sorting requires currency to be specified in filter conditions" {

--- a/internal/apisrv/frontend/server.go
+++ b/internal/apisrv/frontend/server.go
@@ -10,6 +10,21 @@ import (
 	pb_frontend "github.com/jekabolt/grbpwr-manager/proto/gen/frontend"
 )
 
+// clampPagination bounds a client-supplied limit/offset for public list
+// endpoints so a huge limit can't force MySQL to materialize the whole table.
+func clampPagination(limit, offset, def, max int) (int, int) {
+	if limit <= 0 {
+		limit = def
+	}
+	if limit > max {
+		limit = max
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
+}
+
 // Server implements handlers for frontend requests.
 type Server struct {
 	pb_frontend.UnimplementedFrontendServiceServer

--- a/internal/apisrv/frontend/support.go
+++ b/internal/apisrv/frontend/support.go
@@ -13,6 +13,10 @@ import (
 )
 
 func (s *Server) SubmitSupportTicket(ctx context.Context, req *pb_frontend.SubmitSupportTicketRequest) (*pb_frontend.SubmitSupportTicketResponse, error) {
+	if req.GetTicket() == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "ticket is required")
+	}
+
 	clientIP := middleware.GetClientIP(ctx)
 
 	ticket := dto.ConvertPbSupportTicketInsertToEntity(req.Ticket)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -127,6 +127,15 @@ var (
 	complimentaryShippingPricesMu sync.RWMutex
 	paymentIsProd                = true // true = prod Stripe (CARD), false = test Stripe (CARD_TEST)
 	paymentIsProdMu              sync.RWMutex
+
+	// cacheMu guards the runtime-mutable dictionary, settings and payment-method
+	// state below that is otherwise unsynchronized: the dictionary slices/maps
+	// (entityCategories, entitySizes, entityCollections, sizeById), the payment
+	// method maps/slice, the hero/announce pointers, and the scalar settings
+	// (maxOrderItems, siteEnabled, defaultCurrency, bigMenu, orderExpirationSeconds).
+	// These are written by admin handlers while read by storefront handlers, so
+	// without this lock the maps can trigger a fatal concurrent map read/write.
+	cacheMu sync.RWMutex
 )
 
 var (
@@ -289,7 +298,9 @@ func OrderStatusIDsForRefund() []int {
 }
 
 func UpdateHero(hf *entity.HeroFullWithTranslations) {
+	cacheMu.Lock()
 	hero = hf
+	cacheMu.Unlock()
 }
 
 // RefreshDictionary updates categories, sizes, and collections (including CountMen/CountWomen) in the in-memory cache.
@@ -298,6 +309,8 @@ func RefreshDictionary(dInfo *entity.DictionaryInfo) {
 	if dInfo == nil {
 		return
 	}
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
 	entityCategories = dInfo.Categories
 	entitySizes = dInfo.Sizes
 	entityCollections = dInfo.Collections
@@ -400,16 +413,28 @@ func UpdateShipmentCarrierCost(carrier string, price decimal.Decimal) {
 }
 
 func GetPaymentMethodById(id int) (PaymentMethod, bool) {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	pm, ok := paymentMethodsById[id]
+	if !ok {
+		return PaymentMethod{}, false
+	}
 	return *pm, ok
 }
 
 func GetPaymentMethodByName(n entity.PaymentMethodName) (PaymentMethod, bool) {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	pm, ok := paymentMethodsByName[n]
+	if !ok {
+		return PaymentMethod{}, false
+	}
 	return *pm, ok
 }
 
 func UpdatePaymentMethodAllowance(method entity.PaymentMethodName, allowed bool) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
 	pm, ok := paymentMethodsByName[method]
 	if ok {
 		pm.Method.Allowed = allowed
@@ -427,23 +452,33 @@ func UpdatePaymentMethodAllowance(method entity.PaymentMethodName, allowed bool)
 }
 
 func GetSizeById(id int) (entity.Size, bool) {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	s, ok := sizeById[id]
 	return s, ok
 }
 
 func GetHero() *entity.HeroFullWithTranslations {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return hero
 }
 func GetMaxOrderItems() int {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return maxOrderItems
 }
 
 func SetMaxOrderItems(n int) {
+	cacheMu.Lock()
 	maxOrderItems = n
+	cacheMu.Unlock()
 }
 
 func SetBigMenu(enabled bool) {
+	cacheMu.Lock()
 	bigMenu = enabled
+	cacheMu.Unlock()
 }
 
 // GetBackgroundHeroColor returns the storefront hero background CSS color (may be empty).
@@ -461,42 +496,60 @@ func SetBackgroundHeroColor(color string) {
 }
 
 func SetAnnounce(link string, translations []entity.AnnounceTranslation) {
+	cacheMu.Lock()
 	announce = &entity.AnnounceWithTranslations{
 		Link:         link,
 		Translations: translations,
 	}
+	cacheMu.Unlock()
 }
 
 func SetDefaultCurrency(c string) {
+	cacheMu.Lock()
 	defaultCurrency = c
+	cacheMu.Unlock()
 }
 
 func SetSiteAvailability(enabled bool) {
+	cacheMu.Lock()
 	siteEnabled = enabled
+	cacheMu.Unlock()
 }
 
 func GetSiteAvailability() bool {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return siteEnabled
 }
 
 func GetBaseCurrency() string {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return defaultCurrency
 }
 
 func GetBigMenu() bool {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return bigMenu
 }
 
 func GetAnnounce() *entity.AnnounceWithTranslations {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return announce
 }
 
 func GetOrderExpirationSeconds() int {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return orderExpirationSeconds
 }
 
 func SetOrderExpirationSeconds(seconds int) {
+	cacheMu.Lock()
 	orderExpirationSeconds = seconds
+	cacheMu.Unlock()
 }
 
 func UpdateComplimentaryShippingPrices(prices map[string]decimal.Decimal) {
@@ -516,6 +569,8 @@ func GetComplimentaryShippingPrices() map[string]decimal.Decimal {
 }
 
 func GetCategories() []entity.Category {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return entityCategories
 }
 
@@ -540,6 +595,8 @@ func GetOrderStatuses() []entity.OrderStatus {
 }
 
 func GetPaymentMethods() []entity.PaymentMethod {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return entityPaymentMethods
 }
 
@@ -569,6 +626,8 @@ func GetPaymentMethodsFilteredByIsProd() []entity.PaymentMethod {
 		target = entity.CARD_TEST
 	}
 
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	result := make([]entity.PaymentMethod, 0, 1)
 	for _, pm := range entityPaymentMethods {
 		if pm.Name == target && pm.Allowed {
@@ -580,10 +639,14 @@ func GetPaymentMethodsFilteredByIsProd() []entity.PaymentMethod {
 }
 
 func GetSizes() []entity.Size {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return entitySizes
 }
 
 func GetCollections() []entity.Collection {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
 	return entityCollections
 }
 
@@ -611,8 +674,13 @@ func GetPaymentMethodIdByPbId(pbId pb_common.PaymentMethodNameEnum) int {
 
 // RefreshEntityPaymentMethods updates the exported entityPaymentMethods slice from the current paymentMethodsById map.
 func RefreshEntityPaymentMethods() {
-	entityPaymentMethods = entityPaymentMethods[:0]
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	// Build a fresh slice rather than reusing the backing array, so concurrent
+	// readers holding a previously returned slice never observe in-place mutation.
+	refreshed := make([]entity.PaymentMethod, 0, len(paymentMethodsById))
 	for _, pm := range paymentMethodsById {
-		entityPaymentMethods = append(entityPaymentMethods, pm.Method)
+		refreshed = append(refreshed, pm.Method)
 	}
+	entityPaymentMethods = refreshed
 }

--- a/internal/cache/cache_race_test.go
+++ b/internal/cache/cache_race_test.go
@@ -1,0 +1,68 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+)
+
+// TestCacheConcurrentAccess hammers the runtime-mutable dictionary and
+// payment-method state from many goroutines at once. Run with -race: before the
+// cacheMu guard was added this panicked with "concurrent map read and map write"
+// (sizeById / paymentMethodsById). It must now complete cleanly.
+func TestCacheConcurrentAccess(t *testing.T) {
+	const goroutines = 16
+	const iterations = 500
+
+	dict := func(n int) *entity.DictionaryInfo {
+		return &entity.DictionaryInfo{
+			Categories:  []entity.Category{},
+			Collections: []entity.Collection{},
+			Sizes: []entity.Size{
+				{Id: 1, Name: "S"},
+				{Id: 2, Name: "M"},
+				{Id: n%3 + 3, Name: "L"},
+			},
+		}
+	}
+
+	var wg sync.WaitGroup
+
+	// Writers: replace the dictionary maps/slices.
+	for range goroutines {
+		wg.Go(func() {
+			for i := range iterations {
+				RefreshDictionary(dict(i))
+				UpdatePaymentMethodAllowance(entity.CARD, i%2 == 0)
+				RefreshEntityPaymentMethods()
+				SetSiteAvailability(i%2 == 0)
+				SetMaxOrderItems(i)
+				SetOrderExpirationSeconds(i)
+				UpdateHero(&entity.HeroFullWithTranslations{})
+			}
+		})
+	}
+
+	// Readers: read everything concurrently.
+	for range goroutines {
+		wg.Go(func() {
+			for range iterations {
+				_ = GetSizes()
+				_, _ = GetSizeById(1)
+				_ = GetCategories()
+				_ = GetCollections()
+				_, _ = GetPaymentMethodByName(entity.CARD)
+				_, _ = GetPaymentMethodById(1)
+				_ = GetPaymentMethods()
+				_ = GetPaymentMethodsFilteredByIsProd()
+				_ = GetSiteAvailability()
+				_ = GetMaxOrderItems()
+				_ = GetOrderExpirationSeconds()
+				_ = GetHero()
+			}
+		})
+	}
+
+	wg.Wait()
+}

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -108,6 +108,7 @@ type (
 		InsertFiatInvoice(ctx context.Context, orderUUID string, clientSecret string, pm entity.PaymentMethod, expiredAt time.Time) (*entity.OrderFull, error)
 		AssociatePaymentIntentWithOrder(ctx context.Context, orderUUID string, paymentIntentId string) error
 		UpdateTotalPaymentCurrency(ctx context.Context, orderUUID string, tapc decimal.Decimal) error
+		UpdateTotalSettledBase(ctx context.Context, orderUUID string, settledBase decimal.Decimal) error
 		SetTrackingNumber(ctx context.Context, orderUUID string, trackingCode string) (*entity.OrderBuyerShipment, error)
 		GetOrderById(ctx context.Context, orderID int) (*entity.OrderFull, error)
 		GetPaymentByOrderUUID(ctx context.Context, orderUUID string) (*entity.Payment, error)

--- a/internal/dto/mail.go
+++ b/internal/dto/mail.go
@@ -245,12 +245,19 @@ func ResendSendEmailRequestToEntity(mr *resend.SendEmailRequest) (*entity.SendEm
 	if len(mr.To) == 0 {
 		return nil, fmt.Errorf("mail req 'to' is empty")
 	}
+	var html, replyTo string
+	if mr.Html != nil {
+		html = *mr.Html
+	}
+	if mr.ReplyTo != nil {
+		replyTo = *mr.ReplyTo
+	}
 	return &entity.SendEmailRequest{
 		From:    mr.From,
 		To:      mr.To[0],
-		Html:    *mr.Html,
+		Html:    html,
 		Subject: mr.Subject,
-		ReplyTo: *mr.ReplyTo,
+		ReplyTo: replyTo,
 	}, nil
 }
 

--- a/internal/entity/order.go
+++ b/internal/entity/order.go
@@ -63,6 +63,11 @@ type Order struct {
 	// TotalPriceEUR is the order total converted to EUR at order time, used for
 	// loyalty qualifying-spend accumulation. NULL when it could not be derived.
 	TotalPriceEUR decimal.NullDecimal `db:"total_price_eur"`
+	// TotalSettledBase is the actual amount Stripe settled for this order, converted
+	// to the base currency (EUR) at Stripe's FX rate. It is the authoritative
+	// base-currency revenue figure. NULL when not captured (pre-feature, non-Stripe,
+	// or unpaid), in which case metrics fall back to the product_price reconstruction.
+	TotalSettledBase decimal.NullDecimal `db:"total_settled_base"`
 }
 
 func (o *Order) TotalPriceDecimal() decimal.Decimal {

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"log/slog"
@@ -93,6 +94,7 @@ type Mailer struct {
 	ctx            context.Context
 	cancel         context.CancelFunc
 	templates      map[templateName]*template.Template
+	wg             sync.WaitGroup
 }
 
 // addAuthHeader is a custom RequestEditorFn that adds an authorization header to the request

--- a/internal/mail/worker.go
+++ b/internal/mail/worker.go
@@ -16,11 +16,14 @@ func (m *Mailer) Start(ctx context.Context) error {
 	}
 
 	m.ctx, m.cancel = context.WithCancel(ctx)
-	go m.worker(m.ctx)
+	m.wg.Go(func() {
+		m.worker(m.ctx)
+	})
 	return nil
 }
 
-// Stop stops the worker gracefully
+// Stop signals the worker to stop and waits for its goroutine to exit, so the
+// caller can safely close shared resources (e.g. the DB) afterwards.
 func (m *Mailer) Stop() error {
 	if m.cancel == nil {
 		return fmt.Errorf("Mailer already stopped or not started")
@@ -28,6 +31,7 @@ func (m *Mailer) Stop() error {
 
 	m.cancel() // This will cancel the context used by the worker
 	m.cancel = nil
+	m.wg.Wait()
 	return nil
 }
 

--- a/internal/ordercleanup/ordercleanup.go
+++ b/internal/ordercleanup/ordercleanup.go
@@ -3,6 +3,7 @@ package ordercleanup
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
@@ -22,18 +23,29 @@ func DefaultConfig() Config {
 	}
 }
 
+// PaymentExpirer verifies an order's payment with the provider (e.g. Stripe)
+// before expiring it. Implementations MUST confirm the order when the payment
+// actually succeeded instead of cancelling it, so the safety-net never cancels
+// a paid order whose in-process monitor was lost (e.g. on deploy).
+type PaymentExpirer interface {
+	ExpireOrderPayment(ctx context.Context, orderUUID string) error
+}
+
 // Worker cancels orders stuck in Placed status (never reached InsertFiatInvoice)
 // and AwaitingPayment orders past their expired_at (safety net when monitors fail).
 type Worker struct {
 	repo           dependency.Repository
 	reservationMgr dependency.StockReservationManager
+	expirer        PaymentExpirer
 	c              *Config
 	ctx            context.Context
 	stop           context.CancelFunc
+	wg             sync.WaitGroup
 }
 
-// New creates a new order cleanup worker.
-func New(c *Config, repo dependency.Repository, reservationMgr dependency.StockReservationManager) *Worker {
+// New creates a new order cleanup worker. expirer may be nil, in which case
+// expiry falls back to the store-level path (which does not verify the provider).
+func New(c *Config, repo dependency.Repository, reservationMgr dependency.StockReservationManager, expirer PaymentExpirer) *Worker {
 	if c == nil {
 		dc := DefaultConfig()
 		c = &dc
@@ -47,6 +59,7 @@ func New(c *Config, repo dependency.Repository, reservationMgr dependency.StockR
 	return &Worker{
 		repo:           repo,
 		reservationMgr: reservationMgr,
+		expirer:        expirer,
 		c:              c,
 	}
 }
@@ -57,16 +70,20 @@ func (w *Worker) Start(ctx context.Context) error {
 		return fmt.Errorf("order cleanup worker already started")
 	}
 	w.ctx, w.stop = context.WithCancel(ctx)
-	go w.worker(w.ctx)
+	w.wg.Go(func() {
+		w.worker(w.ctx)
+	})
 	return nil
 }
 
-// Stop stops the worker gracefully.
+// Stop signals the worker to stop and waits for its goroutine to exit, so the
+// caller can safely close shared resources (e.g. the DB) afterwards.
 func (w *Worker) Stop() error {
 	if w.stop == nil {
 		return fmt.Errorf("order cleanup worker already stopped or not started")
 	}
 	w.stop()
 	w.stop = nil
+	w.wg.Wait()
 	return nil
 }

--- a/internal/ordercleanup/worker.go
+++ b/internal/ordercleanup/worker.go
@@ -75,7 +75,15 @@ func (w *Worker) cancelExpiredAwaitingPaymentOrders(ctx context.Context) error {
 			return err
 		}
 
-		_, err := w.repo.Order().ExpireOrderPayment(ctx, order.UUID)
+		// Prefer the provider-checked expiry so a payment that actually succeeded
+		// (but whose in-process monitor was lost) is confirmed, not cancelled.
+		// Fall back to the store-level path only when no expirer is wired.
+		var err error
+		if w.expirer != nil {
+			err = w.expirer.ExpireOrderPayment(ctx, order.UUID)
+		} else {
+			_, err = w.repo.Order().ExpireOrderPayment(ctx, order.UUID)
+		}
 		if err != nil {
 			slog.Default().ErrorContext(ctx, "can't expire awaiting payment order",
 				slog.String("err", err.Error()),

--- a/internal/payment/stripe/payment.go
+++ b/internal/payment/stripe/payment.go
@@ -31,10 +31,19 @@ type Config struct {
 	SecretKey         string        `mapstructure:"secret_key"`
 	PubKey            string        `mapstructure:"pub_key"`
 	InvoiceExpiration time.Duration `mapstructure:"invoice_expiration"`
+	// WebhookSecret is the Stripe webhook signing secret (whsec_...) used to
+	// verify inbound events for this processor. Empty disables this endpoint.
+	WebhookSecret string `mapstructure:"webhook_secret"`
 }
 
 // ErrPaymentAlreadyCompleted is returned when the PaymentIntent was already used for a completed payment.
 var ErrPaymentAlreadyCompleted = errors.New("payment already completed for this session")
+
+// ErrUnderpaid is returned by updateOrderAsPaid when a PaymentIntent succeeded
+// for less than the order total (amount tampering / early confirmation). The
+// order is intentionally left AwaitingPayment for manual review rather than
+// fulfilled; callers treat it as "not paid", not as a hard failure.
+var ErrUnderpaid = errors.New("payment intent succeeded for less than the order total")
 
 type Processor struct {
 	c                *Config
@@ -51,6 +60,11 @@ type Processor struct {
 }
 
 func New(ctx context.Context, c *Config, rep dependency.Repository, m dependency.Mailer, pmn entity.PaymentMethodName) (dependency.Invoicer, error) {
+	if c.SecretKey == "" {
+		// Without this guard an empty key only surfaces at the first live charge
+		// (i.e. in production checkout). Fail closed at startup instead.
+		return nil, fmt.Errorf("stripe secret_key is required for payment method %s", pmn)
+	}
 	if cache.GetBaseCurrency() == "" {
 		return nil, fmt.Errorf("base currency not configured")
 	}
@@ -141,8 +155,14 @@ func (p *Processor) expireOrderPayment(ctx context.Context, orderUUID string) er
 				Valid:  true,
 			}
 		}
-		err = p.updateOrderAsPaid(ctx, p.rep, orderUUID, *payment)
+		received := AmountFromSmallestUnit(pi.AmountReceived, string(pi.Currency))
+		err = p.updateOrderAsPaid(ctx, p.rep, orderUUID, *payment, received)
 		if err != nil {
+			// Underpaid: leave the order AwaitingPayment (flagged for review) and
+			// do NOT fall through to the cancel/restore-stock branch below.
+			if errors.Is(err, ErrUnderpaid) {
+				return nil
+			}
 			return fmt.Errorf("can't update order as paid: %w", err)
 		}
 		return nil
@@ -161,8 +181,39 @@ func (p *Processor) expireOrderPayment(ctx context.Context, orderUUID string) er
 	return nil
 }
 
-func (p *Processor) updateOrderAsPaid(ctx context.Context, rep dependency.Repository, orderUUID string, payment entity.Payment) error {
+// ExpireOrderPayment verifies the order's PaymentIntent with Stripe and either
+// marks the order paid (when the PaymentIntent already succeeded) or expires it
+// (cancel + restore stock). Unlike the store-level ExpireOrderPayment, this is
+// safe to call from the cleanup safety-net: it never cancels a payment that
+// actually succeeded on Stripe.
+func (p *Processor) ExpireOrderPayment(ctx context.Context, orderUUID string) error {
+	return p.expireOrderPayment(ctx, orderUUID)
+}
+
+// updateOrderAsPaid marks an order paid after its PaymentIntent succeeded.
+// receivedAmount is the amount Stripe actually collected, in the payment
+// currency, and is validated against the order total before fulfillment: the
+// client holds the client_secret from pre-checkout and can confirm the
+// PaymentIntent before the server finalizes the amount, so a succeeded PI is not
+// by itself proof of full payment. This is the single choke point for all
+// confirmation paths (expiry monitor, lazy check, and the Stripe webhook).
+func (p *Processor) updateOrderAsPaid(ctx context.Context, rep dependency.Repository, orderUUID string, payment entity.Payment, receivedAmount decimal.Decimal) error {
 	var err error
+
+	// Amount-tamper / underpayment guard. expected is the order total in payment
+	// currency, persisted at invoice time (see SubmitOrder/GetOrderInvoice). When
+	// Stripe received less, leave the order AwaitingPayment and flag for review
+	// instead of fulfilling it for less than it owes.
+	expected := payment.TransactionAmountPaymentCurrency
+	if expected.IsPositive() && receivedAmount.LessThan(expected) {
+		slog.Default().ErrorContext(ctx, "UNDERPAID order: payment intent succeeded for less than the order total; leaving AwaitingPayment for manual review",
+			slog.String("orderUUID", orderUUID),
+			slog.String("received", receivedAmount.String()),
+			slog.String("expected", expected.String()),
+		)
+		p.flagUnderpaidForReview(ctx, rep, orderUUID, receivedAmount, expected)
+		return ErrUnderpaid
+	}
 
 	payment.IsTransactionDone = true
 	wasUpdated, err := rep.Order().OrderPaymentDone(ctx, orderUUID, &payment)
@@ -181,6 +232,10 @@ func (p *Processor) updateOrderAsPaid(ctx context.Context, rep dependency.Reposi
 	}
 
 	slog.Default().InfoContext(ctx, "Order marked as paid", slog.String("orderUUID", orderUUID))
+
+	// Capture the actual amount Stripe settled, in base currency, for accurate
+	// revenue analytics. Best effort — never blocks fulfillment.
+	p.captureSettledBase(ctx, rep, orderUUID, payment)
 
 	// RELEASE RESERVATION: Free stock when payment is completed
 	if p.reservationMgr != nil {
@@ -215,6 +270,63 @@ func (p *Processor) updateOrderAsPaid(ctx context.Context, rep dependency.Reposi
 
 	return nil
 
+}
+
+// captureSettledBase records the actual amount Stripe settled for the order,
+// converted to the base currency, taken from the charge's balance transaction. The
+// Stripe account settles in the base currency (EUR), so BalanceTransaction.Amount is
+// already in base. Best effort: it never blocks fulfillment — when total_settled_base
+// stays NULL (no charge yet, or a non-base settlement), revenue metrics fall back to
+// the product_price reconstruction.
+func (p *Processor) captureSettledBase(ctx context.Context, rep dependency.Repository, orderUUID string, payment entity.Payment) {
+	if !payment.ClientSecret.Valid || payment.ClientSecret.String == "" {
+		return
+	}
+	pi, err := p.getPaymentIntentWithExpand(payment.ClientSecret.String, []string{"latest_charge.balance_transaction"})
+	if err != nil {
+		slog.Default().ErrorContext(ctx, "settled-base: can't fetch payment intent",
+			slog.String("orderUUID", orderUUID), slog.String("err", err.Error()))
+		return
+	}
+	if pi.LatestCharge == nil || pi.LatestCharge.BalanceTransaction == nil {
+		slog.Default().WarnContext(ctx, "settled-base: no balance transaction on charge yet",
+			slog.String("orderUUID", orderUUID))
+		return
+	}
+	bt := pi.LatestCharge.BalanceTransaction
+	baseCurrency := cache.GetBaseCurrency()
+	// The balance transaction settles in the Stripe account's payout currency, which
+	// we require to equal the base currency. If Stripe ever settles in another
+	// currency, skip rather than store a non-base amount as if it were base.
+	if !strings.EqualFold(string(bt.Currency), baseCurrency) {
+		slog.Default().ErrorContext(ctx, "settled-base: Stripe settlement currency != base currency; skipping capture",
+			slog.String("orderUUID", orderUUID),
+			slog.String("settlement_currency", string(bt.Currency)),
+			slog.String("base_currency", baseCurrency))
+		return
+	}
+	settledBase := AmountFromSmallestUnit(bt.Amount, baseCurrency)
+	if err := rep.Order().UpdateTotalSettledBase(ctx, orderUUID, settledBase); err != nil {
+		slog.Default().ErrorContext(ctx, "settled-base: can't persist",
+			slog.String("orderUUID", orderUUID), slog.String("err", err.Error()))
+		return
+	}
+	slog.Default().InfoContext(ctx, "settled-base captured",
+		slog.String("orderUUID", orderUUID), slog.String("amount_base", settledBase.String()))
+}
+
+// flagUnderpaidForReview records a persistent, admin-visible marker on the order
+// so an underpaid-but-charged order surfaces in the admin panel for manual
+// reconciliation. Best effort: it never blocks confirmation handling.
+func (p *Processor) flagUnderpaidForReview(ctx context.Context, rep dependency.Repository, orderUUID string, received, expected decimal.Decimal) {
+	comment := fmt.Sprintf("UNDERPAID: Stripe received %s but the order total is %s — manual review required; order kept in AwaitingPayment.",
+		received.String(), expected.String())
+	if err := rep.Order().AddOrderComment(ctx, orderUUID, comment); err != nil {
+		slog.Default().ErrorContext(ctx, "can't flag underpaid order for review",
+			slog.String("orderUUID", orderUUID),
+			slog.String("err", err.Error()),
+		)
+	}
 }
 
 // GetOrderInvoice returns the payment details for the given order and expiration date.
@@ -420,8 +532,14 @@ func (p *Processor) CheckForTransactions(ctx context.Context, orderUUID string, 
 		switch pi.Status {
 		case stripe.PaymentIntentStatusSucceeded:
 			slog.Default().Info("payment intent succeeded", "pi", pi)
-			err := p.updateOrderAsPaid(ctx, p.rep, orderUUID, payment)
+			received := AmountFromSmallestUnit(pi.AmountReceived, string(pi.Currency))
+			err := p.updateOrderAsPaid(ctx, p.rep, orderUUID, payment, received)
 			if err != nil {
+				// Underpaid: order stays AwaitingPayment (flagged for review);
+				// surface the current payment state without a hard error.
+				if errors.Is(err, ErrUnderpaid) {
+					return &payment, nil
+				}
 				return nil, fmt.Errorf("can't update order as paid: %w", err)
 			}
 			return &payment, nil

--- a/internal/payment/stripe/payment_test.go
+++ b/internal/payment/stripe/payment_test.go
@@ -1,10 +1,61 @@
 package stripe
 
 import (
+	"context"
 	"testing"
 
+	mocks "github.com/jekabolt/grbpwr-manager/internal/dependency/mocks"
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+// TestUpdateOrderAsPaidRejectsUnderpayment verifies the amount-tamper guard:
+// when Stripe received less than the order total, the order is NOT marked paid
+// (OrderPaymentDone is never called), ErrUnderpaid is returned, and the order is
+// flagged for manual review via an order comment.
+func TestUpdateOrderAsPaidRejectsUnderpayment(t *testing.T) {
+	mockOrders := mocks.NewMockOrder(t)
+	mockRepo := mocks.NewMockRepository(t)
+	mockRepo.EXPECT().Order().Return(mockOrders)
+	mockOrders.EXPECT().
+		AddOrderComment(mock.Anything, "ord-underpaid", mock.AnythingOfType("string")).
+		Return(nil)
+	// OrderPaymentDone must NOT be set: if updateOrderAsPaid called it, the mock
+	// would fail on an unexpected call.
+
+	p := &Processor{rep: mockRepo}
+	payment := entity.Payment{PaymentInsert: entity.PaymentInsert{
+		TransactionAmountPaymentCurrency: decimal.RequireFromString("123.45"),
+	}}
+	received := decimal.RequireFromString("100.00")
+
+	err := p.updateOrderAsPaid(context.Background(), mockRepo, "ord-underpaid", payment, received)
+	assert.ErrorIs(t, err, ErrUnderpaid)
+}
+
+// TestUpdateOrderAsPaidAllowsFullPayment verifies that a payment covering the
+// order total passes the guard and proceeds to OrderPaymentDone (here stubbed to
+// error so the test stays light), i.e. it does not return ErrUnderpaid.
+func TestUpdateOrderAsPaidAllowsFullPayment(t *testing.T) {
+	mockOrders := mocks.NewMockOrder(t)
+	mockRepo := mocks.NewMockRepository(t)
+	mockRepo.EXPECT().Order().Return(mockOrders)
+	mockOrders.EXPECT().
+		OrderPaymentDone(mock.Anything, "ord-paid", mock.Anything).
+		Return(false, assert.AnError)
+
+	p := &Processor{rep: mockRepo}
+	payment := entity.Payment{PaymentInsert: entity.PaymentInsert{
+		TransactionAmountPaymentCurrency: decimal.RequireFromString("123.45"),
+	}}
+	received := decimal.RequireFromString("123.45")
+
+	err := p.updateOrderAsPaid(context.Background(), mockRepo, "ord-paid", payment, received)
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, ErrUnderpaid)
+}
 
 func TestPaymentMethodTypesForCurrency(t *testing.T) {
 	// KRW: card, kr_card, apple_pay

--- a/internal/payment/stripe/stripe.go
+++ b/internal/payment/stripe/stripe.go
@@ -20,6 +20,13 @@ func IsZeroDecimalCurrency(c string) bool {
 	return curr.IsZeroDecimal(c)
 }
 
+// PaymentIntentSucceeded reports whether a PaymentIntent has already been paid.
+// A succeeded PaymentIntent can no longer have its amount/shipping updated, so
+// callers should skip those mutations instead of failing.
+func PaymentIntentSucceeded(pi *stripe.PaymentIntent) bool {
+	return pi != nil && pi.Status == stripe.PaymentIntentStatusSucceeded
+}
+
 // AmountToSmallestUnit converts an amount to the smallest currency unit for Stripe
 // For zero-decimal currencies (like JPY, KRW), rounds to whole units (no decimals)
 // For other currencies, multiplies by 100 to convert to cents

--- a/internal/payment/stripe/webhook.go
+++ b/internal/payment/stripe/webhook.go
@@ -1,0 +1,153 @@
+package stripe
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/stripe/stripe-go/v79"
+	"github.com/stripe/stripe-go/v79/webhook"
+)
+
+// maxStripeWebhookBody caps the request body read for a webhook event (64 KiB).
+const maxStripeWebhookBody = 1 << 16
+
+// WebhookHandler verifies and dispatches inbound Stripe webhook events. It holds
+// one (signing secret, processor) endpoint per configured Stripe processor
+// (live/test), so a single /api/webhooks/stripe route serves both modes: the
+// secret that validates the signature identifies the owning processor.
+type WebhookHandler struct {
+	endpoints []webhookEndpoint
+}
+
+type webhookEndpoint struct {
+	secret    string
+	processor *Processor
+}
+
+// NewWebhookHandler builds a handler from the given processors. Processors with
+// an empty WebhookSecret are skipped (their endpoint is disabled), so a
+// test-only deployment can configure just the test secret.
+func NewWebhookHandler(processors ...*Processor) *WebhookHandler {
+	h := &WebhookHandler{}
+	for _, p := range processors {
+		if p != nil && p.c != nil && p.c.WebhookSecret != "" {
+			h.endpoints = append(h.endpoints, webhookEndpoint{secret: p.c.WebhookSecret, processor: p})
+		}
+	}
+	return h
+}
+
+// Enabled reports whether at least one signing secret is configured.
+func (h *WebhookHandler) Enabled() bool {
+	return len(h.endpoints) > 0
+}
+
+// HandleStripeEvent is the HTTP entry point for Stripe webhook deliveries. It
+// verifies the signature against the configured secrets and, for a succeeded
+// PaymentIntent, confirms the corresponding order. Unhandled event types are
+// acknowledged with 200 so Stripe stops retrying them. A 5xx is returned only
+// for transient failures, which Stripe will retry.
+func (h *WebhookHandler) HandleStripeEvent(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	payload, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxStripeWebhookBody))
+	if err != nil {
+		slog.Default().ErrorContext(ctx, "stripe webhook: can't read body", slog.String("err", err.Error()))
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	sig := r.Header.Get("Stripe-Signature")
+
+	// Verify against each configured secret; the one that validates identifies
+	// the owning processor (live vs test).
+	var event stripe.Event
+	var proc *Processor
+	for _, ep := range h.endpoints {
+		ev, verr := webhook.ConstructEvent(payload, sig, ep.secret)
+		if verr == nil {
+			event = ev
+			proc = ep.processor
+			break
+		}
+	}
+	if proc == nil {
+		slog.Default().WarnContext(ctx, "stripe webhook: signature verification failed for all configured secrets")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	switch event.Type {
+	case stripe.EventTypePaymentIntentSucceeded:
+		var pi stripe.PaymentIntent
+		if err := json.Unmarshal(event.Data.Raw, &pi); err != nil {
+			slog.Default().ErrorContext(ctx, "stripe webhook: can't parse payment_intent",
+				slog.String("event_id", event.ID),
+				slog.String("err", err.Error()),
+			)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if err := proc.confirmPaymentFromWebhook(ctx, &pi); err != nil {
+			// Transient failure: return 5xx so Stripe retries delivery.
+			slog.Default().ErrorContext(ctx, "stripe webhook: can't confirm payment",
+				slog.String("payment_intent_id", pi.ID),
+				slog.String("err", err.Error()),
+			)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	default:
+		slog.Default().DebugContext(ctx, "stripe webhook: ignoring event type", slog.String("type", string(event.Type)))
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// confirmPaymentFromWebhook marks the order behind a succeeded PaymentIntent as
+// paid. It routes through updateOrderAsPaid (the shared confirmation choke point),
+// so it is idempotent and shares the underpayment guard with the monitor and the
+// lazy CheckForTransactions path.
+func (p *Processor) confirmPaymentFromWebhook(ctx context.Context, pi *stripe.PaymentIntent) error {
+	orderUUID := pi.Metadata["order_id"]
+	if orderUUID == "" {
+		// Pre-order PaymentIntents (cart sessions) have no order yet — ignore.
+		slog.Default().InfoContext(ctx, "stripe webhook: payment_intent has no order_id metadata, ignoring",
+			slog.String("payment_intent_id", pi.ID))
+		return nil
+	}
+
+	payment, err := p.rep.Order().GetPaymentByOrderUUID(ctx, orderUUID)
+	if err != nil {
+		return fmt.Errorf("can't get payment for order %s: %w", orderUUID, err)
+	}
+
+	// Capture the payment method sub-type (apple_pay, klarna, ...) when available.
+	if piExpanded, expErr := p.getPaymentIntentWithExpand(payment.ClientSecret.String, []string{"payment_method"}); expErr == nil && piExpanded.PaymentMethod != nil {
+		payment.PaymentInsert.PaymentMethodType = sql.NullString{String: string(piExpanded.PaymentMethod.Type), Valid: true}
+	}
+
+	received := AmountFromSmallestUnit(pi.AmountReceived, string(pi.Currency))
+	if err := p.updateOrderAsPaid(ctx, p.rep, orderUUID, *payment, received); err != nil {
+		// Underpaid: order stays AwaitingPayment (flagged for review). Acknowledge
+		// the event so Stripe does not retry it.
+		if errors.Is(err, ErrUnderpaid) {
+			slog.Default().WarnContext(ctx, "stripe webhook: underpaid order left for manual review",
+				slog.String("order_uuid", orderUUID),
+				slog.String("payment_intent_id", pi.ID),
+			)
+			return nil
+		}
+		return fmt.Errorf("can't mark order %s as paid: %w", orderUUID, err)
+	}
+
+	// Free the in-process monitor goroutine promptly (best effort).
+	_ = p.CancelMonitorPayment(orderUUID)
+	return nil
+}

--- a/internal/revalidation/revalidation.go
+++ b/internal/revalidation/revalidation.go
@@ -57,7 +57,9 @@ func (v *Revalidator) getDeployments(ctx context.Context) ([]*dto.Deployment, er
 	if err != nil {
 		return nil, fmt.Errorf("failed to make GET request to %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	// Drain before close so the keep-alive connection can be reused — the non-200 path
+	// and json.Decoder may otherwise leave the body partially read.
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code %d from %s", resp.StatusCode, url)
@@ -91,23 +93,25 @@ func (v *Revalidator) revalidate(ctx context.Context, deploymentURL string, reva
 		return fmt.Errorf("failed to marshal revalidationData for deployment %s: %w", deploymentURL, err)
 	}
 
+	// NOTE: apiUrl carries ?secret=<RevalidateSecret>; never put it in errors/logs.
+	// Use deploymentURL (host only) for any surfaced message.
 	req, err := http.NewRequestWithContext(ctx, "POST", apiUrl, bytes.NewBuffer(payload))
 	if err != nil {
-		return fmt.Errorf("failed to create POST request to %s: %w", apiUrl, err)
+		return fmt.Errorf("failed to create POST request to %s: %w", deploymentURL, err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := v.client.Do(req)
 	if err != nil {
 		slog.Default().Error("HTTP request failed", "deploymentURL", deploymentURL, "error", err)
-		return fmt.Errorf("failed to POST to %s: %w", apiUrl, err)
+		return fmt.Errorf("failed to POST to %s: %w", deploymentURL, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		slog.Default().Error("Failed to read response body", "deploymentURL", deploymentURL, "error", err)
-		return fmt.Errorf("failed to read response body from %s: %w", apiUrl, err)
+		return fmt.Errorf("failed to read response body from %s: %w", deploymentURL, err)
 	}
 
 	if resp.StatusCode != 200 {

--- a/internal/store/bqcache/read.go
+++ b/internal/store/bqcache/read.go
@@ -78,7 +78,7 @@ func (s *ReadStore) GetBQOOSImpact(ctx context.Context, from, to time.Time, limi
 			click_count, estimated_lost_sales, estimated_lost_revenue
 		FROM bq_oos_impact
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY estimated_lost_revenue DESC
+		ORDER BY estimated_lost_revenue DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -187,7 +187,7 @@ func (s *ReadStore) GetBQUserJourneys(ctx context.Context, from, to time.Time, l
 		SELECT date, journey_path, session_count, conversions
 		FROM bq_user_journeys
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY session_count DESC
+		ORDER BY session_count DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -250,7 +250,7 @@ func (s *ReadStore) GetBQSizeIntent(ctx context.Context, from, to time.Time, lim
 		SELECT date, product_id, size_id, size_name, size_clicks
 		FROM bq_size_intent
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY date ASC, size_clicks DESC
+		ORDER BY date ASC, size_clicks DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -347,7 +347,7 @@ func (s *ReadStore) GetBQProductEngagement(ctx context.Context, from, to time.Ti
 				AND page_path LIKE '%%/product/%%'
 			GROUP BY SUBSTRING_INDEX(page_path, '/', -1)
 		) top ON top.product_id = agg.product_id
-		ORDER BY agg.image_views DESC
+		ORDER BY agg.image_views DESC, agg.product_name
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -386,7 +386,7 @@ func (s *ReadStore) GetBQFormErrors(ctx context.Context, from, to time.Time, lim
 		SELECT date, field_name, error_count
 		FROM bq_form_errors
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY error_count DESC
+		ORDER BY error_count DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -416,7 +416,7 @@ func (s *ReadStore) GetBQExceptions(ctx context.Context, from, to time.Time, lim
 		SELECT date, page_path, exception_count, description
 		FROM bq_exceptions
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY exception_count DESC
+		ORDER BY exception_count DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -447,7 +447,7 @@ func (s *ReadStore) GetBQNotFoundPages(ctx context.Context, from, to time.Time, 
 		SELECT date, page_path, hit_count
 		FROM bq_not_found_pages
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY hit_count DESC
+		ORDER BY hit_count DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -537,7 +537,7 @@ func (s *ReadStore) GetBQSizeConfidence(ctx context.Context, from, to time.Time,
 		SELECT date, product_id, product_name, size_guide_views, size_selections
 		FROM bq_size_confidence
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY size_guide_views DESC
+		ORDER BY size_guide_views DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -641,7 +641,7 @@ func (s *ReadStore) GetBQTimeOnPage(ctx context.Context, from, to time.Time, lim
 		FROM bq_time_on_page
 		WHERE date >= :fromDate AND date <= :toDate
 		GROUP BY page_path
-		ORDER BY page_views DESC
+		ORDER BY page_views DESC, page_path
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -677,7 +677,7 @@ func (s *ReadStore) GetBQProductZoom(ctx context.Context, from, to time.Time, li
 		SELECT date, product_id, product_name, zoom_method, zoom_count
 		FROM bq_product_zoom
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY zoom_count DESC
+		ORDER BY zoom_count DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -711,7 +711,7 @@ func (s *ReadStore) GetBQImageSwipes(ctx context.Context, from, to time.Time, li
 		SELECT date, product_id, product_name, swipe_direction, swipe_count
 		FROM bq_image_swipes
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY swipe_count DESC
+		ORDER BY swipe_count DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -745,7 +745,7 @@ func (s *ReadStore) GetBQSizeGuideClicks(ctx context.Context, from, to time.Time
 		SELECT date, product_id, product_name, page_location, click_count
 		FROM bq_size_guide_clicks
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY click_count DESC
+		ORDER BY click_count DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -779,7 +779,7 @@ func (s *ReadStore) GetBQDetailsExpansion(ctx context.Context, from, to time.Tim
 		SELECT date, product_id, product_name, section_name, expand_count
 		FROM bq_details_expansion
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY expand_count DESC
+		ORDER BY expand_count DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -813,7 +813,7 @@ func (s *ReadStore) GetBQNotifyMeIntent(ctx context.Context, from, to time.Time,
 		SELECT date, product_id, product_name, action, count, conversion_rate
 		FROM bq_notify_me_intent
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY count DESC
+		ORDER BY count DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -856,7 +856,7 @@ func (s *ReadStore) GetBQAddToCartRate(ctx context.Context, from, to time.Time, 
 		WHERE date >= :fromDate AND date <= :toDate
 		GROUP BY product_id
 		HAVING SUM(view_count) > 0
-		ORDER BY view_count DESC, cart_rate DESC
+		ORDER BY view_count DESC, cart_rate DESC, product_id
 		LIMIT :limit OFFSET :offset
 	`
 	type productRow struct {
@@ -967,7 +967,7 @@ func (s *ReadStore) GetBQBrowserBreakdown(ctx context.Context, from, to time.Tim
 		SELECT date, browser, sessions, users, conversions, conversion_rate
 		FROM bq_browser_breakdown
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY sessions DESC
+		ORDER BY sessions DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -1065,7 +1065,7 @@ func (s *ReadStore) GetBQCampaignAttribution(ctx context.Context, from, to time.
 		SELECT date, utm_source, utm_medium, utm_campaign, sessions, users, conversions, revenue, conversion_rate
 		FROM bq_campaign_attribution
 		WHERE date >= :fromDate AND date <= :toDate
-		ORDER BY date DESC, sessions DESC
+		ORDER BY date DESC, sessions DESC, id ASC
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {
@@ -1150,7 +1150,7 @@ func (s *ReadStore) GetBQCampaignAttributionAggregated(ctx context.Context, from
 		FROM bq_campaign_attribution
 		WHERE date >= :fromDate AND date <= :toDate
 		GROUP BY utm_source, utm_medium, utm_campaign
-		ORDER BY sessions DESC
+		ORDER BY sessions DESC, utm_source, utm_medium, utm_campaign
 		LIMIT :limit OFFSET :offset
 	`
 	type row struct {

--- a/internal/store/metrics/analytics.go
+++ b/internal/store/metrics/analytics.go
@@ -34,21 +34,22 @@ func (s *Store) analytics() *analyticsStore {
 // Products with zero sales in the period appear first with revenue=0.
 // Includes hidden products with product_hidden flag and GA4 page views.
 func (as *analyticsStore) GetSlowMovers(ctx context.Context, from, to time.Time, limit int) ([]entity.SlowMoverRow, error) {
-	statusIDs := storeutil.JoinInts(cache.OrderStatusIDsForNetRevenue())
 	baseCurrency := strings.ToUpper(cache.GetBaseCurrency())
 
+	// Revenue is the actual settled base apportioned across line items (order_factors /
+	// itemAdjExpr); all order currencies are included (no co.currency filter) and prices
+	// come from product_price in base currency rather than the order-currency snapshot.
 	query := fmt.Sprintf(`
-		WITH product_sales AS (
+		WITH %s,
+		product_sales AS (
 			SELECT
 				oi.product_id,
-				SUM(oi.product_price * oi.quantity) AS revenue,
-				SUM(oi.quantity)                     AS units_sold,
-				MAX(co.placed)                       AS last_sale_date
+				COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity * %s), 0) AS revenue,
+				SUM(oi.quantity)     AS units_sold,
+				MAX(ofac.placed)     AS last_sale_date
 			FROM order_item oi
-			JOIN customer_order co ON oi.order_id = co.id
-			WHERE co.order_status_id IN (%s)
-				AND co.currency = :baseCurrency
-				AND co.placed >= :from AND co.placed < :to
+			JOIN order_factors ofac ON ofac.order_id = oi.order_id
+			LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
 			GROUP BY oi.product_id
 		),
 		ga4_views AS (
@@ -76,10 +77,11 @@ func (as *analyticsStore) GetSlowMovers(ctx context.Context, from, to time.Time,
 		LEFT JOIN ga4_views gv ON gv.product_id = p.id
 		ORDER BY revenue ASC, days_in_stock DESC
 		LIMIT :limit
-	`, statusIDs)
+	`, orderFactorsCTE, itemAdjExpr)
 
 	result, err := storeutil.QueryListNamed[entity.SlowMoverRow](ctx, as.DB, query, map[string]any{
 		"baseCurrency": baseCurrency,
+		"statusIds":    cache.OrderStatusIDsForNetRevenue(),
 		"from":         from,
 		"to":           to,
 		"fromDate":     from.Format("2006-01-02"),
@@ -266,22 +268,25 @@ func (as *analyticsStore) GetReturnBySize(ctx context.Context, from, to time.Tim
 // GetSizeAnalytics returns units sold and revenue by product+size with % of product total.
 // Correctly handles partial refunds by subtracting refunded quantities and revenue.
 func (as *analyticsStore) GetSizeAnalytics(ctx context.Context, from, to time.Time, limit int) ([]entity.SizeAnalyticsRow, error) {
-	statusIDs := storeutil.JoinInts(cache.OrderStatusIDsForNetRevenue())
 	baseCurrency := strings.ToUpper(cache.GetBaseCurrency())
 
 	query := fmt.Sprintf(`
-		WITH size_sales AS (
+		WITH %s,
+		refunds AS (
+			SELECT order_item_id, SUM(quantity_refunded) AS quantity_refunded
+			FROM refunded_order_item
+			GROUP BY order_item_id
+		),
+		size_sales AS (
 			SELECT
 				oi.product_id,
 				oi.size_id,
-				SUM(oi.quantity) - COALESCE(SUM(roi.quantity_refunded), 0) AS units_sold,
-				SUM(oi.product_price * oi.quantity) - COALESCE(SUM(oi.product_price * roi.quantity_refunded), 0) AS revenue
+				SUM(oi.quantity) - COALESCE(SUM(r.quantity_refunded), 0) AS units_sold,
+				COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * (oi.quantity - COALESCE(r.quantity_refunded, 0)) * %s), 0) AS revenue
 			FROM order_item oi
-			JOIN customer_order co ON oi.order_id = co.id
-			LEFT JOIN refunded_order_item roi ON roi.order_item_id = oi.id
-			WHERE co.order_status_id IN (%s)
-				AND co.currency = :baseCurrency
-				AND co.placed >= :from AND co.placed < :to
+			JOIN order_factors ofac ON ofac.order_id = oi.order_id
+			LEFT JOIN refunds r ON r.order_item_id = oi.id
+			LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
 			GROUP BY oi.product_id, oi.size_id
 			HAVING units_sold > 0
 		),
@@ -312,10 +317,11 @@ func (as *analyticsStore) GetSizeAnalytics(ctx context.Context, from, to time.Ti
 			AND (p.hidden IS NULL OR p.hidden = 0)
 		ORDER BY ss.revenue DESC
 		LIMIT :limit
-	`, statusIDs)
+	`, orderFactorsCTE, itemAdjGrossExpr)
 
 	result, err := storeutil.QueryListNamed[entity.SizeAnalyticsRow](ctx, as.DB, query, map[string]any{
 		"baseCurrency": baseCurrency,
+		"statusIds":    cache.OrderStatusIDsForNetRevenue(),
 		"from":         from,
 		"to":           to,
 		"limit":        limit,
@@ -403,7 +409,6 @@ func (as *analyticsStore) GetDeadStock(ctx context.Context, from, to time.Time, 
 // GetProductTrend compares revenue for each product in the current period
 // vs the same-length previous period. Sorted by change_pct ascending (worst decliners first).
 func (as *analyticsStore) GetProductTrend(ctx context.Context, from, to time.Time, limit int) ([]entity.ProductTrendRow, error) {
-	statusIDs := storeutil.JoinInts(cache.OrderStatusIDsForNetRevenue())
 	baseCurrency := strings.ToUpper(cache.GetBaseCurrency())
 
 	dur := to.Sub(from)
@@ -411,28 +416,26 @@ func (as *analyticsStore) GetProductTrend(ctx context.Context, from, to time.Tim
 	prevTo := from
 
 	query := fmt.Sprintf(`
-		WITH current_period AS (
+		WITH %s,
+		%s,
+		current_period AS (
 			SELECT
 				oi.product_id,
-				SUM(oi.product_price * oi.quantity) AS revenue,
+				COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity * %s), 0) AS revenue,
 				SUM(oi.quantity) AS units
 			FROM order_item oi
-			JOIN customer_order co ON oi.order_id = co.id
-			WHERE co.order_status_id IN (%[1]s)
-				AND co.currency = :baseCurrency
-				AND co.placed >= :from AND co.placed < :to
+			JOIN order_factors_cur ofc ON ofc.order_id = oi.order_id
+			LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
 			GROUP BY oi.product_id
 		),
 		previous_period AS (
 			SELECT
 				oi.product_id,
-				SUM(oi.product_price * oi.quantity) AS revenue,
+				COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity * %s), 0) AS revenue,
 				SUM(oi.quantity) AS units
 			FROM order_item oi
-			JOIN customer_order co ON oi.order_id = co.id
-			WHERE co.order_status_id IN (%[1]s)
-				AND co.currency = :baseCurrency
-				AND co.placed >= :prevFrom AND co.placed < :prevTo
+			JOIN order_factors_prev ofp ON ofp.order_id = oi.order_id
+			LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
 			GROUP BY oi.product_id
 		)
 		SELECT
@@ -474,10 +477,13 @@ func (as *analyticsStore) GetProductTrend(ctx context.Context, from, to time.Tim
 			AND (p.hidden IS NULL OR p.hidden = 0)
 		ORDER BY change_pct ASC
 		LIMIT :limit
-	`, statusIDs)
+	`, orderFactorsCTENamed("order_factors_cur", "from", "to"),
+		orderFactorsCTENamed("order_factors_prev", "prevFrom", "prevTo"),
+		itemAdj("ofc"), itemAdj("ofp"))
 
 	result, err := storeutil.QueryListNamed[entity.ProductTrendRow](ctx, as.DB, query, map[string]any{
 		"baseCurrency": baseCurrency,
+		"statusIds":    cache.OrderStatusIDsForNetRevenue(),
 		"from":         from,
 		"to":           to,
 		"prevFrom":     prevFrom,

--- a/internal/store/metrics/apportion.go
+++ b/internal/store/metrics/apportion.go
@@ -1,0 +1,72 @@
+package metrics
+
+import "fmt"
+
+// Shared SQL for apportioning the actual Stripe-settled base amount across line items.
+//
+// Order-level revenue metrics anchor to customer_order.total_settled_base (the amount
+// Stripe actually settled, in base currency) when present, falling back to the
+// product_price reconstruction. Item/category metrics cannot use that order total
+// directly, so each line item's base list value (pp_base.price * (1-sale) * qty) is
+// scaled by a per-order factor that reproduces the same total:
+//
+//	adj = (100 - discount)/100               -- promo discount applied to items
+//	      * COALESCE(settled, recon)/recon   -- scale reconstruction to the actual settled amount (FX)
+//	      * (total_price - refunded)/total    -- refund proration
+//
+// where recon = items_base_total*(100-discount)/100 + shipping. For EUR orders with no
+// FX gap and no refund the factor reduces to (100-discount)/100, so item revenues sum to
+// the discounted items subtotal (shipping is intentionally excluded from product revenue).
+// For orders with no captured settled amount (pre-feature / non-Stripe) the COALESCE keeps
+// the pure reconstruction.
+
+// orderFactorsCTENamed returns an order_factors CTE body (no leading WITH) named `name`,
+// covering orders in [:fromParam, :toParam) with status IN (:statusIds) priced in
+// :baseCurrency. Join it as `JOIN <name> <alias> ON <alias>.order_id = oi.order_id` and
+// reference the per-item multiplier via itemAdj(alias) / itemAdjGross(alias).
+func orderFactorsCTENamed(name, fromParam, toParam string) string {
+	return fmt.Sprintf(`%s AS (
+		SELECT co.id AS order_id, co.placed, co.total_price,
+			COALESCE(co.refunded_amount, 0) AS refunded_amount,
+			co.total_settled_base,
+			COALESCE(MAX(pc.discount), 0) AS discount,
+			COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
+			COALESCE(MAX(scp.price), 0) AS shipment_base,
+			COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base_total
+		FROM customer_order co
+		LEFT JOIN order_item oi ON co.id = oi.order_id
+		LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
+		LEFT JOIN shipment s ON co.id = s.order_id
+		LEFT JOIN shipment_carrier_price scp ON s.carrier_id = scp.shipment_carrier_id AND UPPER(scp.currency) = UPPER(:baseCurrency)
+		LEFT JOIN promo_code pc ON co.promo_id = pc.id
+		WHERE co.placed >= :%s AND co.placed < :%s
+		AND co.order_status_id IN (:statusIds)
+		GROUP BY co.id, co.placed, co.total_price, co.refunded_amount, co.total_settled_base
+	)`, name, fromParam, toParam)
+}
+
+// itemAdj is the per-order multiplier (incl. refund ratio) for the order_factors row
+// joined as `alias`. Note: `of` is a reserved word in MySQL 8, so callers alias e.g. `ofac`.
+func itemAdj(alias string) string {
+	return fmt.Sprintf(`((100 - %[1]s.discount) / 100.0
+		* COALESCE(%[1]s.total_settled_base, %[1]s.items_base_total * (100 - %[1]s.discount) / 100.0 + CASE WHEN %[1]s.free_shipping THEN 0 ELSE %[1]s.shipment_base END)
+			/ NULLIF(%[1]s.items_base_total * (100 - %[1]s.discount) / 100.0 + CASE WHEN %[1]s.free_shipping THEN 0 ELSE %[1]s.shipment_base END, 0)
+		* (%[1]s.total_price - %[1]s.refunded_amount) / NULLIF(%[1]s.total_price, 0))`, alias)
+}
+
+// itemAdjGross is itemAdj WITHOUT the refund ratio — promo discount × fx/actual scaling
+// only. Use it where refunds are already accounted for at the line-item level (e.g. net
+// units via refunded_order_item), so refunds are not double-counted.
+func itemAdjGross(alias string) string {
+	return fmt.Sprintf(`((100 - %[1]s.discount) / 100.0
+		* COALESCE(%[1]s.total_settled_base, %[1]s.items_base_total * (100 - %[1]s.discount) / 100.0 + CASE WHEN %[1]s.free_shipping THEN 0 ELSE %[1]s.shipment_base END)
+			/ NULLIF(%[1]s.items_base_total * (100 - %[1]s.discount) / 100.0 + CASE WHEN %[1]s.free_shipping THEN 0 ELSE %[1]s.shipment_base END, 0))`, alias)
+}
+
+// Convenience values for the common single-period case: a CTE named order_factors over
+// [:from, :to), joined as alias `ofac`.
+var (
+	orderFactorsCTE  = orderFactorsCTENamed("order_factors", "from", "to")
+	itemAdjExpr      = itemAdj("ofac")
+	itemAdjGrossExpr = itemAdjGross("ofac")
+)

--- a/internal/store/metrics/breakdown.go
+++ b/internal/store/metrics/breakdown.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -34,7 +35,7 @@ func (s *Store) getRevenueByPaymentMethod(ctx context.Context, from, to time.Tim
 	query := `
 		WITH order_base AS (
 			SELECT ob.id,
-				(ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
+				COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
 			FROM (
 				SELECT co.id,
 					COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base,
@@ -42,7 +43,7 @@ func (s *Store) getRevenueByPaymentMethod(ctx context.Context, from, to time.Tim
 					COALESCE(MAX(pc.discount), 0) AS discount,
 					COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 					co.total_price,
-					COALESCE(co.refunded_amount, 0) AS refunded_amount
+					co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 				FROM customer_order co
 				LEFT JOIN order_item oi ON co.id = oi.order_id
 				LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
@@ -83,7 +84,7 @@ func (s *Store) getRevenueByCurrency(ctx context.Context, from, to time.Time) ([
 	query := `
 		WITH order_base AS (
 			SELECT ob.id, ob.currency,
-				(ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
+				COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
 			FROM (
 				SELECT co.id, co.currency,
 					COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base,
@@ -91,7 +92,7 @@ func (s *Store) getRevenueByCurrency(ctx context.Context, from, to time.Time) ([
 					COALESCE(MAX(pc.discount), 0) AS discount,
 					COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 					co.total_price,
-					COALESCE(co.refunded_amount, 0) AS refunded_amount
+					co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 				FROM customer_order co
 				LEFT JOIN order_item oi ON co.id = oi.order_id
 				LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
@@ -127,21 +128,20 @@ func (s *Store) getRevenueByCurrency(ctx context.Context, from, to time.Time) ([
 
 func (s *Store) getTopProductsByRevenue(ctx context.Context, from, to time.Time, limit int) ([]entity.ProductMetric, error) {
 	baseCurrency := strings.ToUpper(cache.GetBaseCurrency())
-	query := `
+	query := fmt.Sprintf(`
+		WITH %s
 		SELECT oi.product_id, p.brand,
 			(SELECT pt.name FROM product_translation pt WHERE pt.product_id = p.id ORDER BY pt.language_id LIMIT 1) AS product_name,
-			COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS value,
+			COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity * %s), 0) AS value,
 			SUM(oi.quantity) AS cnt
 		FROM order_item oi
 		JOIN product p ON oi.product_id = p.id
-		JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
-		JOIN customer_order co ON oi.order_id = co.id
-		WHERE co.placed >= :from AND co.placed < :to
-		AND co.order_status_id IN (:statusIds)
+		JOIN order_factors ofac ON ofac.order_id = oi.order_id
+		LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
 		GROUP BY oi.product_id, p.brand
 		ORDER BY value DESC
 		LIMIT :limit
-	`
+	`, orderFactorsCTE, itemAdjExpr)
 	rows, err := storeutil.QueryListNamed[struct {
 		ProductId   int             `db:"product_id"`
 		Brand       string          `db:"brand"`
@@ -165,21 +165,20 @@ func (s *Store) getTopProductsByRevenue(ctx context.Context, from, to time.Time,
 
 func (s *Store) getTopProductsByQuantity(ctx context.Context, from, to time.Time, limit int) ([]entity.ProductMetric, error) {
 	baseCurrency := strings.ToUpper(cache.GetBaseCurrency())
-	query := `
+	query := fmt.Sprintf(`
+		WITH %s
 		SELECT oi.product_id, p.brand,
 			(SELECT pt.name FROM product_translation pt WHERE pt.product_id = p.id ORDER BY pt.language_id LIMIT 1) AS product_name,
 			SUM(oi.quantity) AS cnt,
-			COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS value
+			COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity * %s), 0) AS value
 		FROM order_item oi
 		JOIN product p ON oi.product_id = p.id
-		JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
-		JOIN customer_order co ON oi.order_id = co.id
-		WHERE co.placed >= :from AND co.placed < :to
-		AND co.order_status_id IN (:statusIds)
+		JOIN order_factors ofac ON ofac.order_id = oi.order_id
+		LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
 		GROUP BY oi.product_id, p.brand
 		ORDER BY cnt DESC
 		LIMIT :limit
-	`
+	`, orderFactorsCTE, itemAdjExpr)
 	rows, err := storeutil.QueryListNamed[struct {
 		ProductId   int             `db:"product_id"`
 		Brand       string          `db:"brand"`
@@ -203,22 +202,21 @@ func (s *Store) getTopProductsByQuantity(ctx context.Context, from, to time.Time
 
 func (s *Store) getRevenueByCategory(ctx context.Context, from, to time.Time) ([]entity.CategoryMetric, error) {
 	baseCurrency := strings.ToUpper(cache.GetBaseCurrency())
-	query := `
+	query := fmt.Sprintf(`
+		WITH %s
 		SELECT p.top_category_id AS category_id, c.name AS category_name,
 			c.name AS category_display_name,
-			COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS value,
+			COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity * %s), 0) AS value,
 			SUM(oi.quantity) AS cnt
 		FROM order_item oi
 		JOIN product p ON oi.product_id = p.id
-		JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
+		JOIN order_factors ofac ON ofac.order_id = oi.order_id
+		LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
 		JOIN category c ON p.top_category_id = c.id
-		JOIN customer_order co ON oi.order_id = co.id
-		WHERE co.placed >= :from AND co.placed < :to
-		AND co.order_status_id IN (:statusIds)
 		GROUP BY p.top_category_id, c.name
 		ORDER BY value DESC
 		LIMIT 30
-	`
+	`, orderFactorsCTE, itemAdjExpr)
 	rows, err := storeutil.QueryListNamed[struct {
 		CategoryId          int             `db:"category_id"`
 		CategoryName        string          `db:"category_name"`

--- a/internal/store/metrics/business.go
+++ b/internal/store/metrics/business.go
@@ -557,23 +557,14 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 		if cTotalSessions > 0 {
 			cConvRate := decimal.NewFromInt(int64(cOrders)).Div(decimal.NewFromInt(int64(cTotalSessions))).Mul(decimal.NewFromInt(100))
 			m.ConversionRate.CompareValue = &cConvRate
-			if !m.ConversionRate.Value.IsZero() {
-				changePct := m.ConversionRate.Value.Sub(cConvRate).Div(cConvRate).Mul(decimal.NewFromInt(100))
-				f, ok := changePct.Round(2).Float64()
-				if ok {
-					m.ConversionRate.ChangePct = &f
-				}
-			}
+			// Guard the divisor (compare value), not the current value: guarding the
+			// current value left ChangePct nil when a metric dropped to 0 (should read
+			// -100%) and risked a decimal Div-by-zero panic when the compare period was 0.
+			m.ConversionRate.ChangePct = changePct(m.ConversionRate.Value, cConvRate)
 
 			cRevPerSession := cRev.Div(decimal.NewFromInt(int64(cTotalSessions)))
 			m.RevenuePerSession.CompareValue = &cRevPerSession
-			if !m.RevenuePerSession.Value.IsZero() {
-				changePct := m.RevenuePerSession.Value.Sub(cRevPerSession).Div(cRevPerSession).Mul(decimal.NewFromInt(100))
-				f, ok := changePct.Round(2).Float64()
-				if ok {
-					m.RevenuePerSession.ChangePct = &f
-				}
-			}
+			m.RevenuePerSession.ChangePct = changePct(m.RevenuePerSession.Value, cRevPerSession)
 		}
 
 		// Conversion rate by day compare

--- a/internal/store/metrics/coresales.go
+++ b/internal/store/metrics/coresales.go
@@ -24,6 +24,7 @@ func (s *Store) getCoreSalesMetrics(ctx context.Context, from, to time.Time) (re
 				COALESCE(MAX(pc.discount), 0) AS discount,
 				COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 				co.total_price,
+				co.total_settled_base,
 				COALESCE(co.refunded_amount, 0) AS refunded_amount
 			FROM customer_order co
 			LEFT JOIN order_item oi ON co.id = oi.order_id
@@ -33,11 +34,11 @@ func (s *Store) getCoreSalesMetrics(ctx context.Context, from, to time.Time) (re
 			LEFT JOIN promo_code pc ON co.promo_id = pc.id
 			WHERE co.placed >= :from AND co.placed < :to
 			AND co.order_status_id IN (:statusIds)
-			GROUP BY co.id, co.total_price, co.refunded_amount
+			GROUP BY co.id, co.total_price, co.refunded_amount, co.total_settled_base
 		)
 		SELECT
 			COALESCE(SUM(
-				(items_base * (100 - discount) / 100.0 + CASE WHEN free_shipping THEN 0 ELSE shipment_base END)
+				COALESCE(total_settled_base, items_base * (100 - discount) / 100.0 + CASE WHEN free_shipping THEN 0 ELSE shipment_base END)
 				* (total_price - refunded_amount) / NULLIF(total_price, 0)
 			), 0) AS revenue,
 			COUNT(*) AS orders
@@ -95,6 +96,7 @@ func (s *Store) getRefundMetrics(ctx context.Context, from, to time.Time) (refun
 				COALESCE(MAX(pc.discount), 0) AS discount,
 				COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 				co.total_price,
+				co.total_settled_base,
 				COALESCE(co.refunded_amount, 0) AS refunded_amount
 			FROM customer_order co
 			LEFT JOIN order_item oi ON co.id = oi.order_id
@@ -104,11 +106,11 @@ func (s *Store) getRefundMetrics(ctx context.Context, from, to time.Time) (refun
 			LEFT JOIN promo_code pc ON co.promo_id = pc.id
 			WHERE co.placed >= :from AND co.placed < :to
 			AND co.order_status_id IN (:statusIds) AND (co.refunded_amount IS NOT NULL AND co.refunded_amount > 0)
-			GROUP BY co.id, co.total_price, co.refunded_amount
+			GROUP BY co.id, co.total_price, co.refunded_amount, co.total_settled_base
 		)
 		SELECT
 			COALESCE(SUM(
-				refunded_amount * (items_base * (100 - discount) / 100.0 + CASE WHEN free_shipping THEN 0 ELSE shipment_base END) / NULLIF(total_price, 0)
+				refunded_amount * COALESCE(total_settled_base, items_base * (100 - discount) / 100.0 + CASE WHEN free_shipping THEN 0 ELSE shipment_base END) / NULLIF(total_price, 0)
 			), 0) AS amount,
 			COUNT(*) AS cnt
 		FROM order_base

--- a/internal/store/metrics/customers.go
+++ b/internal/store/metrics/customers.go
@@ -47,17 +47,22 @@ func (s *Store) getRepeatCustomerMetrics(ctx context.Context, from, to time.Time
 	repeatRate = decimal.NewFromInt(int64(repeatCount)).Div(decimal.NewFromInt(int64(totalCustomers))).Mul(decimal.NewFromInt(100))
 	avgOrders = decimal.NewFromInt(int64(totalOrders)).Div(decimal.NewFromInt(int64(totalCustomers)))
 
-	// Avg days between orders for repeat buyers — computed in SQL with LAG, no row materialization
+	// Avg days between orders for repeat buyers — computed in SQL with LAG, no row materialization.
+	// The LAG runs over each buyer's FULL order history (no date filter inside the window), then we
+	// keep only gaps whose later order falls in [from, to]. Filtering inside the window would measure
+	// a buyer's first in-window order against their previous in-window order, dropping the real gap to
+	// an order placed before `from` and systematically understating the average.
 	q2 := `
 		SELECT AVG(gap_days) AS avg_days
 		FROM (
-			SELECT DATEDIFF(co.placed, LAG(co.placed) OVER (PARTITION BY b.email ORDER BY co.placed)) AS gap_days
+			SELECT co.placed AS placed,
+				DATEDIFF(co.placed, LAG(co.placed) OVER (PARTITION BY b.email ORDER BY co.placed)) AS gap_days
 			FROM customer_order co
 			JOIN buyer b ON co.id = b.order_id
-			WHERE co.placed >= :from AND co.placed < :to
-			AND co.order_status_id IN (:statusIds)
+			WHERE co.order_status_id IN (:statusIds)
 		) t
 		WHERE gap_days IS NOT NULL
+		AND placed >= :from AND placed < :to
 	`
 	params := map[string]any{"from": from, "to": to, "statusIds": cache.OrderStatusIDsForNetRevenue()}
 	avgDaysRow, err := storeutil.QueryNamedOne[struct {
@@ -77,7 +82,7 @@ func (s *Store) getCLVStats(ctx context.Context, from, to time.Time) (entity.CLV
 	query := `
 		WITH order_base AS (
 			SELECT ob.id, b.email,
-				(ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
+				COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
 			FROM (
 				SELECT co.id,
 					COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base,
@@ -85,7 +90,7 @@ func (s *Store) getCLVStats(ctx context.Context, from, to time.Time) (entity.CLV
 					COALESCE(MAX(pc.discount), 0) AS discount,
 					COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 					co.total_price,
-					COALESCE(co.refunded_amount, 0) AS refunded_amount
+					co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 				FROM customer_order co
 				LEFT JOIN order_item oi ON co.id = oi.order_id
 				LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
@@ -173,7 +178,7 @@ WITH order_base AS (
 		COALESCE(MAX(pc.discount), 0) AS discount,
 		COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 		co.total_price,
-		COALESCE(co.refunded_amount, 0) AS refunded_amount
+		co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 	FROM customer_order co
 	LEFT JOIN order_item oi ON co.id = oi.order_id
 	LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
@@ -187,7 +192,7 @@ WITH order_base AS (
 order_revenue AS (
 	SELECT 
 		ob.id,
-		(ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END)
+		COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END)
 			* (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
 	FROM order_base ob
 ),
@@ -259,14 +264,14 @@ func (s *Store) getRevenueByPromo(ctx context.Context, from, to time.Time) ([]en
 	query := `
 		WITH order_base AS (
 			SELECT ob.id, ob.promo_id, ob.code, ob.discount,
-				(ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
+				COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
 			FROM (
 				SELECT co.id, pc.id AS promo_id, pc.code, pc.discount,
 					COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base,
 					COALESCE(MAX(scp.price), 0) AS shipment_base,
 					COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 					co.total_price,
-					COALESCE(co.refunded_amount, 0) AS refunded_amount
+					co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 				FROM customer_order co
 				LEFT JOIN order_item oi ON co.id = oi.order_id
 				LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
@@ -372,7 +377,7 @@ WITH order_base AS (
 			COALESCE(MAX(pc.discount), 0) AS discount,
 			COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 			co.total_price,
-			COALESCE(co.refunded_amount, 0) AS refunded_amount
+			co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 		FROM customer_order co
 		LEFT JOIN order_item oi ON co.id = oi.order_id
 		LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)

--- a/internal/store/metrics/geography.go
+++ b/internal/store/metrics/geography.go
@@ -26,7 +26,7 @@ func (s *Store) getRevenueByGeography(ctx context.Context, from, to time.Time, g
 	query := fmt.Sprintf(`
 		WITH order_base AS (
 			SELECT ob.id,
-				(ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
+				COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
 			FROM (
 				SELECT co.id,
 					COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base,
@@ -34,7 +34,7 @@ func (s *Store) getRevenueByGeography(ctx context.Context, from, to time.Time, g
 					COALESCE(MAX(pc.discount), 0) AS discount,
 					COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 					co.total_price,
-					COALESCE(co.refunded_amount, 0) AS refunded_amount
+					co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 				FROM customer_order co
 				LEFT JOIN order_item oi ON co.id = oi.order_id
 				LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
@@ -98,7 +98,7 @@ func (s *Store) getAvgOrderByGeography(ctx context.Context, from, to time.Time) 
 	query := `
 		WITH order_base AS (
 			SELECT ob.id,
-				(ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
+				COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
 			FROM (
 				SELECT co.id,
 					COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base,
@@ -106,7 +106,7 @@ func (s *Store) getAvgOrderByGeography(ctx context.Context, from, to time.Time) 
 					COALESCE(MAX(pc.discount), 0) AS discount,
 					COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 					co.total_price,
-					COALESCE(co.refunded_amount, 0) AS refunded_amount
+					co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 				FROM customer_order co
 				LEFT JOIN order_item oi ON co.id = oi.order_id
 				LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)

--- a/internal/store/metrics/retention.go
+++ b/internal/store/metrics/retention.go
@@ -30,7 +30,7 @@ func (rs *retentionStore) GetCohortRetention(ctx context.Context, from, to time.
 	query := fmt.Sprintf(`
 		WITH order_revenue_base AS (
 			SELECT ob.id, b.email, co.placed,
-				(ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
+				COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
 			FROM (
 				SELECT co.id,
 					COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base,
@@ -38,7 +38,7 @@ func (rs *retentionStore) GetCohortRetention(ctx context.Context, from, to time.
 					COALESCE(MAX(pc.discount), 0) AS discount,
 					COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 					co.total_price,
-					COALESCE(co.refunded_amount, 0) AS refunded_amount
+					co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 				FROM customer_order co
 				LEFT JOIN order_item oi ON co.id = oi.order_id
 				LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER('%s')
@@ -149,8 +149,8 @@ func (rs *retentionStore) GetOrderSequenceMetrics(ctx context.Context, from, to 
 			SELECT
 				co.id,
 				co.placed,
-				(COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) * (100 - COALESCE(MAX(pc.discount), 0)) / 100.0
-					+ CASE WHEN COALESCE(MAX(pc.free_shipping), 0) THEN 0 ELSE COALESCE(MAX(scp.price), 0) END)
+				COALESCE(co.total_settled_base, (COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) * (100 - COALESCE(MAX(pc.discount), 0)) / 100.0
+					+ CASE WHEN COALESCE(MAX(pc.free_shipping), 0) THEN 0 ELSE COALESCE(MAX(scp.price), 0) END))
 					* (co.total_price - COALESCE(co.refunded_amount, 0)) / NULLIF(co.total_price, 0) AS revenue_base
 			FROM customer_order co
 			LEFT JOIN order_item oi ON co.id = oi.order_id
@@ -327,8 +327,8 @@ func (rs *retentionStore) GetCustomerSpendingCurve(ctx context.Context, from, to
 			SELECT
 				co.id,
 				co.placed,
-				(COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) * (100 - COALESCE(MAX(pc.discount), 0)) / 100.0
-					+ CASE WHEN COALESCE(MAX(pc.free_shipping), 0) THEN 0 ELSE COALESCE(MAX(scp.price), 0) END)
+				COALESCE(co.total_settled_base, (COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) * (100 - COALESCE(MAX(pc.discount), 0)) / 100.0
+					+ CASE WHEN COALESCE(MAX(pc.free_shipping), 0) THEN 0 ELSE COALESCE(MAX(scp.price), 0) END))
 					* (co.total_price - COALESCE(co.refunded_amount, 0)) / NULLIF(co.total_price, 0) AS revenue_base
 			FROM customer_order co
 			LEFT JOIN order_item oi ON co.id = oi.order_id

--- a/internal/store/metrics/timeseries.go
+++ b/internal/store/metrics/timeseries.go
@@ -17,7 +17,7 @@ func (s *Store) getRevenueByPeriod(ctx context.Context, from, to time.Time, date
 	query := fmt.Sprintf(`
 		WITH order_base AS (
 			SELECT ob.id, ob.placed,
-				(ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
+				COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
 			FROM (
 				SELECT co.id, co.placed,
 					COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base,
@@ -25,7 +25,7 @@ func (s *Store) getRevenueByPeriod(ctx context.Context, from, to time.Time, date
 					COALESCE(MAX(pc.discount), 0) AS discount,
 					COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 					co.total_price,
-					COALESCE(co.refunded_amount, 0) AS refunded_amount
+					co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 				FROM customer_order co
 				LEFT JOIN order_item oi ON co.id = oi.order_id
 				LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
@@ -138,7 +138,7 @@ func (s *Store) getGrossRevenueByPeriod(ctx context.Context, from, to time.Time,
 		D     time.Time       `db:"d"`
 		Value decimal.Decimal `db:"value"`
 		Count int             `db:"cnt"`
-	}](ctx, s.DB, query, map[string]any{"from": from, "to": to, "baseCurrency": baseCurrency, "statusIds": cache.OrderStatusIDsForNetRevenue()})
+	}](ctx, s.DB, query, map[string]any{"from": from, "to": to, "baseCurrency": baseCurrency, "statusIds": cache.OrderStatusIDsForRefund()})
 	if err != nil {
 		return nil, err
 	}
@@ -192,9 +192,9 @@ func (s *Store) getRefundsByPeriod(ctx context.Context, from, to time.Time, date
 	query := fmt.Sprintf(`
 		WITH order_base AS (
 			SELECT ob.id, ob.placed,
-				refunded_amount * (ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) / NULLIF(ob.total_price, 0) AS refunded_base
+				refunded_amount * COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) / NULLIF(ob.total_price, 0) AS refunded_base
 			FROM (
-				SELECT co.id, co.placed, COALESCE(co.refunded_amount, 0) AS refunded_amount,
+				SELECT co.id, co.placed, co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount,
 					COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base,
 					COALESCE(MAX(scp.price), 0) AS shipment_base,
 					COALESCE(MAX(pc.discount), 0) AS discount,
@@ -239,7 +239,7 @@ func (s *Store) getAvgOrderValueByPeriod(ctx context.Context, from, to time.Time
 	query := fmt.Sprintf(`
 		WITH order_base AS (
 			SELECT ob.id, ob.placed,
-				(ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
+				COALESCE(ob.total_settled_base, ob.items_base * (100 - ob.discount) / 100.0 + CASE WHEN ob.free_shipping THEN 0 ELSE ob.shipment_base END) * (ob.total_price - ob.refunded_amount) / NULLIF(ob.total_price, 0) AS revenue_base
 			FROM (
 				SELECT co.id, co.placed,
 					COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity), 0) AS items_base,
@@ -247,7 +247,7 @@ func (s *Store) getAvgOrderValueByPeriod(ctx context.Context, from, to time.Time
 					COALESCE(MAX(pc.discount), 0) AS discount,
 					COALESCE(MAX(pc.free_shipping), 0) AS free_shipping,
 					co.total_price,
-					COALESCE(co.refunded_amount, 0) AS refunded_amount
+					co.total_settled_base, COALESCE(co.refunded_amount, 0) AS refunded_amount
 				FROM customer_order co
 				LEFT JOIN order_item oi ON co.id = oi.order_id
 				LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
@@ -315,10 +315,12 @@ func (s *Store) getUnitsSoldByPeriod(ctx context.Context, from, to time.Time, da
 func (s *Store) getNewVsReturningCustomersByPeriod(ctx context.Context, from, to time.Time, dateExpr string) (newCustomers, returningCustomers []entity.TimeSeriesPoint, err error) {
 	query := fmt.Sprintf(`
 		WITH first_order AS (
+			-- A customer's true first order is across ALL statuses: filtering to
+			-- net-revenue statuses here would treat someone whose first order was
+			-- cancelled/unpaid as "new" on a later order, overcounting new customers.
 			SELECT b.email, MIN(co.placed) AS first_placed
 			FROM customer_order co
 			JOIN buyer b ON co.id = b.order_id
-			WHERE co.order_status_id IN (:statusIds)
 			GROUP BY b.email
 		),
 		period_orders AS (

--- a/internal/store/order/insert.go
+++ b/internal/store/order/insert.go
@@ -171,7 +171,10 @@ func insertOrder(ctx context.Context, db dependency.DB, order *entity.Order) (in
 	 VALUES (:uuid, :totalPrice, :totalPriceEur, :currency, :orderStatusId, :promoId, :gaClientId)
 	`
 
-	orderRef := generateOrderReference()
+	orderRef, err := generateOrderReference()
+	if err != nil {
+		return 0, "", err
+	}
 	var totalPriceEur any
 	if order.TotalPriceEUR.Valid {
 		totalPriceEur = order.TotalPriceEUR.Decimal

--- a/internal/store/order/payment.go
+++ b/internal/store/order/payment.go
@@ -8,6 +8,7 @@ import (
 
 	"log/slog"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
 	"github.com/jekabolt/grbpwr-manager/internal/dto"
@@ -161,6 +162,11 @@ func (s *Store) AssociatePaymentIntentWithOrder(ctx context.Context, orderUUID s
 		"orderUUID":       orderUUID,
 	})
 	if err != nil {
+		// UNIQUE violation on payment.client_secret: this PaymentIntent is already
+		// linked to another order (a concurrent SubmitOrder won the race).
+		if me, ok := err.(*mysql.MySQLError); ok && me.Number == 1062 {
+			return ErrPaymentIntentAlreadyAssociated
+		}
 		return fmt.Errorf("can't associate payment intent with order: %w", err)
 	}
 
@@ -190,15 +196,41 @@ func (s *Store) UpdateTotalPaymentCurrency(ctx context.Context, orderUUID string
 	return nil
 }
 
+// UpdateTotalSettledBase records the actual Stripe-settled amount for an order,
+// converted to the base currency (EUR). Captured once at payment confirmation.
+func (s *Store) UpdateTotalSettledBase(ctx context.Context, orderUUID string, settledBase decimal.Decimal) error {
+	query := `
+	UPDATE customer_order
+	SET total_settled_base = :settledBase
+	WHERE uuid = :orderUUID`
+
+	err := storeutil.ExecNamed(ctx, s.DB, query, map[string]any{
+		"settledBase": settledBase,
+		"orderUUID":   orderUUID,
+	})
+	if err != nil {
+		return fmt.Errorf("can't update total settled base: %w", err)
+	}
+	return nil
+}
+
 // GetPaymentByOrderUUID retrieves a payment by the order UUID.
 func (s *Store) GetPaymentByOrderUUID(ctx context.Context, orderUUID string) (*entity.Payment, error) {
+	return getPaymentByOrderUUID(ctx, s.DB, orderUUID)
+}
+
+// getPaymentByOrderUUID runs the lookup on the given DB handle. Inside a
+// transaction it MUST be called with the tx connection (rep.DB()/txDB), not the
+// root pool: the query JOINs customer_order, and under SERIALIZABLE a read on a
+// separate connection would block on the tx's own FOR UPDATE lock (self-deadlock).
+func getPaymentByOrderUUID(ctx context.Context, db dependency.DB, orderUUID string) (*entity.Payment, error) {
 	query := `
     SELECT p.*
     FROM payment p
     JOIN customer_order co ON p.order_id = co.id
     WHERE co.uuid = :orderUUID;`
 
-	payment, err := storeutil.QueryNamedOne[entity.Payment](ctx, s.DB, query, map[string]interface{}{
+	payment, err := storeutil.QueryNamedOne[entity.Payment](ctx, db, query, map[string]interface{}{
 		"orderUUID": orderUUID,
 	})
 	if err != nil {
@@ -232,7 +264,7 @@ func (s *Store) ExpireOrderPayment(ctx context.Context, orderUUID string) (*enti
 			return nil
 		}
 
-		payment, err = s.GetPaymentByOrderUUID(ctx, order.UUID)
+		payment, err = getPaymentByOrderUUID(ctx, txDB, order.UUID)
 		if err != nil {
 			return fmt.Errorf("can't get payment by order id: %w", err)
 		}
@@ -290,9 +322,13 @@ func (s *Store) ExpireOrderPayment(ctx context.Context, orderUUID string) (*enti
 // OrderPaymentDone marks an order payment as done and transitions to Confirmed.
 func (s *Store) OrderPaymentDone(ctx context.Context, orderUUID string, p *entity.Payment) (bool, error) {
 	wasUpdated := false
+	// Promo code to disable in the in-memory cache, applied only after the tx
+	// commits so a rollback/retry can't desync the cache from the DB.
+	var voucherCodeToDisable string
 
 	err := s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
 		txDB := rep.DB()
+		voucherCodeToDisable = ""
 
 		order, err := getOrderByUUIDForUpdate(ctx, txDB, orderUUID)
 		if err != nil {
@@ -309,10 +345,11 @@ func (s *Store) OrderPaymentDone(ctx context.Context, orderUUID string, p *entit
 		}
 
 		if order.PromoId.Int32 != 0 {
-			err := rep.Promo().DisableVoucher(ctx, order.PromoId)
+			code, err := disableVoucherInTx(ctx, txDB, order.PromoId)
 			if err != nil {
 				return fmt.Errorf("can't disable voucher: %w", err)
 			}
+			voucherCodeToDisable = code
 		}
 
 		err = updateOrderStatus(ctx, txDB, order.Id, cache.OrderStatusConfirmed.Status.Id)
@@ -332,6 +369,11 @@ func (s *Store) OrderPaymentDone(ctx context.Context, orderUUID string, p *entit
 	})
 	if err != nil {
 		return false, err
+	}
+
+	// Cache mutation after commit only — see disableVoucherInTx.
+	if voucherCodeToDisable != "" {
+		cache.DisablePromo(voucherCodeToDisable)
 	}
 
 	return wasUpdated, nil

--- a/internal/store/order/refund.go
+++ b/internal/store/order/refund.go
@@ -22,6 +22,29 @@ func refundAmountFromItems(items []entity.OrderItemInsert, currency string) deci
 	return dto.RoundForCurrency(sum, currency)
 }
 
+// stockRestoreMode describes how stock should be handled when cancelling an
+// order in a given status. Stock is only ever reduced on the
+// Placed -> AwaitingPayment transition (InsertFiatInvoice), so restoring it for
+// a status that never reduced it would inflate inventory.
+type stockRestoreMode int
+
+const (
+	stockRestoreNone    stockRestoreMode = iota // status never reduced stock (e.g. Placed)
+	stockRestoreSilent                          // reduced at invoice time; restore without history
+	stockRestoreHistory                         // reduced for a confirmed+ order; restore with history
+)
+
+func stockRestoreModeForCancel(st entity.OrderStatusName) stockRestoreMode {
+	switch st {
+	case entity.Placed:
+		return stockRestoreNone
+	case entity.AwaitingPayment:
+		return stockRestoreSilent
+	default:
+		return stockRestoreHistory
+	}
+}
+
 func cancelOrder(ctx context.Context, rep dependency.Repository, order *entity.Order, orderItems []entity.OrderItemInsert, source entity.StockChangeSource, refundReason string) error {
 	orderStatus, err := getOrderStatus(order.OrderStatusId)
 	if err != nil {
@@ -38,19 +61,22 @@ func cancelOrder(ctx context.Context, rep dependency.Repository, order *entity.O
 		return fmt.Errorf("order cannot be cancelled: %w", err)
 	}
 
-	if st == entity.AwaitingPayment {
-		err := rep.Products().RestoreStockSilently(ctx, orderItems)
-		if err != nil {
+	// Restore stock only for statuses that actually reduced it; restoring for a
+	// Placed order (which never reduced stock) would inflate inventory.
+	switch stockRestoreModeForCancel(st) {
+	case stockRestoreNone:
+		// Stock was never reduced for this status; nothing to restore.
+	case stockRestoreSilent:
+		if err := rep.Products().RestoreStockSilently(ctx, orderItems); err != nil {
 			return fmt.Errorf("can't restore stock for product sizes: %w", err)
 		}
-	} else {
+	case stockRestoreHistory:
 		history := &entity.StockHistoryParams{
 			Source:    source,
 			OrderId:   order.Id,
 			OrderUUID: order.UUID,
 		}
-		err := rep.Products().RestoreStockForProductSizes(ctx, orderItems, history)
-		if err != nil {
+		if err := rep.Products().RestoreStockForProductSizes(ctx, orderItems, history); err != nil {
 			return fmt.Errorf("can't restore stock for product sizes: %w", err)
 		}
 	}

--- a/internal/store/order/refund_test.go
+++ b/internal/store/order/refund_test.go
@@ -1,0 +1,29 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+)
+
+// TestStockRestoreModeForCancel guards the invariant that stock is only ever
+// reduced on the Placed -> AwaitingPayment transition. Cancelling a Placed order
+// must NOT restore stock (it was never reduced), otherwise inventory inflates.
+func TestStockRestoreModeForCancel(t *testing.T) {
+	cases := []struct {
+		status entity.OrderStatusName
+		want   stockRestoreMode
+	}{
+		{entity.Placed, stockRestoreNone},              // stock never reduced -> must not restore
+		{entity.AwaitingPayment, stockRestoreSilent},   // reduced at invoice time
+		{entity.Confirmed, stockRestoreHistory},        // reduced; restore with history
+		{entity.PendingReturn, stockRestoreHistory},    // came from shipped/delivered
+		{entity.RefundInProgress, stockRestoreHistory}, // came from confirmed
+	}
+
+	for _, c := range cases {
+		if got := stockRestoreModeForCancel(c.status); got != c.want {
+			t.Errorf("stockRestoreModeForCancel(%s) = %d, want %d", c.status, got, c.want)
+		}
+	}
+}

--- a/internal/store/order/store.go
+++ b/internal/store/order/store.go
@@ -16,6 +16,11 @@ var ErrOrderItemsUpdated = errors.New("order items are not valid and were update
 // errPaymentRecordNotFound indicates the payment record for the order was not found (0 rows updated).
 var errPaymentRecordNotFound = errors.New("payment record not found for order")
 
+// ErrPaymentIntentAlreadyAssociated is returned when a PaymentIntent is already
+// linked to another order (UNIQUE violation on payment.client_secret), i.e. a
+// concurrent SubmitOrder won the race for the same PaymentIntent.
+var ErrPaymentIntentAlreadyAssociated = errors.New("payment intent already associated with another order")
+
 // TxFunc executes f within a serializable transaction with deadlock retry.
 type TxFunc func(ctx context.Context, f func(context.Context, dependency.Repository) error) error
 

--- a/internal/store/order/update.go
+++ b/internal/store/order/update.go
@@ -164,3 +164,25 @@ func removePromo(ctx context.Context, db dependency.DB, orderId int) error {
 	}
 	return nil
 }
+
+// disableVoucherInTx disables a single-use voucher in the DB on the caller's
+// transaction connection and returns the promo code that was disabled (empty if
+// the promo is not a voucher or is unknown). It intentionally does NOT mutate the
+// in-memory promo cache: the caller must apply cache.DisablePromo only after the
+// transaction commits, otherwise a rollback or serialization retry would leave
+// the cache marking the voucher disabled while the DB still allows it.
+func disableVoucherInTx(ctx context.Context, db dependency.DB, promoID sql.NullInt32) (string, error) {
+	if !promoID.Valid || promoID.Int32 == 0 {
+		return "", nil
+	}
+	promo, ok := cache.GetPromoById(int(promoID.Int32))
+	if !ok || !promo.Voucher {
+		return "", nil
+	}
+	if err := storeutil.ExecNamed(ctx, db, `UPDATE promo_code SET allowed = false WHERE code = :code`, map[string]any{
+		"code": promo.Code,
+	}); err != nil {
+		return "", fmt.Errorf("can't disable voucher: %w", err)
+	}
+	return promo.Code, nil
+}

--- a/internal/store/order/util.go
+++ b/internal/store/order/util.go
@@ -48,7 +48,7 @@ func sanitizePhone(phone string) (string, error) {
 	return sanitized, nil
 }
 
-func generateOrderReference() string {
+func generateOrderReference() (string, error) {
 	const (
 		prefix   = "ORD-"
 		length   = 7
@@ -59,9 +59,9 @@ func generateOrderReference() string {
 	for i := range b {
 		n, err := rand.Int(rand.Reader, big.NewInt(base))
 		if err != nil {
-			panic(err)
+			return "", fmt.Errorf("can't generate order reference: %w", err)
 		}
 		b[i] = alphabet[n.Int64()]
 	}
-	return prefix + string(b)
+	return prefix + string(b), nil
 }

--- a/internal/store/order/validation.go
+++ b/internal/store/order/validation.go
@@ -119,6 +119,13 @@ func validateOrderItemsStockAvailabilityWithLock(ctx context.Context, rep depend
 	adjustments := make([]entity.OrderItemAdjustment, 0)
 
 	for _, item := range items {
+		// Reject non-positive quantities outright: this is malformed/abusive input
+		// (the raw quantity feeds subtotal math, so a negative value would produce a
+		// negative total / store credit), not a soft out-of-stock adjustment.
+		if item.Quantity.LessThanOrEqual(decimal.Zero) {
+			return nil, nil, &entity.ValidationError{Message: fmt.Sprintf("invalid quantity for product %d size %d: must be positive", item.ProductId, item.SizeId)}
+		}
+
 		sizeKey := fmt.Sprintf("%d-%d", item.ProductId, item.SizeId)
 		prdSize, exists := prdSizeMap[sizeKey]
 
@@ -222,6 +229,9 @@ func validateOrderItemsStockForCustomOrder(ctx context.Context, rep dependency.R
 	validItems := make([]entity.OrderItem, 0, len(items))
 	adjustments := make([]entity.OrderItemAdjustment, 0)
 	for _, item := range items {
+		if item.Quantity.LessThanOrEqual(decimal.Zero) {
+			return nil, nil, &entity.ValidationError{Message: fmt.Sprintf("invalid quantity for product %d size %d: must be positive", item.ProductId, item.SizeId)}
+		}
 		sizeKey := fmt.Sprintf("%d-%d", item.ProductId, item.SizeId)
 		prdSize, exists := prdSizeMap[sizeKey]
 		if !exists || !prdSize.QuantityDecimal().GreaterThan(decimal.Zero) {

--- a/internal/store/promo/promo.go
+++ b/internal/store/promo/promo.go
@@ -107,11 +107,10 @@ func (s *Store) DisableVoucher(ctx context.Context, promoID sql.NullInt32) error
 	}
 
 	if promo.Voucher {
-		err := s.DisablePromoCode(ctx, promo.Code)
-		if err != nil {
+		// DisablePromoCode already updates the in-memory cache.
+		if err := s.DisablePromoCode(ctx, promo.Code); err != nil {
 			return fmt.Errorf("failed to disable voucher: %w", err)
 		}
-		cache.DisablePromo(promo.Code)
 	}
 
 	return nil

--- a/internal/store/sql/0059_payment_client_secret_unique.sql
+++ b/internal/store/sql/0059_payment_client_secret_unique.sql
@@ -1,0 +1,16 @@
+-- +migrate Up
+-- Enforce one order per Stripe PaymentIntent. The application stores the
+-- PaymentIntent reference in payment.client_secret; a UNIQUE index makes the
+-- concurrent-SubmitOrder race fail fast (the losing AssociatePaymentIntentWithOrder
+-- hits a duplicate-key error) instead of silently creating duplicate orders with
+-- double stock reduction. NULL is allowed for many rows (MySQL permits multiple
+-- NULLs in a UNIQUE index), so Placed and custom (bank_invoice/cash) orders whose
+-- client_secret is not yet set are unaffected.
+
+ALTER TABLE payment
+  ADD UNIQUE INDEX uniq_payment_client_secret (client_secret);
+
+-- +migrate Down
+
+ALTER TABLE payment
+  DROP INDEX uniq_payment_client_secret;

--- a/internal/store/sql/0060_add_order_settled_base.sql
+++ b/internal/store/sql/0060_add_order_settled_base.sql
@@ -1,0 +1,14 @@
+-- +migrate Up
+-- Store the actual amount Stripe settled for an order, converted to the base
+-- currency (EUR) at Stripe's FX rate (from the charge's balance transaction).
+-- This is the authoritative base-currency revenue figure; revenue metrics use it
+-- in preference to reconstructing from the mutable product_price table. NULL means
+-- not captured (orders placed before this feature, non-Stripe payment methods, or
+-- still-unpaid orders), in which case metrics fall back to the reconstruction.
+ALTER TABLE customer_order
+  ADD COLUMN total_settled_base DECIMAL(10, 2) NULL DEFAULT NULL
+    COMMENT 'Actual Stripe-settled amount in base currency (EUR) at Stripe FX; NULL = not captured';
+
+-- +migrate Down
+ALTER TABLE customer_order
+  DROP COLUMN total_settled_base;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -372,6 +372,9 @@ func (ms *MYSQLStore) StorefrontAccount() dependency.StorefrontAccount {
 // ErrOrderItemsUpdated is re-exported from the order sub-package for backward compatibility.
 var ErrOrderItemsUpdated = order.ErrOrderItemsUpdated
 
+// ErrPaymentIntentAlreadyAssociated is re-exported from the order sub-package.
+var ErrPaymentIntentAlreadyAssociated = order.ErrPaymentIntentAlreadyAssociated
+
 // ValidStatusTransitions is re-exported from the order sub-package for backward compatibility.
 var ValidStatusTransitions = order.ValidStatusTransitions
 

--- a/internal/store/storeutil/helper.go
+++ b/internal/store/storeutil/helper.go
@@ -9,16 +9,25 @@ import (
 // DefaultBQPageLimit is the default limit when 0 is passed to paginated BQ reads.
 const DefaultBQPageLimit = 500
 
+// MaxBQPageLimit caps a caller-supplied page limit so a huge value (e.g. limit=10_000_000)
+// can't make a paginated read materialize an unbounded result set — OOM / oversized
+// response. Callers that need more must page with offset.
+const MaxBQPageLimit = 5000
+
 // BQPageParams holds limit/offset for paginated BQ cache reads.
 type BQPageParams struct {
 	Limit  int // 0 = DefaultBQPageLimit
 	Offset int // must be >= 0
 }
 
-// EffectiveLimit returns the limit to use, defaulting to DefaultBQPageLimit.
+// EffectiveLimit returns the limit to use, defaulting to DefaultBQPageLimit and capped at
+// MaxBQPageLimit so a caller can't request an unbounded result set.
 func (p BQPageParams) EffectiveLimit() int {
 	if p.Limit <= 0 {
 		return DefaultBQPageLimit
+	}
+	if p.Limit > MaxBQPageLimit {
+		return MaxBQPageLimit
 	}
 	return p.Limit
 }

--- a/internal/storefrontcleanup/storefrontcleanup.go
+++ b/internal/storefrontcleanup/storefrontcleanup.go
@@ -3,6 +3,7 @@ package storefrontcleanup
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"log/slog"
@@ -28,6 +29,7 @@ type Worker struct {
 	c    *Config
 	ctx  context.Context
 	stop context.CancelFunc
+	wg   sync.WaitGroup
 }
 
 // New creates a new storefront cleanup worker.
@@ -51,17 +53,21 @@ func (w *Worker) Start(ctx context.Context) error {
 		return fmt.Errorf("storefront cleanup worker already started")
 	}
 	w.ctx, w.stop = context.WithCancel(ctx)
-	go w.worker(w.ctx)
+	w.wg.Go(func() {
+		w.worker(w.ctx)
+	})
 	return nil
 }
 
-// Stop stops the worker gracefully.
+// Stop signals the worker to stop and waits for its goroutine to exit, so the
+// caller can safely close shared resources (e.g. the DB) afterwards.
 func (w *Worker) Stop() error {
 	if w.stop == nil {
 		return fmt.Errorf("storefront cleanup worker already stopped or not started")
 	}
 	w.stop()
 	w.stop = nil
+	w.wg.Wait()
 	return nil
 }
 

--- a/internal/stripereconcile/stripereconcile.go
+++ b/internal/stripereconcile/stripereconcile.go
@@ -3,6 +3,7 @@ package stripereconcile
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -31,6 +32,7 @@ type Worker struct {
 	c        *Config
 	ctx      context.Context
 	stop     context.CancelFunc
+	wg       sync.WaitGroup
 }
 
 // New creates a new Stripe reconciliation worker.
@@ -57,16 +59,20 @@ func (w *Worker) Start(ctx context.Context) error {
 		return fmt.Errorf("stripe reconcile worker already started")
 	}
 	w.ctx, w.stop = context.WithCancel(ctx)
-	go w.worker(w.ctx)
+	w.wg.Go(func() {
+		w.worker(w.ctx)
+	})
 	return nil
 }
 
-// Stop stops the worker gracefully.
+// Stop signals the worker to stop and waits for its goroutine to exit, so the
+// caller can safely close shared resources (e.g. the DB) afterwards.
 func (w *Worker) Stop() error {
 	if w.stop == nil {
 		return fmt.Errorf("stripe reconcile worker already stopped or not started")
 	}
 	w.stop()
 	w.stop = nil
+	w.wg.Wait()
 	return nil
 }

--- a/internal/tiermanagement/worker.go
+++ b/internal/tiermanagement/worker.go
@@ -3,6 +3,7 @@ package tiermanagement
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"log/slog"
@@ -29,6 +30,7 @@ type Worker struct {
 	c      *Config
 	ctx    context.Context
 	stop   context.CancelFunc
+	wg     sync.WaitGroup
 }
 
 // New constructs a tier maintenance worker.
@@ -49,17 +51,21 @@ func (w *Worker) Start(ctx context.Context) error {
 		return fmt.Errorf("tier management worker already started")
 	}
 	w.ctx, w.stop = context.WithCancel(ctx)
-	go w.run(w.ctx)
+	w.wg.Go(func() {
+		w.run(w.ctx)
+	})
 	return nil
 }
 
-// Stop signals the worker to exit.
+// Stop signals the worker to exit and waits for its goroutine to return, so the
+// caller can safely close shared resources (e.g. the DB) afterwards.
 func (w *Worker) Stop() error {
 	if w.stop == nil {
 		return fmt.Errorf("tier management worker already stopped or not started")
 	}
 	w.stop()
 	w.stop = nil
+	w.wg.Wait()
 	return nil
 }
 


### PR DESCRIPTION
Bundles this session's **security/correctness audit fixes** together with the in-progress **payment (Stripe webhook, settled-base) and analytics/metrics** work. They are bundled in one PR because they are intertwined at the file level (e.g. the new webhook + amount validation both live in `payment/stripe/payment.go`/`updateOrderAsPaid`), so independent PRs wouldn't compile in isolation. History is split into logical commits.

## Audit fixes (by commit)
- **cache**: guard runtime-mutable cache globals with `RWMutex` (map read/write could fatally crash the process) + `-race` regression test; fix latent nil deref in `GetPaymentMethodBy*`.
- **auth**: fail closed on empty `jwt_secret`/`master_password`; `TrimSpace` master password (env trailing-newline); WARN (not ERROR) for routine failed logins; config-load test.
- **lifecycle**: gRPC **panic-recovery interceptor** (was commented out — any handler panic crashed the process); **graceful shutdown** draining server before workers/DB; worker `Stop()` joins via `WaitGroup`; stop stockreserve goroutine.
- **api**: nil-guards on unauthenticated handlers (`SubmitOrder`, `SubmitSupportTicket`, `CheckForTransactions` nil); clamp pagination on public `GetProductsPaged`/`GetArchivesPaged` (DoS).
- **orders/payments**: validate Stripe-received amount vs order total at confirmation (reject underpayment); tx-connection read in `ExpireOrderPayment` (self-deadlock); voucher cache mutation after commit; reject non-positive quantities; `generateOrderReference` returns error instead of panic; validate stripe `secret_key` at startup.
- **infra/misc**: Dockerfile non-root user; prod `LOGGER_LEVEL` Debug→Info; package-level metric regexps; nil-safe mail dto.

## Payment & analytics WIP (carried)
- Stripe **webhook handler**, `client_secret` unique constraint (`0059`), **settled-base** capture (`0060`), refund changes.
- BigQuery/GA4/GA4MP/ga4sync updates, metrics store (incl. `apportion`), revalidation, admin/frontend wiring.

## Verification
`go build ./...`, `go vet ./...`, and unit tests (cache/auth/stripe/order/metrics/config/dto/...) pass. DB-backed tests not run locally (no MySQL) — beta deploy exercises those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)