### PR TITLE
fix(store): map shipment.delivered_at + tolerate schema drift (unblocks beta checkout)

### DIFF
--- a/internal/entity/shipment.go
+++ b/internal/entity/shipment.go
@@ -165,6 +165,7 @@ type Shipment struct {
 	TrackingCode         sql.NullString  `db:"tracking_code"`
 	ShippingDate         sql.NullTime    `db:"shipping_date"`
 	EstimatedArrivalDate sql.NullTime    `db:"estimated_arrival_date"`
+	DeliveredAt          sql.NullTime    `db:"delivered_at"`
 }
 
 // CostDecimal returns shipment cost with currency-aware rounding

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -168,7 +168,13 @@ func New(ctx context.Context, cfg Config) (*MYSQLStore, error) {
 
 	ctx, c := context.WithCancel(ctx)
 	ss := &MYSQLStore{
-		db:    d,
+		// Unsafe: ignore DB columns that have no matching struct field. Beta applies
+		// every migration via automigrate ahead of prod, so a column added by a
+		// migration whose struct field was not (yet) added would otherwise make every
+		// SELECT * on that table fail (struct scan: missing destination name ...).
+		// This keeps reads resilient to that schema/struct drift; transactions inherit
+		// the flag from the DB in sqlx.
+		db:    d.Unsafe(),
 		close: c,
 	}
 	initSubStores(ss)
@@ -272,7 +278,13 @@ func NewForTest(ctx context.Context, cfg Config) (*MYSQLStore, error) {
 
 	ctx, c := context.WithCancel(ctx)
 	ss := &MYSQLStore{
-		db:    d,
+		// Unsafe: ignore DB columns that have no matching struct field. Beta applies
+		// every migration via automigrate ahead of prod, so a column added by a
+		// migration whose struct field was not (yet) added would otherwise make every
+		// SELECT * on that table fail (struct scan: missing destination name ...).
+		// This keeps reads resilient to that schema/struct drift; transactions inherit
+		// the flag from the DB in sqlx.
+		db:    d.Unsafe(),
 		close: c,
 	}
 	initSubStores(ss)


### PR DESCRIPTION
## Beta order checkout was failing
`SubmitOrder` returned `Internal: can't associate payment intent with order`. Real cause (from beta logs):
```
InsertFiatInvoice failed -> cannot fetch order info -> can't get shipments by order ids:
struct scan: missing destination name delivered_at in *entity.Shipment
```
Migration `0053` adds `shipment.delivered_at`, but `entity.Shipment` never mapped it and the query is `SELECT s.* FROM shipment`. On **beta** (`automigrate=true`) the column exists → sqlx struct-scan fails → checkout breaks. **Prod** (`automigrate=false`, 0053 not applied) was unaffected — classic beta-ahead-of-prod schema drift.

## Fix
- Add `DeliveredAt sql.NullTime` to `entity.Shipment`.
- Make the store connection `sqlx`-**Unsafe** so a DB column with no matching struct field no longer fails the scan. Beta applies every migration ahead of prod, so this makes all `SELECT *` reads resilient to struct/migration drift (transactions inherit the flag). Verified against the live beta schema via direct DB inspection.

Verified: `go build`, `go vet`, store/order + metrics tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)