### PR TITLE
fix: beta revalidation (per-env domains) + metrics sqlx comment colon

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -216,6 +216,9 @@ envs:
 - key: REVALIDATION_HTTP_TIMEOUT
   scope: RUN_TIME
   value: 10s
+- key: REVALIDATION_DOMAINS
+  scope: RUN_TIME
+  value: grbpwr.com,grbpwr-com-dusky.vercel.app
 - key: GA4MP_ENABLED
   scope: RUN_TIME
   value: "true"

--- a/config/cfg.go
+++ b/config/cfg.go
@@ -224,6 +224,7 @@ func bindEnvVars() {
 	viper.BindEnv("revalidation.vercel_api_token", "REVALIDATION_VERCEL_API_TOKEN")
 	viper.BindEnv("revalidation.revalidate_secret", "REVALIDATION_REVALIDATE_SECRET")
 	viper.BindEnv("revalidation.http_timeout", "REVALIDATION_HTTP_TIMEOUT")
+	viper.BindEnv("revalidation.domains", "REVALIDATION_DOMAINS")
 
 	// GA4 Analytics
 	viper.BindEnv("ga4.enabled", "GA4_ENABLED")

--- a/internal/revalidation/revalidation.go
+++ b/internal/revalidation/revalidation.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,6 +31,30 @@ type Config struct {
 	VercelApiToken   string        `mapstructure:"vercel_api_token"`
 	RevalidateSecret string        `mapstructure:"revalidate_secret"`
 	HTTPTimeout      time.Duration `mapstructure:"http_timeout"`
+	// Domains is a comma-separated list of storefront hosts to always revalidate
+	// (e.g. "grbpwr.com,grbpwr-com-dusky.vercel.app" on prod, "beta.grbpwr.com" on
+	// beta). Replaces the previously hardcoded prod domains so each environment
+	// targets its own site.
+	Domains string `mapstructure:"domains"`
+}
+
+// targetDomains returns the explicit, environment-specific hosts to revalidate.
+func (c *Config) targetDomains() []string {
+	out := make([]string, 0)
+	for d := range strings.SplitSeq(c.Domains, ",") {
+		if d = strings.TrimSpace(d); d != "" {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// discoveryEnabled reports whether Vercel deployment discovery should run. An
+// empty or "disabled" project id (beta) turns it off, so we don't hit the Vercel
+// API (which 403s) and instead revalidate only the configured Domains.
+func (c *Config) discoveryEnabled() bool {
+	p := strings.TrimSpace(c.ProjectId)
+	return p != "" && p != "disabled" && strings.TrimSpace(c.VercelApiToken) != ""
 }
 
 func New(ctx context.Context, c *Config) (*Revalidator, error) {
@@ -124,16 +149,30 @@ func (v *Revalidator) revalidate(ctx context.Context, deploymentURL string, reva
 }
 
 func (v *Revalidator) RevalidateAll(ctx context.Context, revalidationData *dto.RevalidationData) error {
-	deployments, err := v.getDeployments(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get deployments: %w", err)
+	var deployments []*dto.Deployment
+
+	// Discover live Vercel preview/prod deployments only when a project is
+	// configured. On beta (project "disabled") this is skipped to avoid the 403.
+	// A discovery failure must NOT abort revalidation of the configured domains.
+	if v.c.discoveryEnabled() {
+		discovered, err := v.getDeployments(ctx)
+		if err != nil {
+			slog.Default().WarnContext(ctx, "revalidation: vercel deployment discovery failed, continuing with configured domains",
+				slog.String("err", err.Error()))
+		} else {
+			deployments = discovered
+		}
 	}
 
-	deployments = append(deployments, &dto.Deployment{
-		URL: "grbpwr-com-dusky.vercel.app",
-	}, &dto.Deployment{
-		URL: "grbpwr.com",
-	})
+	// Explicit, environment-specific hosts (REVALIDATION_DOMAINS).
+	for _, host := range v.c.targetDomains() {
+		deployments = append(deployments, &dto.Deployment{URL: host})
+	}
+
+	if len(deployments) == 0 {
+		slog.Default().InfoContext(ctx, "revalidation: no Vercel project and no REVALIDATION_DOMAINS configured; skipping")
+		return nil
+	}
 
 	const maxRetries = 3
 	const maxConcurrent = 5

--- a/internal/store/metrics/timeseries.go
+++ b/internal/store/metrics/timeseries.go
@@ -315,9 +315,9 @@ func (s *Store) getUnitsSoldByPeriod(ctx context.Context, from, to time.Time, da
 func (s *Store) getNewVsReturningCustomersByPeriod(ctx context.Context, from, to time.Time, dateExpr string) (newCustomers, returningCustomers []entity.TimeSeriesPoint, err error) {
 	query := fmt.Sprintf(`
 		WITH first_order AS (
-			-- A customer's true first order is across ALL statuses: filtering to
+			-- A customer first order is taken across ALL statuses; filtering to
 			-- net-revenue statuses here would treat someone whose first order was
-			-- cancelled/unpaid as "new" on a later order, overcounting new customers.
+			-- cancelled or unpaid as new on a later order, overcounting new customers.
 			SELECT b.email, MIN(co.placed) AS first_placed
 			FROM customer_order co
 			JOIN buyer b ON co.id = b.order_id


### PR DESCRIPTION
Two fixes found while auditing beta functionality.

## 1. Hero/content not updating on beta.grbpwr.com — revalidation
Root cause: the backend persists hero correctly (the GetHero API returns the new value), but the public beta site never purges its Vercel ISR cache because:
- `RevalidateAll` **hardcoded prod domains** (`grbpwr.com`, `grbpwr-com-dusky.vercel.app`) — beta.grbpwr.com was never revalidated.
- beta's `REVALIDATION_PROJECT_ID="disabled"` made the Vercel discovery call 403, which **aborted the whole revalidation** before even the hardcoded domains.

Fix:
- Targets are now configurable via `REVALIDATION_DOMAINS` (comma-separated) — each env revalidates its own site.
- Vercel discovery is skipped when project id is empty/`disabled`; a discovery failure no longer aborts revalidation of the configured domains.
- Prod `app.yaml` gets `REVALIDATION_DOMAINS=grbpwr.com,grbpwr-com-dusky.vercel.app` to preserve current behavior.

**To enable on beta** after merge: set `REVALIDATION_DOMAINS=beta.grbpwr.com` and ensure `REVALIDATION_REVALIDATE_SECRET` matches the beta frontend's `/api/revalidate` secret.

## 2. Admin metrics 500 — GetBusinessMetrics
`getNewVsReturningCustomersByPeriod` had a `:` (and an apostrophe) inside an **SQL comment**. `sqlx.Named` parses `:` as a bind parameter → empty name → `named: could not find name`. Reworded the comment (same bug class already handled for `+00:00` via `mysqlUTCExpr`/`CHAR(58)`).

Verified: `go build`, `go vet`, metrics + config unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)