### PR TITLE
Promote beta: audit fixes (critical/high/medium) + email size-code labels

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -17,12 +17,22 @@ envs:
 - key: MYSQL_AUTOMIGRATE
   scope: RUN_TIME
   value: "true"
+# NOTE: managed MySQL cluster max_connections=76, SHARED across prod (grbpwr),
+# beta (grbpwr_beta) and admin. Keep prod MYSQL_MAX_OPEN_CONNECTIONS well under
+# that ceiling (15 + beta + admin must stay < 76); beta is set lower in
+# .do/app-beta.yaml.
 - key: MYSQL_MAX_OPEN_CONNECTIONS
   scope: RUN_TIME
-  value: "5"
+  value: "15"
 - key: MYSQL_MAX_IDLE_CONNECTIONS
   scope: RUN_TIME
-  value: "2"
+  value: "5"
+- key: MYSQL_CONN_MAX_LIFETIME
+  scope: RUN_TIME
+  value: "5m"
+- key: MYSQL_CONN_MAX_IDLE_TIME
+  scope: RUN_TIME
+  value: "1m"
 - key: LOGGER_LEVEL
   scope: RUN_TIME
   value: "0"

--- a/app/app.go
+++ b/app/app.go
@@ -18,8 +18,10 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/apisrv/frontend"
 	"github.com/jekabolt/grbpwr-manager/internal/bucket"
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
+	"github.com/jekabolt/grbpwr-manager/internal/circuitbreaker"
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/health"
 	"github.com/jekabolt/grbpwr-manager/internal/mail"
 	"github.com/jekabolt/grbpwr-manager/internal/ordercleanup"
 	"github.com/jekabolt/grbpwr-manager/internal/payment/stripe"
@@ -55,8 +57,12 @@ type App struct {
 	bqc  dependency.BQClient
 	re   dependency.RevalidationService
 	rm   *stockreserve.Manager
-	c    *config.Config
-	done chan struct{}
+	// Stripe processors (live + test). Held so their in-process payment monitors
+	// can be stopped on shutdown before the DB is closed.
+	stripeMain *stripe.Processor
+	stripeTest *stripe.Processor
+	c          *config.Config
+	done       chan struct{}
 }
 
 // New returns a new instance of App
@@ -150,6 +156,15 @@ func (a *App) Start(ctx context.Context) error {
 		return err
 	}
 
+	// Hold the concrete processors so App.Stop can stop their in-process payment
+	// monitors before the DB is closed.
+	if p, ok := stripeMain.(*stripe.Processor); ok {
+		a.stripeMain = p
+	}
+	if p, ok := stripeTest.(*stripe.Processor); ok {
+		a.stripeTest = p
+	}
+
 	// Stripe reconciliation: clean orphaned pre-order PaymentIntents (main + test)
 	var stripeCleaners []stripereconcile.PreOrderPICleaner
 	if p, ok := stripeMain.(*stripe.Processor); ok {
@@ -186,12 +201,17 @@ func (a *App) Start(ctx context.Context) error {
 		return err
 	}
 
-	a.re, err = revalidation.New(ctx, &a.c.Revalidation)
-	if err != nil {
-		slog.Default().ErrorContext(ctx, "failed create new revalidation service",
-			slog.String("err", err.Error()),
+	// Revalidation (Vercel ISR) is a non-critical, best-effort cache-freshness
+	// side effect. If its client can't be constructed, log and continue with a
+	// no-op revalidator instead of crash-looping the whole process — the
+	// storefront/admin must still boot and serve.
+	if rev, revErr := revalidation.New(ctx, &a.c.Revalidation); revErr != nil {
+		slog.Default().WarnContext(ctx, "failed to create revalidation service; continuing with revalidation disabled",
+			slog.String("err", revErr.Error()),
 		)
-		return err
+		a.re = revalidation.NewDisabled()
+	} else {
+		a.re = rev
 	}
 
 	// GA4 Analytics integration
@@ -284,6 +304,13 @@ func (a *App) Start(ctx context.Context) error {
 		slog.Default().InfoContext(ctx, "stripe webhook handler disabled (no signing secret configured)")
 	}
 
+	// Operational status registry for the admin-gated GET /statusz endpoint.
+	// Each worker implements health.Reporter (records last-success at the end of a
+	// clean tick); the store provides DB pool stats; the GA4/BQ clients expose
+	// their circuit-breaker state. nil entries (e.g. ga4 worker when GA4 is off)
+	// are skipped so the endpoint reflects what is actually running.
+	a.hs.SetHealthRegistry(a.buildHealthRegistry(ga4Client))
+
 	if err = a.hs.Start(ctx, adminS, frontendS, authS); err != nil {
 		slog.Default().ErrorContext(ctx, "cannot start http server")
 		return err
@@ -335,6 +362,19 @@ func (a *App) Stop(ctx context.Context) {
 		a.rm.Stop()
 	}
 
+	// Stop the in-process Stripe payment monitors AFTER the workers but BEFORE the
+	// DB is closed: monitors derive from a processor-wide parent context and may be
+	// mid-write (mark-paid / expire), so they must drain against a live connection
+	// pool rather than race a closed one.
+	monStopCtx, monStopCancel := context.WithTimeout(ctx, 15*time.Second)
+	if a.stripeMain != nil {
+		a.stripeMain.StopAllMonitors(monStopCtx)
+	}
+	if a.stripeTest != nil {
+		a.stripeTest.StopAllMonitors(monStopCtx)
+	}
+	monStopCancel()
+
 	if a.bqc != nil {
 		a.bqc.Close()
 	}
@@ -345,6 +385,73 @@ func (a *App) Stop(ctx context.Context) {
 // Done returns a channel that is closed after the application has exited
 func (a *App) Done() chan struct{} {
 	return a.done
+}
+
+// buildHealthRegistry collects the constructed workers (those that implement
+// health.Reporter), the DB pool-stats provider, and the analytics circuit
+// breakers into the registry consumed by GET /statusz. Workers that were not
+// started (nil) are skipped. ga4Client is passed explicitly because it is a
+// local in Start, not a field on App.
+func (a *App) buildHealthRegistry(ga4Client *ga4.Client) *health.Registry {
+	reg := &health.Registry{}
+
+	// Workers. Each appended only if non-nil and actually implements Reporter.
+	// a.ma is a dependency.Mailer interface; the concrete *mail.Mailer is a
+	// Reporter, so it is type-asserted.
+	addWorker := func(r health.Reporter) {
+		if r != nil {
+			reg.Workers = append(reg.Workers, r)
+		}
+	}
+	if a.ma != nil {
+		if r, ok := a.ma.(health.Reporter); ok {
+			addWorker(r)
+		}
+	}
+	if a.oc != nil {
+		addWorker(a.oc)
+	}
+	if a.sc != nil {
+		addWorker(a.sc)
+	}
+	if a.tm != nil {
+		addWorker(a.tm)
+	}
+	if a.sr != nil {
+		addWorker(a.sr)
+	}
+	if a.ga4w != nil {
+		addWorker(a.ga4w)
+	}
+	if a.rm != nil {
+		addWorker(a.rm)
+	}
+
+	// DB pool stats (only the MySQL store exposes them).
+	if mysqlStore, ok := a.db.(*store.MYSQLStore); ok {
+		reg.DB = mysqlStore
+	}
+
+	// Circuit breakers (cheap getters on the analytics clients).
+	if ga4Client != nil {
+		reg.Breakers = append(reg.Breakers, health.BreakerReporter{
+			BreakerName: "ga4",
+			StateFunc: func() circuitbreaker.State {
+				return ga4Client.CircuitBreakerState()
+			},
+		})
+	}
+	if a.bqc != nil {
+		bqc := a.bqc
+		reg.Breakers = append(reg.Breakers, health.BreakerReporter{
+			BreakerName: "bigquery",
+			StateFunc: func() circuitbreaker.State {
+				return bqc.CircuitBreakerState()
+			},
+		})
+	}
+
+	return reg
 }
 
 // stripeOrderExpirer routes an order's safety-net expiry to the correct Stripe

--- a/config/cfg.go
+++ b/config/cfg.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/apisrv/auth"
 	"github.com/jekabolt/grbpwr-manager/internal/bucket"
 	"github.com/jekabolt/grbpwr-manager/internal/mail"
+	"github.com/jekabolt/grbpwr-manager/internal/middleware"
 	"github.com/jekabolt/grbpwr-manager/internal/ordercleanup"
 	"github.com/jekabolt/grbpwr-manager/internal/payment/stripe"
 	"github.com/jekabolt/grbpwr-manager/internal/revalidation"
@@ -30,6 +31,21 @@ type RatesConfig struct {
 	BaseCurrency string `mapstructure:"base_currency"`
 }
 
+// SecurityConfig holds request-handling security settings.
+type SecurityConfig struct {
+	// TrustProxyHops is the number of trusted reverse-proxy hops in front of the
+	// service. Client-IP extraction (used for rate limiting and login
+	// throttling) takes the X-Forwarded-For entry this many hops from the right,
+	// i.e. the first IP a trusted proxy did not let the client forge. A
+	// non-positive value falls back to the secure default of one hop, which
+	// matches DigitalOcean App Platform's single edge proxy.
+	TrustProxyHops int `mapstructure:"trust_proxy_hops"`
+}
+
+// defaultTrustProxyHops is the secure default applied when trust_proxy_hops is
+// unset: one trusted edge proxy, as on DigitalOcean App Platform.
+const defaultTrustProxyHops = 1
+
 // Config represents the global configuration for the service.
 type Config struct {
 	DB                store.Config             `mapstructure:"mysql"`
@@ -44,6 +60,7 @@ type Config struct {
 	TierManagement    tiermanagement.Config    `mapstructure:"tier_management"`
 	StripeReconcile   stripereconcile.Config   `mapstructure:"stripe_reconcile"`
 	Rates             RatesConfig              `mapstructure:"rates"`
+	Security          SecurityConfig           `mapstructure:"security"`
 	StripePayment     stripe.Config            `mapstructure:"stripe_payment"`
 	StripePaymentTest stripe.Config            `mapstructure:"stripe_payment_test"`
 	Revalidation      revalidation.Config      `mapstructure:"revalidation"`
@@ -140,6 +157,14 @@ func LoadConfig(cfgFile string) (*Config, error) {
 		config.DB.MaxIdleConnections = defaultMaxIdleConnections
 	}
 
+	// Apply a secure default for trusted proxy hops when unset, then configure
+	// the client-IP middleware. This keeps X-Forwarded-For spoofing protection
+	// on by default (left-most/attacker-controlled entries are not trusted).
+	if config.Security.TrustProxyHops <= 0 {
+		config.Security.TrustProxyHops = defaultTrustProxyHops
+	}
+	middleware.SetTrustedProxyHops(config.Security.TrustProxyHops)
+
 	return &config, nil
 }
 
@@ -228,6 +253,9 @@ func bindEnvVars() {
 
 	// Rates (base currency only; no exchange rates)
 	viper.BindEnv("rates.base_currency", "RATES_BASE_CURRENCY")
+
+	// Security (trusted reverse-proxy hops for client-IP extraction)
+	viper.BindEnv("security.trust_proxy_hops", "TRUST_PROXY_HOPS")
 
 	// Stripe Payment
 	viper.BindEnv("stripe_payment.secret_key", "STRIPE_PAYMENT_SECRET_KEY")

--- a/config/cfg.go
+++ b/config/cfg.go
@@ -128,8 +128,27 @@ func LoadConfig(cfgFile string) (*Config, error) {
 		}
 	}
 
+	// Apply safe connection-pool defaults when unset. The managed MySQL cluster
+	// has a shared max_connections=76 across prod, beta and admin, so the prod
+	// ceiling stays well under that (15 + beta + admin < 76). SERIALIZABLE
+	// transactions plus background workers each hold connections, so too low a
+	// ceiling (was 5) risks pool starvation.
+	if config.DB.MaxOpenConnections <= 0 {
+		config.DB.MaxOpenConnections = defaultMaxOpenConnections
+	}
+	if config.DB.MaxIdleConnections <= 0 {
+		config.DB.MaxIdleConnections = defaultMaxIdleConnections
+	}
+
 	return &config, nil
 }
+
+// Connection-pool defaults applied when the corresponding config value is unset.
+// Kept under the shared managed-MySQL cap of 76 connections (prod + beta + admin).
+const (
+	defaultMaxOpenConnections = 15
+	defaultMaxIdleConnections = 5
+)
 
 // bindEnvVars binds environment variables to config keys
 // This allows using both nested keys (MYSQL__DSN) and flat keys (MYSQL_DSN)
@@ -139,6 +158,8 @@ func bindEnvVars() {
 	viper.BindEnv("mysql.automigrate", "MYSQL_AUTOMIGRATE")
 	viper.BindEnv("mysql.max_open_connections", "MYSQL_MAX_OPEN_CONNECTIONS")
 	viper.BindEnv("mysql.max_idle_connections", "MYSQL_MAX_IDLE_CONNECTIONS")
+	viper.BindEnv("mysql.conn_max_lifetime", "MYSQL_CONN_MAX_LIFETIME")
+	viper.BindEnv("mysql.conn_max_idle_time", "MYSQL_CONN_MAX_IDLE_TIME")
 	viper.BindEnv("mysql.tls_ca_path", "MYSQL_TLS_CA_PATH")
 
 	// Logger
@@ -149,6 +170,7 @@ func bindEnvVars() {
 	viper.BindEnv("http.port", "HTTP_PORT")
 	viper.BindEnv("http.address", "HTTP_ADDRESS")
 	viper.BindEnv("http.allowed_origins", "HTTP_ALLOWED_ORIGINS")
+	viper.BindEnv("http.allow_dev_origins", "HTTP_ALLOW_DEV_ORIGINS")
 
 	// Auth
 	viper.BindEnv("auth.jwt_secret", "AUTH_JWT_SECRET")

--- a/internal/analytics/ga4sync/worker.go
+++ b/internal/analytics/ga4sync/worker.go
@@ -13,6 +13,8 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/circuitbreaker"
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/health"
+	"github.com/jekabolt/grbpwr-manager/internal/saferun"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -27,6 +29,17 @@ const ga4FinalizationDays = 2
 // stopTimeout bounds how long Stop waits for in-flight syncs to drain after the
 // context is cancelled, so shutdown can't hang on a query that's slow to cancel.
 const stopTimeout = 30 * time.Second
+
+// syncRunTimeout bounds a single sync attempt (one fn(ctx) invocation inside
+// runWithBackoff). GA4/BQ analytics syncs fan out many API + DB calls, so the
+// budget is generous, but it still keeps one stuck call from blocking a run
+// forever or stalling graceful shutdown. Each backoff attempt gets a fresh
+// budget; the inter-attempt backoff sleep is deliberately left outside it.
+const syncRunTimeout = 60 * time.Second
+
+// healthTickTimeout bounds the per-tick health-status work, so a stuck status
+// query can't block the worker loop or stall shutdown.
+const healthTickTimeout = 30 * time.Second
 
 // ga4APISyncTypes are the GA4 Data API sub-syncs whose success high-water-marks gate
 // the API tier's fetch window. These are exactly the types that receive a success=1
@@ -86,7 +99,15 @@ type Worker struct {
 	ga4SyncInProgress bool
 	bqSyncMu          sync.Mutex
 	bqSyncInProgress  bool
+	tracker           health.Tracker
 }
+
+// Name implements health.Reporter.
+func (w *Worker) Name() string { return "ga4sync" }
+
+// LastSuccess implements health.Reporter. It reflects the most recent successful
+// sync of EITHER tier (GA4 API or BQ); zero time until the first one succeeds.
+func (w *Worker) LastSuccess() time.Time { return w.tracker.LastSuccess() }
 
 // New creates a new GA4 sync worker. bqClient may be nil if BQ is disabled.
 func New(ga4Client *ga4.Client, bqClient dependency.BQClient, ga4Data dependency.GA4DataStore, bqCache dependency.BQCacheStore, syncStatus dependency.SyncStatusStore, c *Config) *Worker {
@@ -175,14 +196,7 @@ func (w *Worker) Stop() error {
 }
 
 func (w *Worker) worker(ctx context.Context) {
-	if err := w.runWithBackoff(ctx, "ga4 api", &w.ga4Errors, w.syncGA4API); err != nil {
-		slog.Default().ErrorContext(ctx, "ga4 api sync failed on startup",
-			slog.String("err", err.Error()))
-	}
-	if err := w.runWithBackoff(ctx, "bq", &w.bqErrors, w.syncBQ); err != nil {
-		slog.Default().ErrorContext(ctx, "bq sync failed on startup",
-			slog.String("err", err.Error()))
-	}
+	w.runStartupSyncs(ctx)
 
 	ga4Ticker := time.NewTicker(w.c.WorkerInterval)
 	defer ga4Ticker.Stop()
@@ -200,11 +214,38 @@ func (w *Worker) worker(ctx context.Context) {
 		case <-bqTicker.C:
 			w.tryRunAsync(ctx, &w.bqSyncMu, &w.bqSyncInProgress, "bq", &w.bqErrors, w.syncBQ)
 		case <-healthTicker.C:
-			w.logHealthStatus(ctx)
+			w.runHealthCheck(ctx)
 		case <-ctx.Done():
 			return
 		}
 	}
+}
+
+// runStartupSyncs performs the initial syncs on worker startup. The deferred
+// saferun.Recover keeps a panic here from killing the worker before its loop
+// starts (which would also bring down the whole process).
+func (w *Worker) runStartupSyncs(ctx context.Context) {
+	defer saferun.Recover(ctx, "ga4sync-startup")
+
+	if err := w.runWithBackoff(ctx, "ga4 api", &w.ga4Errors, w.syncGA4API); err != nil {
+		slog.Default().ErrorContext(ctx, "ga4 api sync failed on startup",
+			slog.String("err", err.Error()))
+	}
+	if err := w.runWithBackoff(ctx, "bq", &w.bqErrors, w.syncBQ); err != nil {
+		slog.Default().ErrorContext(ctx, "bq sync failed on startup",
+			slog.String("err", err.Error()))
+	}
+}
+
+// runHealthCheck wraps the periodic health log with panic recovery so a panic
+// in one health tick doesn't kill the worker loop.
+func (w *Worker) runHealthCheck(ctx context.Context) {
+	defer saferun.Recover(ctx, "ga4sync-health")
+
+	ctx, cancel := context.WithTimeout(ctx, healthTickTimeout)
+	defer cancel()
+
+	w.logHealthStatus(ctx)
 }
 
 // tryRunAsync launches fn in a goroutine if a previous run isn't still in progress.
@@ -226,6 +267,9 @@ func (w *Worker) tryRunAsync(ctx context.Context, mu *sync.Mutex, inProgress *bo
 			*inProgress = false
 			mu.Unlock()
 		}()
+		// Recover a panic in this async sync so it can't crash the process; the
+		// in-progress flag is still cleared by the defer above.
+		defer saferun.Recover(ctx, "ga4sync-"+name)
 		if err := w.runWithBackoff(ctx, name, counter, fn); err != nil {
 			slog.Default().ErrorContext(ctx, name+" sync failed",
 				slog.String("err", err.Error()))
@@ -316,9 +360,18 @@ func (w *Worker) runWithBackoff(ctx context.Context, name string, counter *atomi
 	var lastErr error
 
 	for attempt := 0; attempt <= w.c.MaxBackoffRetries; attempt++ {
-		lastErr = fn(ctx)
+		// Bound each attempt with a fresh per-run timeout so one stuck API/DB
+		// call can't block the run forever or stall shutdown. cancel() runs as
+		// soon as the attempt returns (not at function scope) so the contexts
+		// don't accumulate across retries, and so the inter-attempt backoff
+		// sleep below stays outside the budget.
+		runCtx, cancel := context.WithTimeout(ctx, syncRunTimeout)
+		lastErr = fn(runCtx)
+		cancel()
 		if lastErr == nil {
 			counter.Store(0)
+			// Record liveness: a tier (GA4 API or BQ) synced cleanly this run.
+			w.tracker.MarkSuccess()
 			return nil
 		}
 
@@ -349,7 +402,9 @@ func (w *Worker) runWithBackoff(ctx context.Context, name string, counter *atomi
 		}
 	}
 
-	return fmt.Errorf("%s sync failed after %d retries: %w", name, w.c.MaxBackoffRetries, lastErr)
+	err := fmt.Errorf("%s sync failed after %d retries: %w", name, w.c.MaxBackoffRetries, lastErr)
+	w.tracker.MarkError(err)
+	return err
 }
 
 // recordSyncStatus persists a sync-status row and logs (without propagating) a

--- a/internal/api/http/http.go
+++ b/internal/api/http/http.go
@@ -3,8 +3,10 @@ package httpapi
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	goruntime "runtime"
 	"runtime/debug"
 	"strings"
 	"text/template"
@@ -21,6 +23,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
 	grpcSlog "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
@@ -29,6 +32,7 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/apisrv/admin"
 	"github.com/jekabolt/grbpwr-manager/internal/apisrv/auth"
 	"github.com/jekabolt/grbpwr-manager/internal/apisrv/frontend"
+	"github.com/jekabolt/grbpwr-manager/internal/health"
 	"github.com/jekabolt/grbpwr-manager/internal/middleware"
 	"github.com/jekabolt/grbpwr-manager/log"
 	pb_admin "github.com/jekabolt/grbpwr-manager/proto/gen/admin"
@@ -75,8 +79,68 @@ type Config struct {
 	Port           string   `mapstructure:"port"`
 	Address        string   `mapstructure:"address"`
 	AllowedOrigins []string `mapstructure:"allowed_origins"`
-	CommitHash     string   `mapstructure:"commit_hash"`
+	// AllowDevOrigins, when true, additionally permits localhost/127.0.0.1 CORS
+	// origins. It must stay false (unset) in prod/beta since CORS allows
+	// credentials; enable it only for local development.
+	AllowDevOrigins bool   `mapstructure:"allow_dev_origins"`
+	CommitHash      string `mapstructure:"commit_hash"`
 }
+
+// HTTP server timeouts used to harden against slow-loris style DoS without
+// breaking long-lived h2c gRPC streams / SSE or large media uploads.
+const (
+	// serverReadHeaderTimeout caps how long a client may take to send the
+	// request headers before the connection is dropped.
+	serverReadHeaderTimeout = 10 * time.Second
+	// serverIdleTimeout reaps idle keep-alive connections.
+	serverIdleTimeout = 120 * time.Second
+	// serverMaxHeaderBytes bounds the size of request headers (1 MiB).
+	serverMaxHeaderBytes = 1 << 20
+)
+
+// gRPC server limits and keepalive parameters.
+//
+// IMPORTANT: the grpc-gateway REST/JSON gateway connects to THIS gRPC server
+// over loopback via grpc.Dial (see *JSONGateway funcs: insecure credentials, no
+// client-side keepalive). The gateway's client connection is therefore long
+// lived and mostly carries short unary RPCs (often with no active streams). The
+// values below are chosen so neither that loopback connection nor long-lived
+// frontend gRPC streams get throttled or force-closed:
+//   - MaxConnectionAge / MaxConnectionAgeGrace are intentionally NOT set: a
+//     bounded age would periodically GOAWAY+tear down the gateway's own loopback
+//     connection (and any in-flight long stream) for no security benefit on a
+//     trusted loopback peer.
+//   - MaxConnectionIdle is generous (15m); when it fires the server sends GOAWAY
+//     and grpc-go transparently reconnects on the next call, so it only reaps
+//     genuinely idle/half-open peers.
+//   - Enforcement uses PermitWithoutStream:true and a modest MinTime so a
+//     well-behaved client that pings without active streams is never dropped.
+const (
+	// grpcMaxRecvMsgSize / grpcMaxSendMsgSize cap inbound/outbound message size.
+	// Send must be set explicitly: the grpc-go default send cap is ~4MiB, which
+	// would silently truncate large responses while recv allows 50MiB.
+	grpcMaxRecvMsgSize = 50 * 1024 * 1024 // 50 MiB
+	grpcMaxSendMsgSize = 50 * 1024 * 1024 // 50 MiB
+
+	// grpcMaxConcurrentStreams bounds per-connection HTTP/2 stream fan-out so a
+	// single client connection cannot exhaust server resources.
+	grpcMaxConcurrentStreams = 1000
+
+	// grpcKeepaliveMaxConnectionIdle reaps connections idle (no outstanding RPCs)
+	// for this long by sending a GOAWAY; clients transparently reconnect.
+	grpcKeepaliveMaxConnectionIdle = 15 * time.Minute
+	// grpcKeepaliveTime is how long the server waits with no activity before
+	// sending a keepalive ping to detect half-open connections.
+	grpcKeepaliveTime = 1 * time.Minute
+	// grpcKeepaliveTimeout is how long the server waits for a ping ack before
+	// closing the connection.
+	grpcKeepaliveTimeout = 20 * time.Second
+
+	// grpcKeepaliveMinTime is the minimum interval a client must wait between
+	// keepalive pings; paired with PermitWithoutStream:true so compliant clients
+	// (including the loopback gateway) are never disconnected for pinging.
+	grpcKeepaliveMinTime = 30 * time.Second
+)
 
 // WebhookHandler handles inbound webhook HTTP requests.
 type WebhookHandler interface {
@@ -98,6 +162,7 @@ type Server struct {
 	healthChecker        HealthChecker
 	webhookHandler       WebhookHandler
 	stripeWebhookHandler StripeWebhookHandler
+	healthRegistry       *health.Registry
 }
 
 // New creates a new server
@@ -121,6 +186,13 @@ func (s *Server) SetWebhookHandler(h WebhookHandler) {
 // SetStripeWebhookHandler registers the handler for Stripe webhook events.
 func (s *Server) SetStripeWebhookHandler(h StripeWebhookHandler) {
 	s.stripeWebhookHandler = h
+}
+
+// SetHealthRegistry registers the operational-state registry surfaced by the
+// admin-gated GET /statusz endpoint (DB pool, per-worker liveness, breakers,
+// runtime). Optional: when unset, /statusz is not mounted.
+func (s *Server) SetHealthRegistry(r *health.Registry) {
+	s.healthRegistry = r
 }
 
 // Done returns a channel that is closed when gRPC server exits
@@ -153,21 +225,32 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return err
 }
 
-func corsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
-	// Collect all allowed origins (exact and wildcard patterns)
-	origins := make([]string, 0, len(allowedOrigins)+3)
+// corsDevOrigins are localhost/loopback origins permitted ONLY when dev origins
+// are explicitly enabled (allowDevOrigins). They must never be present in prod,
+// since AllowCredentials is true.
+var corsDevOrigins = []string{
+	"http://localhost*",
+	"http://127.0.0.1*",
+}
 
-	// Add localhost and vercel patterns for development
-	origins = append(origins, "http://localhost*")
-	origins = append(origins, "http://127.0.0.1*")
-	origins = append(origins, "https://*.vercel.app")
-	origins = append(origins, "https://*.github.io")
-	origins = append(origins, "https://admin.grbpwr.com")
+// corsMiddleware builds the CORS handler. Because AllowCredentials is true, the
+// set of allowed origins is an EXPLICIT allowlist of the real prod/beta
+// frontends supplied via HTTP_ALLOWED_ORIGINS (e.g. https://grbpwr.com,
+// https://admin.grbpwr.com and their beta.* counterparts). The previous broad
+// credentialed wildcards (https://*.vercel.app, https://*.github.io) are removed:
+// they let any attacker-controlled *.vercel.app / *.github.io deployment make
+// credentialed cross-origin calls. Localhost dev origins are gated behind
+// allowDevOrigins (env-driven; off in prod) so they never widen the prod surface.
+func corsMiddleware(allowedOrigins []string, allowDevOrigins bool) func(http.Handler) http.Handler {
+	origins := make([]string, 0, len(allowedOrigins)+len(corsDevOrigins))
 
-	// Add configured origins (they may contain wildcards)
+	// Configured prod/beta frontends (HTTP_ALLOWED_ORIGINS) are the source of truth.
 	origins = append(origins, allowedOrigins...)
 
-	// chi/cors handles wildcard patterns like "https://*.vercel.app"
+	if allowDevOrigins {
+		origins = append(origins, corsDevOrigins...)
+	}
+
 	return cors.Handler(cors.Options{
 		AllowedOrigins:   origins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"},
@@ -242,6 +325,16 @@ func (s *Server) setupHTTPAPI(ctx context.Context, auth *auth.Server) (http.Hand
 		}
 	})
 
+	// Operational status endpoint. Unlike /livez and /readyz this exposes internal
+	// state (DB pool, per-worker liveness, circuit-breaker state, runtime), so it
+	// is gated behind the same admin JWT auth the admin REST surface uses
+	// (auth.WithAuth). It is read-only and never affects readiness — a stale
+	// worker shows up here but does NOT make /readyz fail (which would trigger
+	// restart loops). Only mounted when a health registry has been registered.
+	if s.healthRegistry != nil {
+		r.Method(http.MethodGet, "/statusz", auth.WithAuth(http.HandlerFunc(s.handleStatusz)))
+	}
+
 	// handle static swagger at root
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// Only serve swagger for root path, not for other paths
@@ -274,7 +367,7 @@ func (s *Server) setupHTTPAPI(ctx context.Context, auth *auth.Server) (http.Hand
 
 	// Apply CORS middleware only to API routes
 	r.Route("/api", func(r chi.Router) {
-		r.Use(corsMiddleware(s.c.AllowedOrigins))
+		r.Use(corsMiddleware(s.c.AllowedOrigins, s.c.AllowDevOrigins))
 		r.Mount("/admin", auth.WithAuth(adminHandler))
 		r.Mount("/frontend", frontendHandler)
 		r.Mount("/auth", authHandler)
@@ -363,6 +456,128 @@ func (s *Server) authJSONGateway(ctx context.Context) (http.Handler, error) {
 	return mux, nil
 }
 
+// statuszResponse is the JSON shape of GET /statusz. It carries no secrets —
+// only operational counters and timestamps.
+type statuszResponse struct {
+	Now     string          `json:"now"`
+	Commit  string          `json:"commit,omitempty"`
+	DB      *statuszDB      `json:"db,omitempty"`
+	Workers []statuszWorker `json:"workers"`
+	// Stale lists the names of workers whose last success is older than
+	// staleThreshold (or that have never run); a convenience summary.
+	Stale    []string         `json:"stale,omitempty"`
+	Breakers []statuszBreaker `json:"breakers,omitempty"`
+	Runtime  statuszRuntime   `json:"runtime"`
+}
+
+type statuszDB struct {
+	OpenConnections    int    `json:"open_connections"`
+	InUse              int    `json:"in_use"`
+	Idle               int    `json:"idle"`
+	WaitCount          int64  `json:"wait_count"`
+	WaitDuration       string `json:"wait_duration"`
+	MaxOpenConnections int    `json:"max_open_connections"`
+}
+
+type statuszWorker struct {
+	Name string `json:"name"`
+	// LastSuccess is RFC3339, or "never" if the worker has not had a successful
+	// tick yet.
+	LastSuccess string `json:"last_success"`
+	// SecondsSinceLastSuccess is null when the worker has never succeeded, so a
+	// never-run worker is not reported as infinitely stale.
+	SecondsSinceLastSuccess *int64 `json:"seconds_since_last_success"`
+}
+
+type statuszBreaker struct {
+	Name  string `json:"name"`
+	State string `json:"state"`
+}
+
+type statuszRuntime struct {
+	NumGoroutine int    `json:"num_goroutine"`
+	NumCPU       int    `json:"num_cpu"`
+	HeapAllocMiB uint64 `json:"heap_alloc_mib"`
+	SysMiB       uint64 `json:"sys_mib"`
+	NumGC        uint32 `json:"num_gc"`
+}
+
+// statuszStaleThreshold is the age past which a worker's last success is flagged
+// in the Stale summary. It is generous so a worker with a long interval (e.g.
+// ga4sync / tier management run hourly+) is not flagged between normal ticks.
+const statuszStaleThreshold = 6 * time.Hour
+
+// handleStatusz renders the operational status JSON. It is registered behind
+// admin auth, so it is never world-readable.
+func (s *Server) handleStatusz(w http.ResponseWriter, r *http.Request) {
+	reg := s.healthRegistry
+	now := time.Now()
+
+	resp := statuszResponse{
+		Now:     now.UTC().Format(time.RFC3339),
+		Commit:  s.c.CommitHash,
+		Workers: make([]statuszWorker, 0, len(reg.Workers)),
+	}
+
+	if reg.DB != nil {
+		st := reg.DB.Stats()
+		resp.DB = &statuszDB{
+			OpenConnections:    st.OpenConnections,
+			InUse:              st.InUse,
+			Idle:               st.Idle,
+			WaitCount:          st.WaitCount,
+			WaitDuration:       st.WaitDuration.String(),
+			MaxOpenConnections: st.MaxOpenConnections,
+		}
+	}
+
+	for _, wk := range reg.Workers {
+		ws := statuszWorker{Name: wk.Name()}
+		last := wk.LastSuccess()
+		if last.IsZero() {
+			ws.LastSuccess = "never"
+			resp.Stale = append(resp.Stale, wk.Name())
+		} else {
+			ws.LastSuccess = last.UTC().Format(time.RFC3339)
+			secs := int64(now.Sub(last).Seconds())
+			ws.SecondsSinceLastSuccess = &secs
+			if now.Sub(last) > statuszStaleThreshold {
+				resp.Stale = append(resp.Stale, wk.Name())
+			}
+		}
+		resp.Workers = append(resp.Workers, ws)
+	}
+
+	for _, b := range reg.Breakers {
+		if b.StateFunc == nil {
+			continue
+		}
+		resp.Breakers = append(resp.Breakers, statuszBreaker{
+			Name:  b.BreakerName,
+			State: b.StateFunc().String(),
+		})
+	}
+
+	var ms goruntime.MemStats
+	goruntime.ReadMemStats(&ms)
+	const miB = 1024 * 1024
+	resp.Runtime = statuszRuntime{
+		NumGoroutine: goruntime.NumGoroutine(),
+		NumCPU:       goruntime.NumCPU(),
+		HeapAllocMiB: ms.HeapAlloc / miB,
+		SysMiB:       ms.Sys / miB,
+		NumGC:        ms.NumGC,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.Default().ErrorContext(r.Context(), "failed to encode statusz response",
+			slog.String("err", err.Error()),
+		)
+	}
+}
+
 // panicRecoveryHandler logs a recovered panic with its stack trace and returns a
 // generic Internal error, so a single malformed request cannot crash the process
 // and panic internals are never leaked to the caller.
@@ -394,7 +609,26 @@ func (s *Server) Start(ctx context.Context,
 	}
 
 	s.gs = grpc.NewServer(
-		grpc.MaxRecvMsgSize(50*1024*1024), // 50MB
+		grpc.MaxRecvMsgSize(grpcMaxRecvMsgSize),
+		// Send limit matched to recv: the grpc-go default send cap (~4MiB) would
+		// otherwise silently truncate large responses.
+		grpc.MaxSendMsgSize(grpcMaxSendMsgSize),
+		// Bound per-connection stream fan-out.
+		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
+		// Reap idle/half-open HTTP/2 connections. MaxConnectionAge is deliberately
+		// unset so the loopback gateway client and long-lived frontend streams are
+		// never periodically force-closed; see the const block for rationale.
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle: grpcKeepaliveMaxConnectionIdle,
+			Time:              grpcKeepaliveTime,
+			Timeout:           grpcKeepaliveTimeout,
+		}),
+		// PermitWithoutStream keeps the (mostly stream-less) loopback gateway
+		// connection alive; MinTime stays modest so compliant clients aren't dropped.
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             grpcKeepaliveMinTime,
+			PermitWithoutStream: true,
+		}),
 		grpc.ChainUnaryInterceptor(
 			grpcRecovery.UnaryServerInterceptor(recoveryOpts...),
 			grpcSlog.UnaryServerInterceptor(log.InterceptorLogger(slog.Default()), opts...),
@@ -434,6 +668,19 @@ func (s *Server) Start(ctx context.Context,
 	s.hs = &http.Server{
 		Addr:    listenerAddr,
 		Handler: h2c.NewHandler(handler, &http2.Server{}),
+		// Slow-loris hardening. ReadHeaderTimeout caps how long a client may take
+		// to send request headers; IdleTimeout reaps idle keep-alive connections;
+		// MaxHeaderBytes bounds header size.
+		// ReadTimeout and WriteTimeout are intentionally omitted: this server
+		// multiplexes h2c gRPC (long-lived streams / SSE) and large media uploads
+		// to the bucket on the same port. A WriteTimeout would kill long-lived
+		// streaming responses, and a ReadTimeout would abort slow but legitimate
+		// large upload / streaming request bodies. The per-connection slow-loris
+		// risk is instead bounded by ReadHeaderTimeout + IdleTimeout.
+		// TODO: make configurable via httpapi.Config.
+		ReadHeaderTimeout: serverReadHeaderTimeout,
+		IdleTimeout:       serverIdleTimeout,
+		MaxHeaderBytes:    serverMaxHeaderBytes,
 	}
 
 	go func() {

--- a/internal/apisrv/admin/order.go
+++ b/internal/apisrv/admin/order.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
 	"github.com/jekabolt/grbpwr-manager/internal/dto"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/payment/stripe"
 	"github.com/jekabolt/grbpwr-manager/internal/tiermanagement"
 	pb_admin "github.com/jekabolt/grbpwr-manager/proto/gen/admin"
 	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
@@ -241,7 +242,13 @@ func (s *Server) RefundOrder(ctx context.Context, req *pb_admin.RefundOrderReque
 			refundAmount = &amount
 		}
 
-		if err := handler.Refund(ctx, orderFull.Payment, req.OrderUuid, refundAmount, orderFull.Order.Currency); err != nil {
+		// Deterministic idempotency key over the refund scope: a retry after a partial
+		// failure (e.g. Stripe succeeded but the DB step failed) and two concurrent
+		// identical refund calls reuse the same key, so Stripe dedupes server-side and
+		// the money is refunded at most once.
+		idemKey := stripe.RefundIdempotencyKey(req.OrderUuid, req.OrderItemIds, refundShipping, refundAmount, orderFull.Order.Currency)
+
+		if err := handler.Refund(ctx, orderFull.Payment, req.OrderUuid, refundAmount, orderFull.Order.Currency, idemKey); err != nil {
 			slog.Default().ErrorContext(ctx, "stripe refund failed",
 				slog.String("err", err.Error()),
 				slog.String("orderUuid", req.OrderUuid),

--- a/internal/apisrv/auth/auth.go
+++ b/internal/apisrv/auth/auth.go
@@ -16,6 +16,8 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/auth/jwt"
 	"github.com/jekabolt/grbpwr-manager/internal/auth/pwhash"
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
+	"github.com/jekabolt/grbpwr-manager/internal/middleware"
+	"github.com/jekabolt/grbpwr-manager/internal/ratelimit"
 	"github.com/jekabolt/grbpwr-manager/proto/gen/auth"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -28,6 +30,24 @@ const (
 	AuthMetadataKey = "Grpc-Metadata-Authorization"
 )
 
+// Brute-force throttling for the admin auth RPCs. These endpoints gate admin
+// account creation/deletion, password changes and login, and are exposed to the
+// internet, so unlimited online password guessing against an admin account or
+// the master password must be stopped. PBKDF2 slows each guess but does not cap
+// the total, so we add an in-memory sliding-window limiter (the same primitive
+// the frontend service uses) keyed by client IP and, where present, by the
+// targeted username. Limits are intentionally tight for admin auth.
+const (
+	// authRateWindow is the sliding window over which auth attempts are counted.
+	authRateWindow = time.Minute
+	// authMaxPerIP caps auth attempts per client IP per window (network-wide
+	// guessing, e.g. against the master password which has no username key).
+	authMaxPerIP = 10
+	// authMaxPerUser caps auth attempts per targeted username per window
+	// (tighter, since a single account should never see this many attempts).
+	authMaxPerUser = 5
+)
+
 // Server implements the heartbeat service.
 type Server struct {
 	auth.UnimplementedAuthServiceServer
@@ -38,6 +58,38 @@ type Server struct {
 	jwtExpectations *jwt.Expectations
 	c               *Config
 	masterHash      string
+	rateLimiter     *authRateLimiter
+}
+
+// authRateLimiter throttles brute-force attempts against the admin auth RPCs.
+// It reuses the same in-memory sliding-window limiter primitive the frontend
+// service uses (ratelimit.MultiKeyLimiter is built from these), keyed per IP
+// and per targeted username.
+type authRateLimiter struct {
+	ip   *ratelimit.Limiter
+	user *ratelimit.Limiter
+}
+
+func newAuthRateLimiter() *authRateLimiter {
+	return &authRateLimiter{
+		ip:   ratelimit.NewLimiter(authRateWindow, authMaxPerIP),
+		user: ratelimit.NewLimiter(authRateWindow, authMaxPerUser),
+	}
+}
+
+// check applies the per-IP limit always and, when a username is supplied, the
+// tighter per-username limit. It returns a ResourceExhausted gRPC error so the
+// throttled response is distinct from a normal failed login at the transport
+// level. An empty ip is still rate limited as a single bucket (fail closed
+// rather than skip when the client-IP middleware did not populate it).
+func (l *authRateLimiter) check(ip, username string) error {
+	if !l.ip.Allow(ip) {
+		return status.Errorf(codes.ResourceExhausted, "too many attempts, please try again later")
+	}
+	if username != "" && !l.user.Allow(username) {
+		return status.Errorf(codes.ResourceExhausted, "too many attempts, please try again later")
+	}
+	return nil
 }
 
 // Config contains the configuration for the auth server.
@@ -45,9 +97,9 @@ type Config struct {
 	JWTSecret                string `mapstructure:"jwt_secret"`
 	JWTIssuer                string `mapstructure:"jwt_issuer"`
 	JWTAudience              string `mapstructure:"jwt_audience"`
-	MasterPassword            string `mapstructure:"master_password"`
-	PasswordHasherSaltSize    int    `mapstructure:"password_hasher_salt_size"`
-	PasswordHasherIterations  int    `mapstructure:"password_hasher_iterations"`
+	MasterPassword           string `mapstructure:"master_password"`
+	PasswordHasherSaltSize   int    `mapstructure:"password_hasher_salt_size"`
+	PasswordHasherIterations int    `mapstructure:"password_hasher_iterations"`
 	JWTTTL                   string `mapstructure:"jwt_ttl"`
 }
 
@@ -97,6 +149,7 @@ func New(c *Config, ar dependency.Admin) (*Server, error) {
 		jwtExpectations: jwtExp,
 		c:               c,
 		masterHash:      hash,
+		rateLimiter:     newAuthRateLimiter(),
 	}
 
 	return s, nil
@@ -112,6 +165,17 @@ func (s *Server) jwtIssueOpts() *jwt.IssueOpts {
 // Login get auth token for provided username and password.
 func (s *Server) Login(ctx context.Context, req *auth.LoginRequest) (*auth.LoginResponse, error) {
 	username := strings.ToLower(req.Username)
+
+	// Throttle online password guessing per IP and per targeted username before
+	// doing any (expensive) PBKDF2 work or DB lookup.
+	ip := middleware.GetClientIP(ctx)
+	if err := s.rateLimiter.check(ip, username); err != nil {
+		slog.Default().WarnContext(ctx, "login attempt throttled",
+			slog.String("ip", ip),
+			slog.String("username", username),
+		)
+		return nil, err
+	}
 
 	pwHash, err := s.adminRepository.PasswordHashByUsername(ctx, username)
 	if err != nil {
@@ -155,6 +219,16 @@ func (s *Server) Login(ctx context.Context, req *auth.LoginRequest) (*auth.Login
 
 // Create creates a new user requires an admin password.
 func (s *Server) Create(ctx context.Context, req *auth.CreateRequest) (*auth.CreateResponse, error) {
+
+	// Gated by the master password, which has no username key — throttle per IP
+	// to stop online guessing of the master password.
+	ip := middleware.GetClientIP(ctx)
+	if err := s.rateLimiter.check(ip, ""); err != nil {
+		slog.Default().WarnContext(ctx, "admin create attempt throttled",
+			slog.String("ip", ip),
+		)
+		return nil, err
+	}
 
 	err := s.pwhash.Validate(strings.TrimSpace(req.MasterPassword), s.masterHash)
 	if err != nil {
@@ -201,6 +275,16 @@ func (s *Server) Create(ctx context.Context, req *auth.CreateRequest) (*auth.Cre
 
 // Delete deletes a user.
 func (s *Server) Delete(ctx context.Context, req *auth.DeleteRequest) (*auth.DeleteResponse, error) {
+	// Gated by the master password (no per-account secret to guess) — throttle
+	// per IP to stop online guessing of the master password.
+	ip := middleware.GetClientIP(ctx)
+	if err := s.rateLimiter.check(ip, ""); err != nil {
+		slog.Default().WarnContext(ctx, "admin delete attempt throttled",
+			slog.String("ip", ip),
+		)
+		return nil, err
+	}
+
 	err := s.pwhash.Validate(strings.TrimSpace(req.MasterPassword), s.masterHash)
 	if err != nil {
 		slog.Default().ErrorContext(ctx, "failed to validate master password",
@@ -223,6 +307,17 @@ func (s *Server) Delete(ctx context.Context, req *auth.DeleteRequest) (*auth.Del
 // ChangePassword changes the password of the user. It requires the old password or admin password provided.
 func (s *Server) ChangePassword(ctx context.Context, req *auth.ChangePasswordRequest) (*auth.ChangePasswordResponse, error) {
 	username := strings.ToLower(req.Username)
+
+	// Accepts either the account's current password or the master password, so
+	// throttle per IP and per targeted username to stop guessing of either.
+	ip := middleware.GetClientIP(ctx)
+	if err := s.rateLimiter.check(ip, username); err != nil {
+		slog.Default().WarnContext(ctx, "change password attempt throttled",
+			slog.String("ip", ip),
+			slog.String("username", username),
+		)
+		return nil, err
+	}
 
 	currentPwdHash, err := s.adminRepository.PasswordHashByUsername(ctx, username)
 	if err != nil {
@@ -283,18 +378,18 @@ func (s *Server) WithAuth(next http.Handler) http.Handler {
 		token := strings.TrimPrefix(r.Header.Get(AuthMetadataKey), "Bearer ")
 		_, err := jwt.VerifyTokenWithExpectations(s.JwtAuth, token, s.jwtExpectations)
 		if err != nil {
-		// Create a new error message
-		errMsg := errorMessage{Error: err.Error()}
+			// Create a new error message
+			errMsg := errorMessage{Error: err.Error()}
 
-		// Set content type to JSON
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
+			// Set content type to JSON
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
 
-		// Write the JSON error message
-		if err := json.NewEncoder(w).Encode(errMsg); err != nil {
-			slog.Default().Error("failed to encode auth error response", slog.String("err", err.Error()))
-		}
-		return
+			// Write the JSON error message
+			if err := json.NewEncoder(w).Encode(errMsg); err != nil {
+				slog.Default().Error("failed to encode auth error response", slog.String("err", err.Error()))
+			}
+			return
 		}
 
 		next.ServeHTTP(w, r)

--- a/internal/apisrv/frontend/order_invoice.go
+++ b/internal/apisrv/frontend/order_invoice.go
@@ -8,12 +8,35 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
 	"github.com/jekabolt/grbpwr-manager/internal/dto"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/middleware"
 	pb_frontend "github.com/jekabolt/grbpwr-manager/proto/gen/frontend"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func (s *Server) GetOrderInvoice(ctx context.Context, req *pb_frontend.GetOrderInvoiceRequest) (*pb_frontend.GetOrderInvoiceResponse, error) {
+	// RATE LIMIT CHECK: this endpoint operates on req.OrderUuid alone and returns
+	// the payment client_secret, so without a limit the ORD-+7-char reference is
+	// brute-forceable over time. Key on client IP and on the order UUID itself.
+	//
+	// TODO(security): close the IDOR. This endpoint has no ownership binding: the
+	// caller only proves knowledge of order_uuid, not that the order is theirs
+	// (unlike GetOrderByUUIDAndEmail, which matches a buyer email). The guest
+	// checkout flow reaches this endpoint without a storefront session, so we
+	// cannot make the storefront access token (s.storefrontEmailFromAccess) a hard
+	// requirement here without breaking guest payments. Fully fixing this needs a
+	// proto change (add an email/token field to GetOrderInvoiceRequest, matched
+	// against the order's buyer email) plus coordinated frontend changes to pass
+	// it. Until then, rate limiting is the mitigation.
+	clientIP := middleware.GetClientIP(ctx)
+	if err := s.rateLimiter.CheckSupportTicket(clientIP, req.OrderUuid); err != nil {
+		slog.Default().WarnContext(ctx, "rate limit exceeded for get order invoice",
+			slog.String("ip", clientIP),
+			slog.String("order_uuid", req.OrderUuid),
+		)
+		return nil, status.Errorf(codes.ResourceExhausted, "rate limit exceeded")
+	}
+
 	pm := dto.ConvertPbPaymentMethodToEntity(req.PaymentMethod)
 
 	pme, ok := cache.GetPaymentMethodByName(pm)
@@ -53,6 +76,29 @@ func (s *Server) GetOrderInvoice(ctx context.Context, req *pb_frontend.GetOrderI
 }
 
 func (s *Server) CancelOrderInvoice(ctx context.Context, req *pb_frontend.CancelOrderInvoiceRequest) (*pb_frontend.CancelOrderInvoiceResponse, error) {
+	// RATE LIMIT CHECK: this endpoint operates on req.OrderUuid alone and cancels
+	// payment monitoring / releases reserved stock, so without a limit the
+	// ORD-+7-char reference is brute-forceable into a denial-of-service against
+	// other buyers' pending orders. Key on client IP and on the order UUID itself.
+	//
+	// TODO(security): close the IDOR. Like GetOrderInvoice, this endpoint has no
+	// ownership binding — the caller only proves knowledge of order_uuid, not that
+	// the order is theirs (unlike CancelOrderByUser, which matches a buyer email).
+	// The guest checkout flow reaches this endpoint without a storefront session,
+	// so the storefront access token (s.storefrontEmailFromAccess) cannot be made
+	// a hard requirement here without breaking guest payments. Fully fixing this
+	// needs a proto change (add an email/token field to CancelOrderInvoiceRequest,
+	// matched against the order's buyer email) plus coordinated frontend changes.
+	// Until then, rate limiting is the mitigation.
+	clientIP := middleware.GetClientIP(ctx)
+	if err := s.rateLimiter.CheckSupportTicket(clientIP, req.OrderUuid); err != nil {
+		slog.Default().WarnContext(ctx, "rate limit exceeded for cancel order invoice",
+			slog.String("ip", clientIP),
+			slog.String("order_uuid", req.OrderUuid),
+		)
+		return nil, status.Errorf(codes.ResourceExhausted, "rate limit exceeded")
+	}
+
 	payment, err := s.repo.Order().ExpireOrderPayment(ctx, req.OrderUuid)
 	if err != nil {
 		slog.Default().ErrorContext(ctx, "can't expire order payment",

--- a/internal/apisrv/frontend/order_post_purchase.go
+++ b/internal/apisrv/frontend/order_post_purchase.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
 	"github.com/jekabolt/grbpwr-manager/internal/dto"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/payment/stripe"
 	pb_frontend "github.com/jekabolt/grbpwr-manager/proto/gen/frontend"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -193,7 +194,12 @@ func (s *Server) CancelOrderByUser(ctx context.Context, req *pb_frontend.CancelO
 				return nil, status.Error(codes.Internal, "can't get payment handler")
 			}
 
-			if err := pHandler.Refund(ctx, orderFull.Payment, req.OrderUuid, nil, orderFull.Order.Currency); err != nil {
+			// Deterministic idempotency key so a retry of this user-initiated full
+			// refund (or a concurrent admin refund of the same scope) dedupes at Stripe
+			// instead of refunding twice. Scope here: full refund, including shipping.
+			idemKey := stripe.RefundIdempotencyKey(req.OrderUuid, nil, true, nil, orderFull.Order.Currency)
+
+			if err := pHandler.Refund(ctx, orderFull.Payment, req.OrderUuid, nil, orderFull.Order.Currency, idemKey); err != nil {
 				slog.Default().ErrorContext(ctx, "stripe refund failed",
 					slog.String("err", err.Error()),
 					slog.String("order_uuid", req.OrderUuid),

--- a/internal/apisrv/frontend/order_submit.go
+++ b/internal/apisrv/frontend/order_submit.go
@@ -254,8 +254,14 @@ func (s *Server) SubmitOrder(ctx context.Context, req *pb_frontend.SubmitOrderRe
 	}
 
 	// start monitoring immediately after InsertFiatInvoice succeeds
-	// to prevent orphaned orders if subsequent operations fail
-	handler.StartMonitoringPayment(ctx, order.UUID, orderFull.Payment)
+	// to prevent orphaned orders if subsequent operations fail.
+	//
+	// Detach the request context: the gRPC request ctx is cancelled the moment
+	// SubmitOrder returns, which would kill the monitor goroutine instantly.
+	// context.WithoutCancel preserves request values/trace while stopping
+	// cancellation from propagating. The monitor's own lifecycle (and shutdown)
+	// is governed by the processor's parent context, not this ctx.
+	handler.StartMonitoringPayment(context.WithoutCancel(ctx), order.UUID, orderFull.Payment)
 
 	err = s.repo.Order().UpdateTotalPaymentCurrency(ctx, order.UUID, orderFull.Order.TotalPriceDecimal())
 	if err != nil {

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -1,9 +1,11 @@
 package bucket
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
@@ -35,6 +37,23 @@ func New(c *Config, mediaStore dependency.Media) (dependency.FileStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize MinIO client: %w", err)
 	}
+
+	// Validate credentials/endpoint connectivity at boot so the app fails fast
+	// instead of appearing healthy and failing on the first upload at runtime.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	exists, err := cli.BucketExists(ctx, c.S3BucketName)
+	if err != nil {
+		return nil, fmt.Errorf("bucket connectivity check failed: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("bucket connectivity check failed: configured bucket %q does not exist", c.S3BucketName)
+	}
+	slog.Default().InfoContext(ctx, "bucket connectivity verified",
+		slog.String("bucket", c.S3BucketName),
+		slog.String("endpoint", c.S3Endpoint),
+	)
+
 	return &Bucket{
 		Client: cli,
 		Config: c,

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -218,7 +218,9 @@ type (
 		StartMonitoringPayment(ctx context.Context, orderUUID string, payment entity.Payment)
 		// Refund performs a Stripe refund for an order. No-op for non-Stripe payment methods.
 		// If amount is nil, performs full refund. Otherwise refunds the specified amount in order currency.
-		Refund(ctx context.Context, payment entity.Payment, orderUUID string, amount *decimal.Decimal, currency string) error
+		// idempotencyKey must be derived deterministically from the refund scope so retries and
+		// concurrent identical refunds dedupe at Stripe (see stripe.RefundIdempotencyKey).
+		Refund(ctx context.Context, payment entity.Payment, orderUUID string, amount *decimal.Decimal, currency string, idempotencyKey string) error
 	}
 
 	StripePayment interface {

--- a/internal/dto/mail.go
+++ b/internal/dto/mail.go
@@ -3,6 +3,8 @@ package dto
 import (
 	"encoding/base64"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
@@ -136,6 +138,23 @@ func OrderFullToOrderPendingReturn(of *entity.OrderFull) *OrderPendingReturn {
 	}
 }
 
+// tailoredSizeNameRe matches internal compound size codes of the form
+// label_measurement{ta|bo}_{m|f}, e.g. "xs_44ta_m" (tailored, chest 44) or
+// "xxs_23bo_f" (bottoms, 23" waist). See migrations 0018/0019.
+var tailoredSizeNameRe = regexp.MustCompile(`^([a-z]+)_(\d+(?:\.\d+)?)(?:ta|bo)_[mf]$`)
+
+// FormatSizeName turns an internal size code into a human-readable label for
+// customer-facing emails. Compound tailored/bottoms codes become
+// "<LABEL> · <measurement>" (e.g. "xs_44ta_m" → "XS · 44"); plain letter sizes
+// ("m"), shoe sizes ("42") and anything unrecognised pass through unchanged.
+func FormatSizeName(name string) string {
+	m := tailoredSizeNameRe.FindStringSubmatch(name)
+	if m == nil {
+		return name
+	}
+	return strings.ToUpper(m[1]) + " · " + m[2]
+}
+
 func EntityOrderItemsToDto(items []entity.OrderItem, currency string) []OrderItem {
 	oi := make([]OrderItem, len(items))
 	for i, item := range items {
@@ -154,7 +173,7 @@ func EntityOrderItemsToDto(items []entity.OrderItem, currency string) []OrderIte
 		oi[i] = OrderItem{
 			Name:      fmt.Sprintf("%s %s", item.ProductBrand, productName),
 			Thumbnail: item.Thumbnail,
-			Size:      size.Name,
+			Size:      FormatSizeName(size.Name),
 			Quantity:  int(item.Quantity.IntPart()),
 			Price:     RoundForCurrency(item.OrderItemInsert.ProductPriceWithSale, currency).String(),
 		}

--- a/internal/dto/mail_test.go
+++ b/internal/dto/mail_test.go
@@ -1,0 +1,28 @@
+package dto
+
+import "testing"
+
+func TestFormatSizeName(t *testing.T) {
+	cases := map[string]string{
+		// tailored (chest) codes — migration 0018
+		"xs_44ta_m":  "XS · 44",
+		"xl_52ta_m":  "XL · 52",
+		"xxs_32ta_f": "XXS · 32",
+		"xxl_54ta_m": "XXL · 54",
+		// bottoms (waist) codes — migration 0019
+		"xxs_23bo_f": "XXS · 23",
+		"xs_28bo_m":  "XS · 28",
+		// plain letter, shoe, and unrecognised values pass through unchanged
+		"m":       "m",
+		"os":      "os",
+		"42":      "42",
+		"35.5":    "35.5",
+		"unknown": "unknown",
+		"":        "",
+	}
+	for in, want := range cases {
+		if got := FormatSizeName(in); got != want {
+			t.Errorf("FormatSizeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/entity/order.go
+++ b/internal/entity/order.go
@@ -59,7 +59,13 @@ type Order struct {
 	RefundReason   sql.NullString  `db:"refund_reason"`
 	OrderComment   sql.NullString  `db:"order_comment"`
 	RefundedAmount decimal.Decimal `db:"refunded_amount"`
-	GAClientID     sql.NullString  `db:"ga_client_id"`
+	// ShippingRefunded records whether the shipping cost has already been
+	// refunded for this order. Shipping must be refunded at most once even though
+	// a PartiallyRefunded order can be refunded again; without this marker two
+	// partial refunds with refundShipping=true would add the shipping cost to
+	// refunded_amount (and the Stripe charge) twice.
+	ShippingRefunded bool           `db:"shipping_refunded"`
+	GAClientID       sql.NullString `db:"ga_client_id"`
 	// TotalPriceEUR is the order total converted to EUR at order time, used for
 	// loyalty qualifying-spend accumulation. NULL when it could not be derived.
 	TotalPriceEUR decimal.NullDecimal `db:"total_price_eur"`
@@ -380,8 +386,8 @@ type OrderReview struct {
 type OrderReviewInsert struct {
 	DeliveryRating       DeliverySpeed      // optional
 	PackagingRating      PackagingCondition // optional
-	ReviewText           string            // optional
-	SophisticationRating ProductRating     // optional
+	ReviewText           string             // optional
+	SophisticationRating ProductRating      // optional
 }
 
 // OrderItemReview represents the order_item_review table (item-level)

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,0 +1,110 @@
+// Package health provides lightweight, dependency-free observability primitives
+// for background workers and the runtime. Workers embed a Tracker to record the
+// timestamp of their last successful tick; the app aggregates them into a
+// Registry that the HTTP status endpoint renders as JSON.
+//
+// No external dependencies (prometheus/otel) are used: this is intentionally a
+// standard-library-only building block.
+package health
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jekabolt/grbpwr-manager/internal/circuitbreaker"
+)
+
+// Reporter is implemented by anything that records a last-successful-run
+// timestamp (typically a background worker). Name identifies the worker in the
+// status output; LastSuccess is the zero value until the first successful tick.
+type Reporter interface {
+	Name() string
+	LastSuccess() time.Time
+}
+
+// Tracker is a thread-safe, race-free record of a worker's last successful tick
+// and last error. Embed it in a worker struct (as a value) and call
+// MarkSuccess() at the END of a successful tick (never on error, so staleness
+// reflects real failures). The zero value is ready to use and reports
+// LastSuccess() as the zero time ("never ran yet").
+type Tracker struct {
+	// lastSuccessNano holds the unix-nano timestamp of the last successful tick,
+	// 0 when none has happened. Accessed atomically so it is safe under -race
+	// without holding errMu.
+	lastSuccessNano atomic.Int64
+
+	errMu   sync.Mutex
+	lastErr string
+}
+
+// MarkSuccess records the current time as the last successful tick.
+func (t *Tracker) MarkSuccess() {
+	t.lastSuccessNano.Store(time.Now().UnixNano())
+	t.errMu.Lock()
+	t.lastErr = ""
+	t.errMu.Unlock()
+}
+
+// MarkError records a human-readable last-error string. It does NOT touch the
+// last-success timestamp, so staleness keeps reflecting the last real success.
+func (t *Tracker) MarkError(err error) {
+	if err == nil {
+		return
+	}
+	t.errMu.Lock()
+	t.lastErr = err.Error()
+	t.errMu.Unlock()
+}
+
+// LastSuccess returns the time of the last successful tick, or the zero time if
+// there has not been one yet.
+func (t *Tracker) LastSuccess() time.Time {
+	n := t.lastSuccessNano.Load()
+	if n == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, n)
+}
+
+// LastError returns the last recorded error string (empty if none / cleared on
+// the next success).
+func (t *Tracker) LastError() string {
+	t.errMu.Lock()
+	defer t.errMu.Unlock()
+	return t.lastErr
+}
+
+// DBStatsProvider exposes connection-pool statistics (typically *sql.DB.Stats()).
+// Kept as a one-method interface so the store can satisfy it without the http
+// package importing the store.
+type DBStatsProvider interface {
+	Stats() DBStats
+}
+
+// DBStats is a stdlib-only mirror of the subset of sql.DBStats reported by the
+// status endpoint. The store maps sql.DBStats into this so the health/http
+// packages don't need to import database/sql or depend on the store.
+type DBStats struct {
+	OpenConnections    int
+	InUse              int
+	Idle               int
+	WaitCount          int64
+	WaitDuration       time.Duration
+	MaxOpenConnections int
+}
+
+// BreakerReporter exposes a named circuit-breaker's current state cheaply.
+type BreakerReporter struct {
+	BreakerName string
+	StateFunc   func() circuitbreaker.State
+}
+
+// Registry aggregates the runtime/DB/worker/breaker state surfaced by the HTTP
+// status endpoint. It is constructed once in app wiring and is read-only
+// afterwards; the workers it references update their own Trackers concurrently.
+type Registry struct {
+	Workers  []Reporter
+	DB       DBStatsProvider
+	Breakers []BreakerReporter
+}

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -9,8 +9,8 @@ import (
 	"html"
 	"html/template"
 	"io"
-	netmail "net/mail"
 	"net/http"
+	netmail "net/mail"
 	"regexp"
 	"strings"
 	"sync"
@@ -21,6 +21,7 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
 	"github.com/jekabolt/grbpwr-manager/internal/dto"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/health"
 	resend "github.com/jekabolt/grbpwr-manager/openapi/gen/resend"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
 	"google.golang.org/grpc/codes"
@@ -32,6 +33,9 @@ var templatesFS embed.FS
 
 const (
 	resendAPIBaseURL = "https://api.resend.com/"
+	// resendHTTPTimeout bounds each Resend API request so a stalled TCP connection
+	// cannot hang the caller indefinitely (e.g. an inline order-confirmation send).
+	resendHTTPTimeout = 15 * time.Second
 )
 
 const maxEmailAddressLength = 254 // RFC 5321
@@ -95,7 +99,14 @@ type Mailer struct {
 	cancel         context.CancelFunc
 	templates      map[templateName]*template.Template
 	wg             sync.WaitGroup
+	tracker        health.Tracker
 }
+
+// Name implements health.Reporter.
+func (m *Mailer) Name() string { return "mail" }
+
+// LastSuccess implements health.Reporter (zero time until the first clean send tick).
+func (m *Mailer) LastSuccess() time.Time { return m.tracker.LastSuccess() }
 
 // addAuthHeader is a custom RequestEditorFn that adds an authorization header to the request
 func addAuthHeader(token string) resend.RequestEditorFn {
@@ -127,11 +138,14 @@ func new(c *Config, mailRepository dependency.Mail) (*Mailer, error) {
 
 	applyMailerRetryDefaults(c)
 
-	// Initialize the resend client
-	cli, err := resend.NewClient(resendAPIBaseURL, resend.ClientOption(func(rc *resend.Client) error {
-		rc.RequestEditors = append(rc.RequestEditors, addAuthHeader(c.APIKey))
-		return nil
-	}))
+	// Initialize the resend client with a bounded HTTP timeout so a stalled
+	// Resend connection cannot hang the caller indefinitely.
+	cli, err := resend.NewClient(resendAPIBaseURL,
+		resend.WithHTTPClient(&http.Client{Timeout: resendHTTPTimeout}),
+		resend.ClientOption(func(rc *resend.Client) error {
+			rc.RequestEditors = append(rc.RequestEditors, addAuthHeader(c.APIKey))
+			return nil
+		}))
 	if err != nil {
 		return nil, fmt.Errorf("error creating resend client: %w", err)
 	}
@@ -380,6 +394,14 @@ func (m *Mailer) listUnsubscribeHeaders(to string) *map[string]interface{} {
 func (m *Mailer) send(ctx context.Context, ser *resend.SendEmailRequest) error {
 
 	resp, err := m.cli.PostEmails(ctx, *ser)
+	if resp != nil {
+		// Drain and close the body so the underlying connection can be reused
+		// rather than leaked (one leak per inline-sent email otherwise).
+		defer func() {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}()
+	}
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
 			return mailApiLimitReached

--- a/internal/mail/worker.go
+++ b/internal/mail/worker.go
@@ -16,6 +16,16 @@ import (
 // shutdown.
 const tickTimeout = 20 * time.Second
 
+// Backoff bounds for consecutive-failure backoff. On a failed tick an extra
+// delay (base * 2^(n-1), capped at backoffMax) is waited before the next
+// iteration so a persistently failing dependency (DB / Resend) isn't hammered
+// every WorkerInterval. A successful tick resets the backoff. See ga4sync for
+// the established pattern in this codebase.
+const (
+	backoffBase = 30 * time.Second
+	backoffMax  = 5 * time.Minute
+)
+
 // Start starts the worker
 func (m *Mailer) Start(ctx context.Context) error {
 	if m.ctx != nil && m.cancel != nil {
@@ -46,19 +56,55 @@ func (m *Mailer) worker(ctx context.Context) {
 	ticker := time.NewTicker(m.c.WorkerInterval)
 	defer ticker.Stop()
 
+	// consecutiveFailures drives the extra backoff delay applied after a failed
+	// tick. Reset to 0 on the first successful tick.
+	var consecutiveFailures int
+
 	for {
 		select {
 		case <-ticker.C:
-			m.runOnce(ctx)
+			if m.runOnce(ctx) {
+				consecutiveFailures = 0
+				continue
+			}
+			consecutiveFailures++
+			delay := backoffDelay(consecutiveFailures)
+			slog.Default().WarnContext(ctx, "mail: backing off after failed tick",
+				slog.Int("consecutive_failures", consecutiveFailures),
+				slog.Duration("delay", delay),
+			)
+			// Wait the extra backoff on top of the ticker interval, but stay
+			// responsive to shutdown — never time.Sleep blindly.
+			timer := time.NewTimer(delay)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-// runOnce performs a single send tick. The deferred saferun.Recover keeps a
-// panic in this iteration from killing the worker loop.
-func (m *Mailer) runOnce(ctx context.Context) {
+// backoffDelay returns the extra inter-iteration delay for the given number of
+// consecutive failures: base * 2^(n-1), capped at backoffMax.
+func backoffDelay(consecutiveFailures int) time.Duration {
+	delay := backoffBase
+	for i := 1; i < consecutiveFailures; i++ {
+		delay *= 2
+		if delay >= backoffMax {
+			return backoffMax
+		}
+	}
+	return delay
+}
+
+// runOnce performs a single send tick and reports whether it drained without a
+// fatal error. The deferred saferun.Recover keeps a panic in this iteration from
+// killing the worker loop.
+func (m *Mailer) runOnce(ctx context.Context) bool {
 	defer saferun.Recover(ctx, "mail")
 
 	ctx, cancel := context.WithTimeout(ctx, tickTimeout)
@@ -69,11 +115,12 @@ func (m *Mailer) runOnce(ctx context.Context) {
 		slog.Default().ErrorContext(ctx, "can't handle unsent mails",
 			slog.String("err", err.Error()),
 		)
-		return
+		return false
 	}
 
 	// Record success only when the send tick drained without a fatal error.
 	m.tracker.MarkSuccess()
+	return true
 }
 
 func (m *Mailer) handleUnsent(ctx context.Context) error {

--- a/internal/mail/worker.go
+++ b/internal/mail/worker.go
@@ -7,7 +7,14 @@ import (
 	"time"
 
 	"log/slog"
+
+	"github.com/jekabolt/grbpwr-manager/internal/saferun"
 )
+
+// tickTimeout bounds the DB + provider work done in a single send tick, so one
+// stuck query or hung HTTP send can't block the loop forever or stall graceful
+// shutdown.
+const tickTimeout = 20 * time.Second
 
 // Start starts the worker
 func (m *Mailer) Start(ctx context.Context) error {
@@ -42,15 +49,31 @@ func (m *Mailer) worker(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			if err := m.handleUnsent(ctx); err != nil {
-				slog.Default().ErrorContext(ctx, "can't handle unsent mails",
-					slog.String("err", err.Error()),
-				)
-			}
+			m.runOnce(ctx)
 		case <-ctx.Done():
 			return
 		}
 	}
+}
+
+// runOnce performs a single send tick. The deferred saferun.Recover keeps a
+// panic in this iteration from killing the worker loop.
+func (m *Mailer) runOnce(ctx context.Context) {
+	defer saferun.Recover(ctx, "mail")
+
+	ctx, cancel := context.WithTimeout(ctx, tickTimeout)
+	defer cancel()
+
+	if err := m.handleUnsent(ctx); err != nil {
+		m.tracker.MarkError(err)
+		slog.Default().ErrorContext(ctx, "can't handle unsent mails",
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	// Record success only when the send tick drained without a fatal error.
+	m.tracker.MarkSuccess()
 }
 
 func (m *Mailer) handleUnsent(ctx context.Context) error {

--- a/internal/middleware/clientid.go
+++ b/internal/middleware/clientid.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 )
 
 type contextKey string
@@ -14,6 +16,33 @@ const (
 	ClientIPKey      contextKey = "client_ip"
 	ClientSessionKey contextKey = "client_session"
 )
+
+// defaultTrustedProxyHops is the secure default number of trusted reverse-proxy
+// hops in front of this service. On DigitalOcean App Platform exactly one
+// trusted edge proxy sits in front of the app and appends the real client IP as
+// the right-most entry of X-Forwarded-For, so 1 is the correct value there.
+const defaultTrustedProxyHops = 1
+
+// trustedProxyHops holds the number of trusted proxy hops used when parsing
+// X-Forwarded-For. It is read on every request via atomic load so it can be
+// configured at startup (see SetTrustedProxyHops) without locking on the hot
+// path. It defaults to defaultTrustedProxyHops so that, even if configuration
+// is never applied, the behaviour stays secure (anti-spoofing) rather than
+// trusting the attacker-controllable left-most XFF entry.
+var trustedProxyHops int64 = defaultTrustedProxyHops
+
+// SetTrustedProxyHops configures how many trusted reverse-proxy hops sit in
+// front of this service. The value is the count of proxies the platform's
+// trusted infrastructure contributes to the right side of X-Forwarded-For
+// (e.g. 1 for DigitalOcean App Platform's single edge proxy). A non-positive
+// value is ignored and the secure default (defaultTrustedProxyHops) is kept,
+// preventing accidental misconfiguration from disabling spoofing protection.
+func SetTrustedProxyHops(hops int) {
+	if hops <= 0 {
+		hops = defaultTrustedProxyHops
+	}
+	atomic.StoreInt64(&trustedProxyHops, int64(hops))
+}
 
 // ClientIdentifier extracts client IP and generates session fingerprint
 func ClientIdentifier(next http.Handler) http.Handler {
@@ -31,30 +60,68 @@ func ClientIdentifier(next http.Handler) http.Handler {
 	})
 }
 
-// getClientIP extracts the real client IP from request headers
+// getClientIP extracts the real client IP from request headers in a way that is
+// robust against X-Forwarded-For spoofing.
+//
+// X-Forwarded-For is a comma-separated chain that grows on the RIGHT as each
+// proxy appends the IP it observed: "<client>, <proxy1>, <proxy2>". Only the
+// right-most entries — those appended by infrastructure WE trust — are
+// authentic; everything to the left can be forged by the client. Blindly taking
+// the left-most entry (the previous behaviour) lets an attacker send an
+// arbitrary or rotating X-Forwarded-For header to evade per-IP rate limiting and
+// login throttling.
+//
+// We therefore skip `trustedProxyHops` entries from the right (the ones our
+// trusted proxies appended) and use the next entry to the left — the first IP
+// the trusted infrastructure did NOT let the client forge. Entries are validated
+// with net.ParseIP. If X-Forwarded-For is absent, too short for the configured
+// hop count, or the selected entry is not a valid IP, we fall back to
+// RemoteAddr, which the client cannot spoof.
 func getClientIP(r *http.Request) string {
-	// Check X-Forwarded-For header (proxy/load balancer)
+	hops := int(atomic.LoadInt64(&trustedProxyHops))
+	if hops <= 0 {
+		hops = defaultTrustedProxyHops
+	}
+
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		ips := strings.Split(xff, ",")
-		return strings.TrimSpace(ips[0])
+		parts := strings.Split(xff, ",")
+
+		// Index of the entry that is `hops` from the right. With a single
+		// trusted hop and chain [client, edge], this selects `client`.
+		idx := len(parts) - 1 - hops
+		if idx >= 0 {
+			if ip := normalizeIP(parts[idx]); ip != "" {
+				return ip
+			}
+		}
+		// Chain shorter than expected or selected entry invalid: fall through
+		// to RemoteAddr rather than trusting an attacker-controllable value.
 	}
 
-	// Check X-Real-IP header
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return xri
+	// Fall back to RemoteAddr (the immediate peer; cannot be spoofed at the
+	// application layer). It is typically "host:port" but may be a bare host.
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		if ip := normalizeIP(host); ip != "" {
+			return ip
+		}
 	}
+	if ip := normalizeIP(r.RemoteAddr); ip != "" {
+		return ip
+	}
+	return r.RemoteAddr
+}
 
-	// Check CF-Connecting-IP (Cloudflare)
-	if cfip := r.Header.Get("CF-Connecting-IP"); cfip != "" {
-		return cfip
+// normalizeIP trims surrounding whitespace and returns the canonical string
+// form of the IP if it parses, or "" if the value is not a valid IP address.
+func normalizeIP(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
 	}
-
-	// Fall back to RemoteAddr
-	addr := r.RemoteAddr
-	if idx := strings.LastIndex(addr, ":"); idx != -1 {
-		return addr[:idx]
+	if ip := net.ParseIP(s); ip != nil {
+		return ip.String()
 	}
-	return addr
+	return ""
 }
 
 // generateFingerprint creates a unique session identifier from request headers

--- a/internal/ordercleanup/ordercleanup.go
+++ b/internal/ordercleanup/ordercleanup.go
@@ -7,12 +7,13 @@ import (
 	"time"
 
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
+	"github.com/jekabolt/grbpwr-manager/internal/health"
 )
 
 // Config holds configuration for the order cleanup worker.
 type Config struct {
-	WorkerInterval   time.Duration `mapstructure:"worker_interval"`
-	PlacedThreshold  time.Duration `mapstructure:"placed_threshold"` // e.g. 24h - cancel orders in Placed older than this
+	WorkerInterval  time.Duration `mapstructure:"worker_interval"`
+	PlacedThreshold time.Duration `mapstructure:"placed_threshold"` // e.g. 24h - cancel orders in Placed older than this
 }
 
 // DefaultConfig returns default configuration values.
@@ -41,7 +42,14 @@ type Worker struct {
 	ctx            context.Context
 	stop           context.CancelFunc
 	wg             sync.WaitGroup
+	tracker        health.Tracker
 }
+
+// Name implements health.Reporter.
+func (w *Worker) Name() string { return "ordercleanup" }
+
+// LastSuccess implements health.Reporter (zero time until the first clean tick).
+func (w *Worker) LastSuccess() time.Time { return w.tracker.LastSuccess() }
 
 // New creates a new order cleanup worker. expirer may be nil, in which case
 // expiry falls back to the store-level path (which does not verify the provider).

--- a/internal/ordercleanup/worker.go
+++ b/internal/ordercleanup/worker.go
@@ -14,23 +14,69 @@ import (
 // query can't block the loop forever or stall graceful shutdown.
 const tickTimeout = 30 * time.Second
 
+// Backoff bounds for consecutive-failure backoff. On a failed tick an extra
+// delay (base * 2^(n-1), capped at backoffMax) is waited before the next
+// iteration so a persistently failing dependency (e.g. the DB) isn't hammered
+// every WorkerInterval. A successful tick resets the backoff. See ga4sync for
+// the established pattern in this codebase.
+const (
+	backoffBase = 30 * time.Second
+	backoffMax  = 5 * time.Minute
+)
+
 func (w *Worker) worker(ctx context.Context) {
 	ticker := time.NewTicker(w.c.WorkerInterval)
 	defer ticker.Stop()
 
+	// consecutiveFailures drives the extra backoff delay applied after a failed
+	// tick. Reset to 0 on the first successful tick.
+	var consecutiveFailures int
+
 	for {
 		select {
 		case <-ticker.C:
-			w.runOnce(ctx)
+			if w.runOnce(ctx) {
+				consecutiveFailures = 0
+				continue
+			}
+			consecutiveFailures++
+			delay := backoffDelay(consecutiveFailures)
+			slog.Default().WarnContext(ctx, "ordercleanup: backing off after failed tick",
+				slog.Int("consecutive_failures", consecutiveFailures),
+				slog.Duration("delay", delay),
+			)
+			// Wait the extra backoff on top of the ticker interval, but stay
+			// responsive to shutdown — never time.Sleep blindly.
+			timer := time.NewTimer(delay)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-// runOnce performs a single cleanup tick. The deferred saferun.Recover keeps a
-// panic in this iteration from killing the worker loop (and the whole process).
-func (w *Worker) runOnce(ctx context.Context) {
+// backoffDelay returns the extra inter-iteration delay for the given number of
+// consecutive failures: base * 2^(n-1), capped at backoffMax.
+func backoffDelay(consecutiveFailures int) time.Duration {
+	delay := backoffBase
+	for i := 1; i < consecutiveFailures; i++ {
+		delay *= 2
+		if delay >= backoffMax {
+			return backoffMax
+		}
+	}
+	return delay
+}
+
+// runOnce performs a single cleanup tick and reports whether it fully succeeded.
+// The deferred saferun.Recover keeps a panic in this iteration from killing the
+// worker loop (and the whole process).
+func (w *Worker) runOnce(ctx context.Context) bool {
 	defer saferun.Recover(ctx, "ordercleanup")
 
 	ctx, cancel := context.WithTimeout(ctx, tickTimeout)
@@ -57,6 +103,7 @@ func (w *Worker) runOnce(ctx context.Context) {
 	if ok {
 		w.tracker.MarkSuccess()
 	}
+	return ok
 }
 
 func (w *Worker) cancelStuckPlacedOrders(ctx context.Context) error {

--- a/internal/ordercleanup/worker.go
+++ b/internal/ordercleanup/worker.go
@@ -6,7 +6,13 @@ import (
 	"time"
 
 	"log/slog"
+
+	"github.com/jekabolt/grbpwr-manager/internal/saferun"
 )
+
+// tickTimeout bounds the DB work done in a single cleanup tick, so one stuck
+// query can't block the loop forever or stall graceful shutdown.
+const tickTimeout = 30 * time.Second
 
 func (w *Worker) worker(ctx context.Context) {
 	ticker := time.NewTicker(w.c.WorkerInterval)
@@ -15,19 +21,41 @@ func (w *Worker) worker(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			if err := w.cancelStuckPlacedOrders(ctx); err != nil {
-				slog.Default().ErrorContext(ctx, "can't cancel stuck placed orders",
-					slog.String("err", err.Error()),
-				)
-			}
-			if err := w.cancelExpiredAwaitingPaymentOrders(ctx); err != nil {
-				slog.Default().ErrorContext(ctx, "can't cancel expired awaiting payment orders",
-					slog.String("err", err.Error()),
-				)
-			}
+			w.runOnce(ctx)
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+// runOnce performs a single cleanup tick. The deferred saferun.Recover keeps a
+// panic in this iteration from killing the worker loop (and the whole process).
+func (w *Worker) runOnce(ctx context.Context) {
+	defer saferun.Recover(ctx, "ordercleanup")
+
+	ctx, cancel := context.WithTimeout(ctx, tickTimeout)
+	defer cancel()
+
+	ok := true
+	if err := w.cancelStuckPlacedOrders(ctx); err != nil {
+		ok = false
+		w.tracker.MarkError(err)
+		slog.Default().ErrorContext(ctx, "can't cancel stuck placed orders",
+			slog.String("err", err.Error()),
+		)
+	}
+	if err := w.cancelExpiredAwaitingPaymentOrders(ctx); err != nil {
+		ok = false
+		w.tracker.MarkError(err)
+		slog.Default().ErrorContext(ctx, "can't cancel expired awaiting payment orders",
+			slog.String("err", err.Error()),
+		)
+	}
+
+	// Record success only when the whole tick completed without error, so
+	// staleness reflects real failures.
+	if ok {
+		w.tracker.MarkSuccess()
 	}
 }
 

--- a/internal/payment/stripe/payment.go
+++ b/internal/payment/stripe/payment.go
@@ -14,11 +14,11 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"github.com/jekabolt/grbpwr-manager/internal/analytics/ga4mp"
-	"github.com/jekabolt/grbpwr-manager/internal/preorderpayment"
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
 	"github.com/jekabolt/grbpwr-manager/internal/dto"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/preorderpayment"
 	"github.com/jekabolt/grbpwr-manager/internal/tiermanagement"
 	"github.com/jekabolt/grbpwr-manager/log"
 	"github.com/shopspring/decimal"
@@ -39,6 +39,13 @@ type Config struct {
 // ErrPaymentAlreadyCompleted is returned when the PaymentIntent was already used for a completed payment.
 var ErrPaymentAlreadyCompleted = errors.New("payment already completed for this session")
 
+// monEntry is a single tracked payment monitor: its cancel func plus a unique
+// token used to identify map ownership (CancelFunc values are not comparable).
+type monEntry struct {
+	cancel context.CancelFunc
+	token  *int
+}
+
 // ErrUnderpaid is returned by updateOrderAsPaid when a PaymentIntent succeeded
 // for less than the order total (amount tampering / early confirmation). The
 // order is intentionally left AwaitingPayment for manual review rather than
@@ -46,17 +53,27 @@ var ErrPaymentAlreadyCompleted = errors.New("payment already completed for this 
 var ErrUnderpaid = errors.New("payment intent succeeded for less than the order total")
 
 type Processor struct {
-	c                *Config
-	mailer           dependency.Mailer
-	rep              dependency.Repository
-	stripeClient     *client.API
-	pm               entity.PaymentMethod
-	reservationMgr   dependency.StockReservationManager
-	preOrderStore    *preorderpayment.Store
-	ga4mp            *ga4mp.Client
+	c              *Config
+	mailer         dependency.Mailer
+	rep            dependency.Repository
+	stripeClient   *client.API
+	pm             entity.PaymentMethod
+	reservationMgr dependency.StockReservationManager
+	preOrderStore  *preorderpayment.Store
+	ga4mp          *ga4mp.Client
 
-	monCtxt map[string]context.CancelFunc // tracks monitoring contexts by order uuid
+	monCtxt map[string]monEntry // tracks monitoring contexts by order uuid
 	ctxMu   sync.Mutex
+
+	// monParentCtx is the parent context for ALL in-process payment monitors.
+	// Every monitor derives its context from this one, so cancelling monParent
+	// (via StopAllMonitors) stops every monitor at shutdown — before the DB is
+	// closed — instead of leaving detached goroutines racing against teardown.
+	monParentCtx    context.Context
+	monParentCancel context.CancelFunc
+	// monWg tracks in-flight monitor goroutines so StopAllMonitors can wait for
+	// them to finish before the app closes the DB.
+	monWg sync.WaitGroup
 }
 
 func New(ctx context.Context, c *Config, rep dependency.Repository, m dependency.Mailer, pmn entity.PaymentMethodName) (dependency.Invoicer, error) {
@@ -83,15 +100,22 @@ func New(ctx context.Context, c *Config, rep dependency.Repository, m dependency
 	if ttl <= 0 {
 		ttl = 30 * time.Minute
 	}
+	// Parent context for all in-process payment monitors. Derived from
+	// context.Background() (NOT the boot ctx) so monitors live for the lifetime
+	// of the process and are stopped explicitly via StopAllMonitors at shutdown.
+	monParentCtx, monParentCancel := context.WithCancel(context.Background())
+
 	p := Processor{
-		c:              c,
-		mailer:         m,
-		stripeClient:   client.New(c.SecretKey, nil),
-		rep:            rep,
-		pm:             pm.Method,
-		monCtxt:        make(map[string]context.CancelFunc),
-		reservationMgr: nil, // Will be set via SetReservationManager if needed
-		preOrderStore:  preorderpayment.NewStore(ttl),
+		c:               c,
+		mailer:          m,
+		stripeClient:    client.New(c.SecretKey, nil),
+		rep:             rep,
+		pm:              pm.Method,
+		monCtxt:         make(map[string]monEntry),
+		reservationMgr:  nil, // Will be set via SetReservationManager if needed
+		preOrderStore:   preorderpayment.NewStore(ttl),
+		monParentCtx:    monParentCtx,
+		monParentCancel: monParentCancel,
 	}
 
 	err := p.initAddressesFromUnpaidOrders(ctx)
@@ -434,21 +458,47 @@ func (p *Processor) GetOrderInvoice(ctx context.Context, orderUUID string) (*ent
 		Valid: true,
 	}
 
+	// The monitor's lifecycle is governed by the processor's parent context
+	// (monParentCtx), not the passed ctx — see monitorPayment.
 	go p.monitorPayment(context.Background(), orderUUID, payment)
 
 	return &payment.PaymentInsert, nil
 }
 
-func (p *Processor) monitorPayment(ctx context.Context, orderUUID string, payment *entity.Payment) {
-	ctx, cancel := context.WithCancel(ctx)
+// monitorPayment watches a single order's PaymentIntent until it expires (or is
+// cancelled). It derives its context from the processor-wide parent (monParentCtx)
+// so StopAllMonitors can stop every monitor at shutdown; the caller-supplied ctx
+// is intentionally ignored for cancellation (e.g. a per-request ctx would die the
+// moment the RPC returns). Monitors are tracked in monWg so shutdown can wait for
+// them to finish before the DB is closed.
+func (p *Processor) monitorPayment(_ context.Context, orderUUID string, payment *entity.Payment) {
+	p.monWg.Add(1)
+	defer p.monWg.Done()
+
+	ctx, cancel := context.WithCancel(p.monParentCtx)
+	// token identifies this monitor's entry in monCtxt so a later monitor that
+	// replaces us can be distinguished on cleanup (CancelFunc values are not
+	// comparable, so we key map ownership by this unique pointer instead).
+	token := new(int)
+
 	p.ctxMu.Lock()
-	p.monCtxt[orderUUID] = cancel
+	// Cancel any monitor already registered for this order before overwriting it,
+	// otherwise the previous goroutine leaks and CancelMonitorPayment /
+	// confirmPaymentFromWebhook would only ever cancel the latest one.
+	if prev, exists := p.monCtxt[orderUUID]; exists {
+		prev.cancel()
+	}
+	p.monCtxt[orderUUID] = monEntry{cancel: cancel, token: token}
 	p.ctxMu.Unlock()
 
 	defer cancel() // Ensure the context is cancelled when the monitoring stops.
 	defer func() {
 		p.ctxMu.Lock()
-		delete(p.monCtxt, orderUUID) // Clean up the map when monitoring ends.
+		// Only delete our own entry: a newer monitor may have replaced us in the
+		// map (it cancelled us above), and removing it would orphan that monitor.
+		if cur, ok := p.monCtxt[orderUUID]; ok && cur.token == token {
+			delete(p.monCtxt, orderUUID) // Clean up the map when monitoring ends.
+		}
 		p.ctxMu.Unlock()
 	}()
 
@@ -488,12 +538,46 @@ func (p *Processor) CancelMonitorPayment(orderUUID string) error {
 	p.ctxMu.Lock()
 	defer p.ctxMu.Unlock()
 
-	if cancel, exists := p.monCtxt[orderUUID]; exists {
-		cancel()                     // Cancel the monitoring context.
+	if entry, exists := p.monCtxt[orderUUID]; exists {
+		entry.cancel()               // Cancel the monitoring context.
 		delete(p.monCtxt, orderUUID) // Clean up the map.
 		return nil
 	}
 	return fmt.Errorf("no monitoring process found for order ID: %s", orderUUID)
+}
+
+// StopAllMonitors cancels the processor-wide monitor parent context (stopping
+// every in-process payment monitor) and waits for the in-flight monitor
+// goroutines to return, or until ctx is done. It is called from App.Stop after
+// the workers are stopped but BEFORE the DB is closed, so monitors never write to
+// a closed connection pool. Safe to call more than once.
+func (p *Processor) StopAllMonitors(ctx context.Context) {
+	if p.monParentCancel != nil {
+		p.monParentCancel()
+	}
+
+	// Also cancel any per-order entries explicitly (belt-and-suspenders: they all
+	// derive from monParentCtx, but this releases their cancel funcs promptly).
+	p.ctxMu.Lock()
+	for uuid, entry := range p.monCtxt {
+		entry.cancel()
+		delete(p.monCtxt, uuid)
+	}
+	p.ctxMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		p.monWg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		slog.Default().InfoContext(ctx, "all stripe payment monitors stopped")
+	case <-ctx.Done():
+		slog.Default().WarnContext(ctx, "timed out waiting for stripe payment monitors to stop",
+			slog.String("err", ctx.Err().Error()))
+	}
 }
 
 func (p *Processor) ExpirationDuration() time.Duration {
@@ -650,7 +734,7 @@ func (p *Processor) GetOrCreatePreOrderPaymentIntent(ctx context.Context, idempo
 
 	// Valid session - return existing PI (reconstruct for response; ClientSecret is in sess)
 	return &stripe.PaymentIntent{
-		ID:          sess.PaymentIntentID,
+		ID:           sess.PaymentIntentID,
 		ClientSecret: sess.ClientSecret,
 	}, "", nil
 }
@@ -742,7 +826,10 @@ func (p *Processor) UpdatePaymentIntentWithOrderNew(ctx context.Context, payment
 	return nil
 }
 
-// StartMonitoringPayment starts monitoring an existing payment
+// StartMonitoringPayment starts monitoring an existing payment in a background
+// goroutine. The monitor's cancellation is tied to the processor's parent
+// context (monParentCtx), not the supplied ctx, so it survives the caller's
+// request returning and is stopped centrally via StopAllMonitors at shutdown.
 func (p *Processor) StartMonitoringPayment(ctx context.Context, orderUUID string, payment entity.Payment) {
 	go p.monitorPayment(ctx, orderUUID, &payment)
 }

--- a/internal/payment/stripe/stripe.go
+++ b/internal/payment/stripe/stripe.go
@@ -2,9 +2,11 @@ package stripe
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
-	"time"
 
 	"github.com/jekabolt/grbpwr-manager/internal/analytics/ga4mp"
 	curr "github.com/jekabolt/grbpwr-manager/internal/currency"
@@ -178,15 +180,57 @@ func trimSecret(s string) string {
 	return s[:index]
 }
 
+// RefundIdempotencyKey derives a DETERMINISTIC Stripe idempotency key for a refund
+// from its scope, so that a retry of the same refund AND two concurrent identical
+// refund calls reuse the same key — Stripe then dedupes the operation server-side and
+// only moves money once. The key changes when the scope changes (different items,
+// quantities, shipping flag, full-vs-partial, or amount), so distinct partial refunds
+// of the same order still get distinct keys.
+//
+// orderItemIDs may contain repeated IDs (each occurrence = 1 unit); empty = full refund.
+func RefundIdempotencyKey(orderUUID string, orderItemIDs []int32, refundShipping bool, amount *decimal.Decimal, currency string) string {
+	// Canonicalize the item scope: count units per id, then emit in sorted id order so
+	// input ordering does not affect the key.
+	counts := make(map[int32]int, len(orderItemIDs))
+	for _, id := range orderItemIDs {
+		counts[id]++
+	}
+	ids := make([]int32, 0, len(counts))
+	for id := range counts {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	full := len(orderItemIDs) == 0
+	var b strings.Builder
+	fmt.Fprintf(&b, "scope=%t;shipping=%t;currency=%s;items=", full, refundShipping, currency)
+	for _, id := range ids {
+		fmt.Fprintf(&b, "%d:%d,", id, counts[id])
+	}
+	b.WriteString(";amount=")
+	if amount != nil {
+		b.WriteString(dto.RoundForCurrency(*amount, currency).String())
+	} else {
+		b.WriteString("full")
+	}
+
+	sum := sha256.Sum256([]byte(b.String()))
+	return "refund:" + orderUUID + ":" + hex.EncodeToString(sum[:])
+}
+
 // Refund creates a refund for the order via Stripe API.
 // If amount is nil, performs full refund. Otherwise refunds the specified amount in the given currency.
 // Requires payment with valid ClientSecret (PaymentIntent) and IsTransactionDone.
-// Each refund call generates a unique idempotency key based on orderUUID + timestamp to support
-// multiple partial refunds for the same order.
-func (p *Processor) Refund(ctx context.Context, payment entity.Payment, orderUUID string, amount *decimal.Decimal, currency string) error {
+// idempotencyKey MUST be derived deterministically from the refund scope (see
+// RefundIdempotencyKey) so that retries and concurrent identical refunds dedupe at
+// Stripe instead of issuing a second refund.
+func (p *Processor) Refund(ctx context.Context, payment entity.Payment, orderUUID string, amount *decimal.Decimal, currency string, idempotencyKey string) error {
 	ok := payment.ClientSecret.Valid
 	if !ok {
 		return fmt.Errorf("payment has no client secret (PaymentIntent)")
+	}
+	if idempotencyKey == "" {
+		return fmt.Errorf("refund idempotency key is empty")
 	}
 
 	paymentIntentID := trimSecret(payment.ClientSecret.String)
@@ -211,9 +255,8 @@ func (p *Processor) Refund(ctx context.Context, payment entity.Payment, orderUUI
 		params.Amount = stripe.Int64(amountCents)
 	}
 
-	// Use unique idempotency key per refund operation to support multiple partial refunds.
-	// Format: orderUUID_refund_<timestamp> ensures each refund call is unique.
-	idempotencyKey := fmt.Sprintf("%s_refund_%d", orderUUID, time.Now().UTC().UnixNano())
+	// Deterministic idempotency key: retries and concurrent identical refunds reuse the
+	// same key, so Stripe refunds the money at most once for this scope.
 	params.SetIdempotencyKey(idempotencyKey)
 
 	_, err := p.stripeClient.Refunds.New(params)

--- a/internal/revalidation/revalidation.go
+++ b/internal/revalidation/revalidation.go
@@ -69,6 +69,24 @@ func New(ctx context.Context, c *Config) (*Revalidator, error) {
 	return v, nil
 }
 
+// disabledRevalidator is a no-op implementation of dependency.RevalidationService.
+// It is used as a safe fallback when the real revalidator cannot be constructed,
+// so the storefront/admin can still boot and serve while ISR revalidation is
+// simply skipped (storefront caches go stale until the next successful write
+// against a working revalidator, rather than crash-looping the whole process).
+type disabledRevalidator struct{}
+
+// NewDisabled returns a no-op RevalidationService. RevalidateAll always succeeds
+// without contacting Vercel.
+func NewDisabled() *disabledRevalidator {
+	return &disabledRevalidator{}
+}
+
+func (*disabledRevalidator) RevalidateAll(ctx context.Context, _ *dto.RevalidationData) error {
+	slog.Default().DebugContext(ctx, "revalidation disabled; skipping RevalidateAll")
+	return nil
+}
+
 func (v *Revalidator) getDeployments(ctx context.Context) ([]*dto.Deployment, error) {
 	url := fmt.Sprintf("%s?projectId=%s&state=READY&limit=3", vercelApiUrl, v.c.ProjectId)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)

--- a/internal/saferun/saferun.go
+++ b/internal/saferun/saferun.go
@@ -1,0 +1,33 @@
+// Package saferun provides a small helper to recover panics in background
+// worker loops, so a panic in a single iteration is logged (with stack) and the
+// loop continues instead of crashing the whole process.
+package saferun
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+)
+
+// Recover recovers a panic in a deferred call, logs it with stack via log/slog
+// (tagged with the worker name), and allows the caller to continue.
+//
+// Use it as the first deferred call inside the per-iteration work function of a
+// worker loop, e.g.:
+//
+//	func (w *Worker) runOnce(ctx context.Context) {
+//	    defer saferun.Recover(ctx, "my-worker")
+//	    // ... per-tick work ...
+//	}
+//
+// Placed there, a panic unwinds to this defer, is recovered, the function
+// returns, and the surrounding for/select loop proceeds to the next tick.
+func Recover(ctx context.Context, name string) {
+	if r := recover(); r != nil {
+		slog.ErrorContext(ctx, "panic recovered",
+			slog.String("worker", name),
+			slog.Any("panic", r),
+			slog.String("stack", string(debug.Stack())),
+		)
+	}
+}

--- a/internal/stockreserve/reserve.go
+++ b/internal/stockreserve/reserve.go
@@ -7,8 +7,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jekabolt/grbpwr-manager/internal/health"
+	"github.com/jekabolt/grbpwr-manager/internal/saferun"
 	"github.com/shopspring/decimal"
 )
+
+// cleanupTickTimeout bounds a single cleanup tick. The work is in-memory and
+// holds rm.mu, so this guards against a pathological tick wedging the loop (and
+// indirectly any caller waiting on the lock); it also bounds the ctx passed to
+// logging.
+const cleanupTickTimeout = 15 * time.Second
 
 // Limits configures abuse prevention thresholds
 type Limits struct {
@@ -56,18 +64,25 @@ type sessionRateEntry struct {
 
 // Manager handles stock reservations with TTL and abuse prevention
 type Manager struct {
-	mu           sync.RWMutex
-	reservations map[string]*Reservation        // key: "productID-sizeID-sessionID"
-	bySession    map[string][]string             // sessionID -> reservation keys
-	byOrder      map[string][]string             // orderUUID -> reservation keys
-	byProductSize map[productSizeKey][]string    // (productID, sizeID) -> reservation keys (O(1) lookup)
-	sessionRates map[string]*sessionRateEntry    // per-session call rate
-	cartTTL      time.Duration
-	orderTTL     time.Duration
-	limits       Limits
-	stopCh       chan struct{}
-	stopOnce     sync.Once
+	mu            sync.RWMutex
+	reservations  map[string]*Reservation      // key: "productID-sizeID-sessionID"
+	bySession     map[string][]string          // sessionID -> reservation keys
+	byOrder       map[string][]string          // orderUUID -> reservation keys
+	byProductSize map[productSizeKey][]string  // (productID, sizeID) -> reservation keys (O(1) lookup)
+	sessionRates  map[string]*sessionRateEntry // per-session call rate
+	cartTTL       time.Duration
+	orderTTL      time.Duration
+	limits        Limits
+	stopCh        chan struct{}
+	stopOnce      sync.Once
+	tracker       health.Tracker
 }
+
+// Name implements health.Reporter.
+func (rm *Manager) Name() string { return "stockreserve" }
+
+// LastSuccess implements health.Reporter (zero time until the first clean cleanup tick).
+func (rm *Manager) LastSuccess() time.Time { return rm.tracker.LastSuccess() }
 
 // NewManager creates a new reservation manager with abuse prevention
 func NewManager(cartTTL, orderTTL time.Duration, limits Limits) *Manager {
@@ -307,45 +322,59 @@ func (rm *Manager) cleanup() {
 		case <-rm.stopCh:
 			return
 		case <-ticker.C:
-			rm.mu.Lock()
-			now := time.Now().UTC()
-			expiredCount := 0
-
-			for key, res := range rm.reservations {
-				if now.After(res.ExpiresAt) {
-					rm.removeReservation(key, res)
-
-					// Clean up byOrder
-					if res.OrderUUID != "" {
-						if orderKeys, ok := rm.byOrder[res.OrderUUID]; ok {
-							rm.byOrder[res.OrderUUID] = removeKey(orderKeys, key)
-							if len(rm.byOrder[res.OrderUUID]) == 0 {
-								delete(rm.byOrder, res.OrderUUID)
-							}
-						}
-					}
-
-					expiredCount++
-				}
-			}
-
-			// Clean up expired session rate entries
-			for sid, entry := range rm.sessionRates {
-				if now.After(entry.expiresAt) {
-					delete(rm.sessionRates, sid)
-				}
-			}
-
-			if expiredCount > 0 {
-				slog.Default().Debug("cleaned up expired reservations",
-					slog.Int("count", expiredCount),
-					slog.Int("remaining", len(rm.reservations)),
-				)
-			}
-
-			rm.mu.Unlock()
+			rm.runCleanupOnce()
 		}
 	}
+}
+
+// runCleanupOnce removes expired reservations for a single tick. The deferred
+// saferun.Recover keeps a panic in this iteration from killing the cleanup loop
+// (and the whole process). It also guarantees the mutex is released on panic.
+func (rm *Manager) runCleanupOnce() {
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupTickTimeout)
+	defer cancel()
+	defer saferun.Recover(ctx, "stockreserve-cleanup")
+
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	now := time.Now().UTC()
+	expiredCount := 0
+
+	for key, res := range rm.reservations {
+		if now.After(res.ExpiresAt) {
+			rm.removeReservation(key, res)
+
+			// Clean up byOrder
+			if res.OrderUUID != "" {
+				if orderKeys, ok := rm.byOrder[res.OrderUUID]; ok {
+					rm.byOrder[res.OrderUUID] = removeKey(orderKeys, key)
+					if len(rm.byOrder[res.OrderUUID]) == 0 {
+						delete(rm.byOrder, res.OrderUUID)
+					}
+				}
+			}
+
+			expiredCount++
+		}
+	}
+
+	// Clean up expired session rate entries
+	for sid, entry := range rm.sessionRates {
+		if now.After(entry.expiresAt) {
+			delete(rm.sessionRates, sid)
+		}
+	}
+
+	if expiredCount > 0 {
+		slog.Default().Debug("cleaned up expired reservations",
+			slog.Int("count", expiredCount),
+			slog.Int("remaining", len(rm.reservations)),
+		)
+	}
+
+	// The cleanup tick is in-memory and cannot fail; reaching here is a success.
+	rm.tracker.MarkSuccess()
 }
 
 // removeReservation removes a reservation and cleans up all indexes.
@@ -410,12 +439,12 @@ func (rm *Manager) GetStats() map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"total_reservations":  len(rm.reservations),
-		"cart_reservations":   cartReservations,
-		"order_reservations":  orderReservations,
-		"active_sessions":     len(rm.bySession),
-		"active_orders":       len(rm.byOrder),
-		"capacity_pct":        float64(len(rm.reservations)) / float64(rm.limits.MaxTotalReservations) * 100,
+		"total_reservations": len(rm.reservations),
+		"cart_reservations":  cartReservations,
+		"order_reservations": orderReservations,
+		"active_sessions":    len(rm.bySession),
+		"active_orders":      len(rm.byOrder),
+		"capacity_pct":       float64(len(rm.reservations)) / float64(rm.limits.MaxTotalReservations) * 100,
 	}
 }
 

--- a/internal/store/order/insert.go
+++ b/internal/store/order/insert.go
@@ -225,9 +225,19 @@ func (s *Store) insertOrderDetails(ctx context.Context, db dependency.DB, order 
 	return nil
 }
 
+// insertRefundedOrderItems records newly refunded units in the refunded_order_item ledger.
+// The ledger has a UNIQUE (order_id, order_item_id); ON DUPLICATE KEY UPDATE accumulates
+// the quantity so repeated partial refunds of distinct units sum into one row, and a
+// retried full refund (where qty is 0 because no new units remain) is a no-op. This keeps
+// the whole RefundOrder transaction idempotent against a re-run.
 func insertRefundedOrderItems(ctx context.Context, db dependency.DB, orderId int, refundedByItem map[int]int64) error {
 	for orderItemId, qty := range refundedByItem {
-		query := `INSERT INTO refunded_order_item (order_id, order_item_id, quantity_refunded) VALUES (:orderId, :orderItemId, :quantityRefunded)`
+		if qty <= 0 {
+			continue
+		}
+		query := `INSERT INTO refunded_order_item (order_id, order_item_id, quantity_refunded)
+			VALUES (:orderId, :orderItemId, :quantityRefunded)
+			ON DUPLICATE KEY UPDATE quantity_refunded = quantity_refunded + VALUES(quantity_refunded)`
 		if err := storeutil.ExecNamed(ctx, db, query, map[string]any{
 			"orderId":          orderId,
 			"orderItemId":      orderItemId,

--- a/internal/store/order/lifecycle.go
+++ b/internal/store/order/lifecycle.go
@@ -96,9 +96,13 @@ func refundCoversFullOrder(orderItems []entity.OrderItem, orderItemIDs []int32, 
 
 // determineRefundScope determines which items to refund and the target status based on
 // the current order status and requested item IDs.
+//
+// alreadyRefunded (read from the refunded_order_item ledger under FOR UPDATE) makes this
+// idempotent: full-refund paths expand only the REMAINING (not-yet-refunded) units, so a
+// re-run of an already-completed refund restores zero stock.
 func determineRefundScope(currentStatus entity.OrderStatusName, orderItems []entity.OrderItem, orderItemIDs []int32, alreadyRefunded map[int]int64) ([]refundItem, *cache.Status, error) {
 	if currentStatus == entity.Confirmed {
-		return orderItemsToRefundItems(orderItems), &cache.OrderStatusRefunded, nil
+		return orderItemsToRefundItems(orderItems, alreadyRefunded), &cache.OrderStatusRefunded, nil
 	}
 
 	partialItems, err := validateAndMapOrderItems(orderItems, orderItemIDs, alreadyRefunded)
@@ -107,20 +111,28 @@ func determineRefundScope(currentStatus entity.OrderStatusName, orderItems []ent
 	}
 
 	if partialItems == nil {
-		return orderItemsToRefundItems(orderItems), &cache.OrderStatusRefunded, nil
+		return orderItemsToRefundItems(orderItems, alreadyRefunded), &cache.OrderStatusRefunded, nil
 	}
 
 	if refundCoversFullOrder(orderItems, orderItemIDs, alreadyRefunded) {
-		return orderItemsToRefundItems(orderItems), &cache.OrderStatusRefunded, nil
+		return orderItemsToRefundItems(orderItems, alreadyRefunded), &cache.OrderStatusRefunded, nil
 	}
 
 	return partialItems, &cache.OrderStatusPartiallyRefunded, nil
 }
 
-func orderItemsToRefundItems(orderItems []entity.OrderItem) []refundItem {
-	out := make([]refundItem, len(orderItems))
-	for i, item := range orderItems {
-		out[i] = refundItem{OrderItemId: item.Id, OrderItemInsert: item.OrderItemInsert}
+// orderItemsToRefundItems expands each order item into one refundItem per remaining
+// (not-yet-refunded) unit. Units already recorded in the refunded_order_item ledger are
+// skipped so stock is restored only once even if the refund is retried.
+func orderItemsToRefundItems(orderItems []entity.OrderItem, alreadyRefunded map[int]int64) []refundItem {
+	out := make([]refundItem, 0, len(orderItems))
+	for _, item := range orderItems {
+		remaining := item.Quantity.IntPart() - alreadyRefunded[item.Id]
+		for i := int64(0); i < remaining; i++ {
+			insert := item.OrderItemInsert
+			insert.Quantity = decimal.NewFromInt(1)
+			out = append(out, refundItem{OrderItemId: item.Id, OrderItemInsert: insert})
+		}
 	}
 	return out
 }
@@ -277,7 +289,7 @@ func (s *Store) RefundOrder(ctx context.Context, orderUUID string, orderItemIDs 
 // DeliveredOrder updates order status to Delivered.
 func (s *Store) DeliveredOrder(ctx context.Context, orderUUID string) error {
 	err := s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
-		order, err := getOrderByUUID(ctx, rep.DB(), orderUUID)
+		order, err := getOrderByUUIDForUpdate(ctx, rep.DB(), orderUUID)
 		if err != nil {
 			return fmt.Errorf("can't get order by id: %w", err)
 		}

--- a/internal/store/order/lifecycle.go
+++ b/internal/store/order/lifecycle.go
@@ -272,13 +272,21 @@ func (s *Store) RefundOrder(ctx context.Context, orderUUID string, orderItemIDs 
 
 		refundedAmount := refundAmountFromItems(itemsForStock, order.Currency)
 
-		if refundShipping {
+		// Shipping is refunded at most once. order was read FOR UPDATE above, so
+		// order.ShippingRefunded reflects the locked row: a second partial refund
+		// with refundShipping=true skips the shipping portion (without erroring the
+		// whole refund) instead of adding the shipping cost twice. Free-shipping
+		// orders never add cost and so never set the marker.
+		if refundShipping && !order.ShippingRefunded {
 			shipment, err := getOrderShipment(ctx, rep.DB(), order.Id)
 			if err != nil {
 				return fmt.Errorf("get order shipment: %w", err)
 			}
 			if !shipment.FreeShipping {
 				refundedAmount = refundedAmount.Add(shipment.CostDecimal(order.Currency))
+				if err := markShippingRefunded(ctx, rep.DB(), order.Id); err != nil {
+					return fmt.Errorf("mark shipping refunded: %w", err)
+				}
 			}
 		}
 

--- a/internal/store/order/refund.go
+++ b/internal/store/order/refund.go
@@ -22,6 +22,17 @@ func refundAmountFromItems(items []entity.OrderItemInsert, currency string) deci
 	return dto.RoundForCurrency(sum, currency)
 }
 
+// markShippingRefunded flags that the shipping cost has been refunded for this
+// order so a subsequent partial refund cannot refund it again. Must be called
+// within the RefundOrder transaction that holds the customer_order row FOR UPDATE.
+func markShippingRefunded(ctx context.Context, db dependency.DB, orderId int) error {
+	query := `UPDATE customer_order SET shipping_refunded = TRUE WHERE id = :orderId`
+	if err := storeutil.ExecNamed(ctx, db, query, map[string]any{"orderId": orderId}); err != nil {
+		return fmt.Errorf("update shipping_refunded: %w", err)
+	}
+	return nil
+}
+
 // stockRestoreMode describes how stock should be handled when cancelling an
 // order in a given status. Stock is only ever reduced on the
 // Placed -> AwaitingPayment transition (InsertFiatInvoice), so restoring it for

--- a/internal/store/sql/0061_refunded_order_item_unique.sql
+++ b/internal/store/sql/0061_refunded_order_item_unique.sql
@@ -1,0 +1,45 @@
+-- +migrate Up
+-- Make refunded_order_item the authoritative idempotency ledger for refunds:
+-- one row per (order_id, order_item_id). The RefundOrder transaction restores stock
+-- only for order items NOT already present here, and inserts with ON DUPLICATE KEY,
+-- so a retry after a partial failure (Stripe succeeded, DB step failed) cannot
+-- double-restore stock or double-count refunded quantity.
+--
+-- Historically the table allowed many rows per (order_id, order_item_id): each partial
+-- refund inserted a new row and reads aggregated with SUM(quantity_refunded). Before
+-- adding the UNIQUE index we must collapse those groups WITHOUT losing already-refunded
+-- quantity: fold the summed quantity into the surviving row, then delete the rest.
+
+-- 1) Fold each duplicate group's total refunded quantity into the lowest-id row of the
+--    group, so the surviving row carries the full historical quantity.
+UPDATE refunded_order_item r
+JOIN (
+  SELECT MIN(id) AS keep_id, order_id, order_item_id, SUM(quantity_refunded) AS total_qty
+  FROM refunded_order_item
+  GROUP BY order_id, order_item_id
+  HAVING COUNT(*) > 1
+) agg
+  ON r.id = agg.keep_id
+SET r.quantity_refunded = agg.total_qty;
+
+-- 2) Delete the now-redundant duplicate rows, keeping only the lowest-id row per
+--    (order_id, order_item_id).
+DELETE r FROM refunded_order_item r
+JOIN (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY order_id, order_item_id
+           ORDER BY id ASC
+         ) AS rn
+  FROM refunded_order_item
+) ranked
+  ON r.id = ranked.id
+WHERE ranked.rn > 1;
+
+-- 3) Enforce one ledger row per (order_id, order_item_id).
+ALTER TABLE refunded_order_item
+  ADD UNIQUE INDEX uniq_refunded_order_item (order_id, order_item_id);
+
+-- +migrate Down
+ALTER TABLE refunded_order_item
+  DROP INDEX uniq_refunded_order_item;

--- a/internal/store/sql/0062_add_performance_indexes.sql
+++ b/internal/store/sql/0062_add_performance_indexes.sql
@@ -1,0 +1,100 @@
+-- +migrate Up
+-- Forward-looking performance indexes.
+--
+-- These tables are small today (hundreds of rows), so the query planner still
+-- prefers full scans and these indexes have little immediate effect. They are
+-- added now because customer_order, payment and send_email_request grow with
+-- traffic and are full-scanned by the metrics rollups and the cleanup/retry
+-- workers; the indexes prevent that scan cost from growing linearly with data.
+--
+-- Each ADD is guarded via information_schema (same idiom as 0033) so the
+-- statement is idempotent: re-running it, or running it when the index already
+-- exists, is a no-op. This matters because auto-migrate runs on prod and halts
+-- startup on any failed statement.
+
+-- customer_order(order_status_id, placed)
+-- Serves the metrics suite (order_status_id IN (...) AND placed >= :from AND placed < :to),
+-- GetStuckPlacedOrders (order_status_id = ? AND placed < ?) and the expired-payment join.
+-- For each status value the IN expands to a tight (status, placed-range) index scan.
+-- Note: this is a superset of the existing single-column idx_customer_order_status_id
+-- (left-most prefix), which is kept as-is to keep this migration minimal and low-risk.
+SET @sql = IF(
+    (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'customer_order' AND index_name = 'idx_customer_order_status_placed') > 0,
+    'SELECT 1',
+    'ALTER TABLE customer_order ADD INDEX idx_customer_order_status_placed (order_status_id, placed)'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- payment(expired_at)
+-- GetExpiredAwaitingPaymentOrders + stripereconcile filter: p.expired_at IS NOT NULL AND p.expired_at < :now.
+SET @sql = IF(
+    (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'payment' AND index_name = 'idx_payment_expired_at') > 0,
+    'SELECT 1',
+    'ALTER TABLE payment ADD INDEX idx_payment_expired_at (expired_at)'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- send_email_request(sent, next_retry_at)
+-- Retry worker scans: sent = false AND send_attempt_count < ? AND (next_retry_at IS NULL OR next_retry_at <= ?).
+-- The index lets it seek straight to the few unsent rows instead of scanning every row
+-- (each carries a large inline HTML body) on every tick.
+SET @sql = IF(
+    (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'send_email_request' AND index_name = 'idx_send_email_request_pending') > 0,
+    'SELECT 1',
+    'ALTER TABLE send_email_request ADD INDEX idx_send_email_request_pending (sent, next_retry_at)'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- subscriber(created_at)
+-- Newsletter time-series metrics range/group on created_at.
+SET @sql = IF(
+    (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'subscriber' AND index_name = 'idx_subscriber_created_at') > 0,
+    'SELECT 1',
+    'ALTER TABLE subscriber ADD INDEX idx_subscriber_created_at (created_at)'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- +migrate Down
+SET @sql = IF(
+    (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'customer_order' AND index_name = 'idx_customer_order_status_placed') > 0,
+    'ALTER TABLE customer_order DROP INDEX idx_customer_order_status_placed',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(
+    (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'payment' AND index_name = 'idx_payment_expired_at') > 0,
+    'ALTER TABLE payment DROP INDEX idx_payment_expired_at',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(
+    (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'send_email_request' AND index_name = 'idx_send_email_request_pending') > 0,
+    'ALTER TABLE send_email_request DROP INDEX idx_send_email_request_pending',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(
+    (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'subscriber' AND index_name = 'idx_subscriber_created_at') > 0,
+    'ALTER TABLE subscriber DROP INDEX idx_subscriber_created_at',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/internal/store/sql/0063_add_shipping_refunded.sql
+++ b/internal/store/sql/0063_add_shipping_refunded.sql
@@ -1,0 +1,32 @@
+-- +migrate Up
+-- Track whether the shipping cost has already been refunded for an order.
+--
+-- A PartiallyRefunded order can be refunded again (RefundOrder allows it), so two
+-- partial refunds each with refundShipping=true would add shipment.cost to
+-- refunded_amount (and the Stripe charge) twice. This boolean marker, set inside the
+-- refund transaction that holds the customer_order row FOR UPDATE, lets the refund
+-- logic add the shipping cost at most once.
+--
+-- Additive ADD COLUMN of a defaulted (NOT NULL DEFAULT FALSE) column is safe against
+-- existing prod data — every existing row gets FALSE. The information_schema guard
+-- (same idiom as 0033/0062) makes the statement idempotent so a re-run, or running it
+-- when the column already exists, is a no-op; this matters because auto-migrate runs
+-- on prod and halts startup on any failed statement.
+SET @sql = IF(
+    (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'customer_order' AND column_name = 'shipping_refunded') > 0,
+    'SELECT 1',
+    'ALTER TABLE customer_order ADD COLUMN shipping_refunded BOOLEAN NOT NULL DEFAULT FALSE COMMENT ''Whether the shipping cost has already been refunded for this order'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- +migrate Down
+SET @sql = IF(
+    (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'customer_order' AND column_name = 'shipping_refunded') > 0,
+    'ALTER TABLE customer_order DROP COLUMN shipping_refunded',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
+	"github.com/jekabolt/grbpwr-manager/internal/health"
 	"github.com/jekabolt/grbpwr-manager/internal/store/account"
 	"github.com/jekabolt/grbpwr-manager/internal/store/admin"
 	"github.com/jekabolt/grbpwr-manager/internal/store/bqcache"
@@ -38,13 +39,41 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/database/mysql"
 )
 
+// Default connection-pool lifetimes used when the corresponding config field
+// is unset (zero). A 5m lifetime avoids frequent TLS re-handshakes to managed
+// MySQL under steady load while still cycling connections regularly.
+const (
+	defaultConnMaxLifetime = 5 * time.Minute
+	defaultConnMaxIdleTime = 1 * time.Minute
+)
+
 // Config defines configurations to connect database
 type Config struct {
-	DSN                string `mapstructure:"dsn"`
-	Automigrate        bool   `mapstructure:"automigrate"`
-	MaxOpenConnections int    `mapstructure:"max_open_connections"`
-	MaxIdleConnections int    `mapstructure:"max_idle_connections"`
-	TLSCAPath          string `mapstructure:"tls_ca_path"`
+	DSN                string        `mapstructure:"dsn"`
+	Automigrate        bool          `mapstructure:"automigrate"`
+	MaxOpenConnections int           `mapstructure:"max_open_connections"`
+	MaxIdleConnections int           `mapstructure:"max_idle_connections"`
+	ConnMaxLifetime    time.Duration `mapstructure:"conn_max_lifetime"`
+	ConnMaxIdleTime    time.Duration `mapstructure:"conn_max_idle_time"`
+	TLSCAPath          string        `mapstructure:"tls_ca_path"`
+}
+
+// connMaxLifetime returns the configured connection max lifetime or the default
+// when unset.
+func (c Config) connMaxLifetime() time.Duration {
+	if c.ConnMaxLifetime > 0 {
+		return c.ConnMaxLifetime
+	}
+	return defaultConnMaxLifetime
+}
+
+// connMaxIdleTime returns the configured connection max idle time or the default
+// when unset.
+func (c Config) connMaxIdleTime() time.Duration {
+	if c.ConnMaxIdleTime > 0 {
+		return c.ConnMaxIdleTime
+	}
+	return defaultConnMaxIdleTime
 }
 
 // MYSQLStore implements methods to access MYSQL database
@@ -146,8 +175,8 @@ func New(ctx context.Context, cfg Config) (*MYSQLStore, error) {
 	if cfg.MaxIdleConnections > 0 {
 		d.SetMaxIdleConns(cfg.MaxIdleConnections)
 	}
-	d.SetConnMaxLifetime(2 * time.Minute)
-	d.SetConnMaxIdleTime(30 * time.Second)
+	d.SetConnMaxLifetime(cfg.connMaxLifetime())
+	d.SetConnMaxIdleTime(cfg.connMaxIdleTime())
 
 	pingCtx, pingCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer pingCancel()
@@ -256,8 +285,8 @@ func NewForTest(ctx context.Context, cfg Config) (*MYSQLStore, error) {
 	if cfg.MaxIdleConnections > 0 {
 		d.SetMaxIdleConns(cfg.MaxIdleConnections)
 	}
-	d.SetConnMaxLifetime(2 * time.Minute)
-	d.SetConnMaxIdleTime(30 * time.Second)
+	d.SetConnMaxLifetime(cfg.connMaxLifetime())
+	d.SetConnMaxIdleTime(cfg.connMaxIdleTime())
 
 	pingCtx, pingCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer pingCancel()
@@ -339,6 +368,29 @@ func initSubStoresForTx(txStore *MYSQLStore, outerTx func(context.Context, func(
 
 func (ms *MYSQLStore) Close() {
 	ms.close()
+}
+
+// Stats returns connection-pool statistics for the underlying *sql.DB, mapped
+// into health.DBStats so the http/health packages don't import database/sql or
+// the store. ms.db is a *sqlx.DB (see store.New: d.Unsafe()), which embeds the
+// *sql.DB whose Stats() this reports. Returns a zero value if the handle does
+// not expose Stats (e.g. inside a transaction), so the status endpoint degrades
+// gracefully instead of panicking.
+func (ms *MYSQLStore) Stats() health.DBStats {
+	type statser interface{ Stats() sql.DBStats }
+	s, ok := ms.db.(statser)
+	if !ok {
+		return health.DBStats{}
+	}
+	st := s.Stats()
+	return health.DBStats{
+		OpenConnections:    st.OpenConnections,
+		InUse:              st.InUse,
+		Idle:               st.Idle,
+		WaitCount:          st.WaitCount,
+		WaitDuration:       st.WaitDuration,
+		MaxOpenConnections: st.MaxOpenConnections,
+	}
 }
 
 // Ping checks database connectivity by executing a simple query

--- a/internal/storefrontcleanup/storefrontcleanup.go
+++ b/internal/storefrontcleanup/storefrontcleanup.go
@@ -9,7 +9,13 @@ import (
 	"log/slog"
 
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
+	"github.com/jekabolt/grbpwr-manager/internal/health"
+	"github.com/jekabolt/grbpwr-manager/internal/saferun"
 )
+
+// tickTimeout bounds the DB work done in a single cleanup tick, so one stuck
+// query can't block the loop forever or stall graceful shutdown.
+const tickTimeout = 30 * time.Second
 
 // Config holds configuration for the storefront cleanup worker.
 type Config struct {
@@ -25,12 +31,19 @@ func DefaultConfig() Config {
 
 // Worker deletes expired rows from storefront auth tables (JTI denylist, login challenges, refresh tokens).
 type Worker struct {
-	repo dependency.Repository
-	c    *Config
-	ctx  context.Context
-	stop context.CancelFunc
-	wg   sync.WaitGroup
+	repo    dependency.Repository
+	c       *Config
+	ctx     context.Context
+	stop    context.CancelFunc
+	wg      sync.WaitGroup
+	tracker health.Tracker
 }
+
+// Name implements health.Reporter.
+func (w *Worker) Name() string { return "storefrontcleanup" }
+
+// LastSuccess implements health.Reporter (zero time until the first clean tick).
+func (w *Worker) LastSuccess() time.Time { return w.tracker.LastSuccess() }
 
 // New creates a new storefront cleanup worker.
 func New(c *Config, repo dependency.Repository) *Worker {
@@ -86,10 +99,19 @@ func (w *Worker) worker(ctx context.Context) {
 }
 
 func (w *Worker) runCleanup(ctx context.Context) {
+	defer saferun.Recover(ctx, "storefrontcleanup")
+
+	ctx, cancel := context.WithTimeout(ctx, tickTimeout)
+	defer cancel()
+
 	sa := w.repo.StorefrontAccount()
+
+	ok := true
 
 	jtiN, err := sa.CleanupExpiredJtiDenylist(ctx)
 	if err != nil {
+		ok = false
+		w.tracker.MarkError(err)
 		slog.Default().ErrorContext(ctx, "storefront cleanup: jti denylist failed", slog.String("err", err.Error()))
 	} else if jtiN > 0 {
 		slog.Default().InfoContext(ctx, "storefront cleanup: expired jti denylist removed", slog.Int64("count", jtiN))
@@ -97,6 +119,8 @@ func (w *Worker) runCleanup(ctx context.Context) {
 
 	challengeN, err := sa.CleanupExpiredLoginChallenges(ctx)
 	if err != nil {
+		ok = false
+		w.tracker.MarkError(err)
 		slog.Default().ErrorContext(ctx, "storefront cleanup: login challenges failed", slog.String("err", err.Error()))
 	} else if challengeN > 0 {
 		slog.Default().InfoContext(ctx, "storefront cleanup: expired login challenges removed", slog.Int64("count", challengeN))
@@ -104,8 +128,15 @@ func (w *Worker) runCleanup(ctx context.Context) {
 
 	refreshN, err := sa.CleanupExpiredRefreshTokens(ctx)
 	if err != nil {
+		ok = false
+		w.tracker.MarkError(err)
 		slog.Default().ErrorContext(ctx, "storefront cleanup: refresh tokens failed", slog.String("err", err.Error()))
 	} else if refreshN > 0 {
 		slog.Default().InfoContext(ctx, "storefront cleanup: expired refresh tokens removed", slog.Int64("count", refreshN))
+	}
+
+	// Record success only when every sub-cleanup completed without error.
+	if ok {
+		w.tracker.MarkSuccess()
 	}
 }

--- a/internal/storefrontcleanup/storefrontcleanup.go
+++ b/internal/storefrontcleanup/storefrontcleanup.go
@@ -17,6 +17,15 @@ import (
 // query can't block the loop forever or stall graceful shutdown.
 const tickTimeout = 30 * time.Second
 
+// Backoff bounds for consecutive-failure backoff. On a failed tick an extra
+// delay (base * 2^(n-1), capped at backoffMax) is waited before the next
+// iteration so a persistently failing DB isn't hammered every WorkerInterval. A
+// successful tick resets the backoff. See ga4sync for the established pattern.
+const (
+	backoffBase = 30 * time.Second
+	backoffMax  = 5 * time.Minute
+)
+
 // Config holds configuration for the storefront cleanup worker.
 type Config struct {
 	WorkerInterval time.Duration `mapstructure:"worker_interval"`
@@ -88,17 +97,54 @@ func (w *Worker) worker(ctx context.Context) {
 	ticker := time.NewTicker(w.c.WorkerInterval)
 	defer ticker.Stop()
 
+	// consecutiveFailures drives the extra backoff delay applied after a failed
+	// tick. Reset to 0 on the first successful tick.
+	var consecutiveFailures int
+
 	for {
 		select {
 		case <-ticker.C:
-			w.runCleanup(ctx)
+			if w.runCleanup(ctx) {
+				consecutiveFailures = 0
+				continue
+			}
+			consecutiveFailures++
+			delay := backoffDelay(consecutiveFailures)
+			slog.Default().WarnContext(ctx, "storefront cleanup: backing off after failed tick",
+				slog.Int("consecutive_failures", consecutiveFailures),
+				slog.Duration("delay", delay),
+			)
+			// Wait the extra backoff on top of the ticker interval, but stay
+			// responsive to shutdown — never time.Sleep blindly.
+			timer := time.NewTimer(delay)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (w *Worker) runCleanup(ctx context.Context) {
+// backoffDelay returns the extra inter-iteration delay for the given number of
+// consecutive failures: base * 2^(n-1), capped at backoffMax.
+func backoffDelay(consecutiveFailures int) time.Duration {
+	delay := backoffBase
+	for i := 1; i < consecutiveFailures; i++ {
+		delay *= 2
+		if delay >= backoffMax {
+			return backoffMax
+		}
+	}
+	return delay
+}
+
+// runCleanup performs a single cleanup tick and reports whether it fully
+// succeeded (every sub-cleanup completed without error).
+func (w *Worker) runCleanup(ctx context.Context) bool {
 	defer saferun.Recover(ctx, "storefrontcleanup")
 
 	ctx, cancel := context.WithTimeout(ctx, tickTimeout)
@@ -139,4 +185,5 @@ func (w *Worker) runCleanup(ctx context.Context) {
 	if ok {
 		w.tracker.MarkSuccess()
 	}
+	return ok
 }

--- a/internal/stripereconcile/stripereconcile.go
+++ b/internal/stripereconcile/stripereconcile.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/jekabolt/grbpwr-manager/internal/health"
 )
 
 // PreOrderPICleaner cleans up orphaned pre-order PaymentIntents from Stripe.
@@ -14,7 +16,7 @@ type PreOrderPICleaner interface {
 
 // Config holds configuration for the Stripe pre-order PI reconciliation worker.
 type Config struct {
-	WorkerInterval   time.Duration `mapstructure:"worker_interval"`
+	WorkerInterval    time.Duration `mapstructure:"worker_interval"`
 	PreOrderThreshold time.Duration `mapstructure:"pre_order_threshold"` // e.g. 24h - cancel pre_order PIs older than this
 }
 
@@ -33,7 +35,14 @@ type Worker struct {
 	ctx      context.Context
 	stop     context.CancelFunc
 	wg       sync.WaitGroup
+	tracker  health.Tracker
 }
+
+// Name implements health.Reporter.
+func (w *Worker) Name() string { return "stripereconcile" }
+
+// LastSuccess implements health.Reporter (zero time until the first clean tick).
+func (w *Worker) LastSuccess() time.Time { return w.tracker.LastSuccess() }
 
 // New creates a new Stripe reconciliation worker.
 func New(c *Config, cleaners ...PreOrderPICleaner) *Worker {

--- a/internal/stripereconcile/worker.go
+++ b/internal/stripereconcile/worker.go
@@ -4,7 +4,14 @@ import (
 	"context"
 	"log/slog"
 	"time"
+
+	"github.com/jekabolt/grbpwr-manager/internal/saferun"
 )
+
+// tickTimeout bounds the DB/Stripe work done in a single reconciliation tick, so
+// one stuck query or hung connection can't block the loop forever or stall
+// graceful shutdown.
+const tickTimeout = 30 * time.Second
 
 func (w *Worker) worker(ctx context.Context) {
 	ticker := time.NewTicker(w.c.WorkerInterval)
@@ -13,19 +20,39 @@ func (w *Worker) worker(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			olderThan := time.Now().UTC().Add(-w.c.PreOrderThreshold)
-			for _, c := range w.cleaners {
-				if err := ctx.Err(); err != nil {
-					return
-				}
-				if err := c.CleanupOrphanedPreOrderPaymentIntents(ctx, olderThan); err != nil {
-					slog.Default().ErrorContext(ctx, "stripe reconcile: cleanup orphaned pre-order PIs failed",
-						slog.String("err", err.Error()),
-					)
-				}
-			}
+			w.runOnce(ctx)
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+// runOnce performs a single reconciliation tick. The deferred saferun.Recover
+// keeps a panic in this iteration from killing the worker loop.
+func (w *Worker) runOnce(ctx context.Context) {
+	defer saferun.Recover(ctx, "stripereconcile")
+
+	ctx, cancel := context.WithTimeout(ctx, tickTimeout)
+	defer cancel()
+
+	olderThan := time.Now().UTC().Add(-w.c.PreOrderThreshold)
+	ok := true
+	for _, c := range w.cleaners {
+		if err := ctx.Err(); err != nil {
+			// Aborted mid-tick (shutdown / timeout): don't record success.
+			return
+		}
+		if err := c.CleanupOrphanedPreOrderPaymentIntents(ctx, olderThan); err != nil {
+			ok = false
+			w.tracker.MarkError(err)
+			slog.Default().ErrorContext(ctx, "stripe reconcile: cleanup orphaned pre-order PIs failed",
+				slog.String("err", err.Error()),
+			)
+		}
+	}
+
+	// Record success only when every cleaner completed without error.
+	if ok {
+		w.tracker.MarkSuccess()
 	}
 }

--- a/internal/stripereconcile/worker.go
+++ b/internal/stripereconcile/worker.go
@@ -13,23 +13,69 @@ import (
 // graceful shutdown.
 const tickTimeout = 30 * time.Second
 
+// Backoff bounds for consecutive-failure backoff. On a failed tick an extra
+// delay (base * 2^(n-1), capped at backoffMax) is waited before the next
+// iteration so a persistently failing dependency (DB / Stripe) isn't hammered
+// every WorkerInterval. A successful tick resets the backoff. See ga4sync for
+// the established pattern in this codebase.
+const (
+	backoffBase = 30 * time.Second
+	backoffMax  = 5 * time.Minute
+)
+
 func (w *Worker) worker(ctx context.Context) {
 	ticker := time.NewTicker(w.c.WorkerInterval)
 	defer ticker.Stop()
 
+	// consecutiveFailures drives the extra backoff delay applied after a failed
+	// tick. Reset to 0 on the first successful tick.
+	var consecutiveFailures int
+
 	for {
 		select {
 		case <-ticker.C:
-			w.runOnce(ctx)
+			if w.runOnce(ctx) {
+				consecutiveFailures = 0
+				continue
+			}
+			consecutiveFailures++
+			delay := backoffDelay(consecutiveFailures)
+			slog.Default().WarnContext(ctx, "stripe reconcile: backing off after failed tick",
+				slog.Int("consecutive_failures", consecutiveFailures),
+				slog.Duration("delay", delay),
+			)
+			// Wait the extra backoff on top of the ticker interval, but stay
+			// responsive to shutdown — never time.Sleep blindly.
+			timer := time.NewTimer(delay)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-// runOnce performs a single reconciliation tick. The deferred saferun.Recover
-// keeps a panic in this iteration from killing the worker loop.
-func (w *Worker) runOnce(ctx context.Context) {
+// backoffDelay returns the extra inter-iteration delay for the given number of
+// consecutive failures: base * 2^(n-1), capped at backoffMax.
+func backoffDelay(consecutiveFailures int) time.Duration {
+	delay := backoffBase
+	for i := 1; i < consecutiveFailures; i++ {
+		delay *= 2
+		if delay >= backoffMax {
+			return backoffMax
+		}
+	}
+	return delay
+}
+
+// runOnce performs a single reconciliation tick and reports whether it fully
+// succeeded. The deferred saferun.Recover keeps a panic in this iteration from
+// killing the worker loop.
+func (w *Worker) runOnce(ctx context.Context) bool {
 	defer saferun.Recover(ctx, "stripereconcile")
 
 	ctx, cancel := context.WithTimeout(ctx, tickTimeout)
@@ -39,8 +85,10 @@ func (w *Worker) runOnce(ctx context.Context) {
 	ok := true
 	for _, c := range w.cleaners {
 		if err := ctx.Err(); err != nil {
-			// Aborted mid-tick (shutdown / timeout): don't record success.
-			return
+			// Aborted mid-tick (shutdown / timeout): don't record success, and
+			// report ok so this abort isn't counted as a dependency failure for
+			// backoff (the loop catches ctx.Done() / re-ticks on its own).
+			return true
 		}
 		if err := c.CleanupOrphanedPreOrderPaymentIntents(ctx, olderThan); err != nil {
 			ok = false
@@ -55,4 +103,5 @@ func (w *Worker) runOnce(ctx context.Context) {
 	if ok {
 		w.tracker.MarkSuccess()
 	}
+	return ok
 }

--- a/internal/tiermanagement/engine.go
+++ b/internal/tiermanagement/engine.go
@@ -243,7 +243,8 @@ func formatEUR(d decimal.Decimal) string {
 		}
 	}
 	for i := pre; i < n; i += 3 {
-		b.WriteString(s[i : i+3])
+		end := min(i+3, n)
+		b.WriteString(s[i:end])
 		if i+3 < n {
 			b.WriteString(",")
 		}

--- a/internal/tiermanagement/worker.go
+++ b/internal/tiermanagement/worker.go
@@ -17,6 +17,16 @@ import (
 // query can't block the loop forever or stall graceful shutdown.
 const tickTimeout = 30 * time.Second
 
+// Backoff bounds for consecutive-failure backoff. On a failed tick an extra
+// delay (base * 2^(n-1), capped at backoffMax) is waited before the next
+// iteration so a persistently failing dependency (DB / mailer) isn't hammered
+// every WorkerInterval. A successful tick resets the backoff. See ga4sync for
+// the established pattern in this codebase.
+const (
+	backoffBase = 30 * time.Second
+	backoffMax  = 5 * time.Minute
+)
+
 // Config configures the tier maintenance worker.
 type Config struct {
 	// WorkerInterval is how often the daily jobs are evaluated. The jobs are
@@ -85,17 +95,55 @@ func (w *Worker) Stop() error {
 func (w *Worker) run(ctx context.Context) {
 	ticker := time.NewTicker(w.c.WorkerInterval)
 	defer ticker.Stop()
+
+	// consecutiveFailures drives the extra backoff delay applied after a failed
+	// tick. Reset to 0 on the first successful tick.
+	var consecutiveFailures int
+
 	for {
 		select {
 		case <-ticker.C:
-			w.runOnce(ctx)
+			if w.runOnce(ctx) {
+				consecutiveFailures = 0
+				continue
+			}
+			consecutiveFailures++
+			delay := backoffDelay(consecutiveFailures)
+			slog.Default().WarnContext(ctx, "tiermanagement: backing off after failed tick",
+				slog.Int("consecutive_failures", consecutiveFailures),
+				slog.Duration("delay", delay),
+			)
+			// Wait the extra backoff on top of the ticker interval, but stay
+			// responsive to shutdown — never time.Sleep blindly.
+			timer := time.NewTimer(delay)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (w *Worker) runOnce(ctx context.Context) {
+// backoffDelay returns the extra inter-iteration delay for the given number of
+// consecutive failures: base * 2^(n-1), capped at backoffMax.
+func backoffDelay(consecutiveFailures int) time.Duration {
+	delay := backoffBase
+	for i := 1; i < consecutiveFailures; i++ {
+		delay *= 2
+		if delay >= backoffMax {
+			return backoffMax
+		}
+	}
+	return delay
+}
+
+// runOnce performs a single maintenance tick and reports whether every daily job
+// completed without error.
+func (w *Worker) runOnce(ctx context.Context) bool {
 	defer saferun.Recover(ctx, "tiermanagement")
 
 	ctx, cancel := context.WithTimeout(ctx, tickTimeout)
@@ -129,4 +177,5 @@ func (w *Worker) runOnce(ctx context.Context) {
 	if ok {
 		w.tracker.MarkSuccess()
 	}
+	return ok
 }

--- a/internal/tiermanagement/worker.go
+++ b/internal/tiermanagement/worker.go
@@ -9,7 +9,13 @@ import (
 	"log/slog"
 
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
+	"github.com/jekabolt/grbpwr-manager/internal/health"
+	"github.com/jekabolt/grbpwr-manager/internal/saferun"
 )
+
+// tickTimeout bounds the DB work done in a single maintenance tick, so one stuck
+// query can't block the loop forever or stall graceful shutdown.
+const tickTimeout = 30 * time.Second
 
 // Config configures the tier maintenance worker.
 type Config struct {
@@ -25,13 +31,20 @@ func DefaultConfig() Config {
 
 // Worker runs the periodic tier review, downgrade reminders, and birthday gifts.
 type Worker struct {
-	repo   dependency.Repository
-	mailer dependency.Mailer
-	c      *Config
-	ctx    context.Context
-	stop   context.CancelFunc
-	wg     sync.WaitGroup
+	repo    dependency.Repository
+	mailer  dependency.Mailer
+	c       *Config
+	ctx     context.Context
+	stop    context.CancelFunc
+	wg      sync.WaitGroup
+	tracker health.Tracker
 }
+
+// Name implements health.Reporter.
+func (w *Worker) Name() string { return "tiermanagement" }
+
+// LastSuccess implements health.Reporter (zero time until the first clean tick).
+func (w *Worker) LastSuccess() time.Time { return w.tracker.LastSuccess() }
 
 // New constructs a tier maintenance worker.
 func New(c *Config, repo dependency.Repository, mailer dependency.Mailer) *Worker {
@@ -83,20 +96,37 @@ func (w *Worker) run(ctx context.Context) {
 }
 
 func (w *Worker) runOnce(ctx context.Context) {
+	defer saferun.Recover(ctx, "tiermanagement")
+
+	ctx, cancel := context.WithTimeout(ctx, tickTimeout)
+	defer cancel()
+
+	ok := true
 	e := NewEngine(w.repo, w.mailer)
 	if n, err := e.RunDailyTierReview(ctx); err != nil {
+		ok = false
+		w.tracker.MarkError(err)
 		slog.Default().ErrorContext(ctx, "tier review failed", slog.String("err", err.Error()))
 	} else if n > 0 {
 		slog.Default().InfoContext(ctx, "tier review downgraded members", slog.Int("count", n))
 	}
 	if n, err := e.RunDowngradeReminders(ctx); err != nil {
+		ok = false
+		w.tracker.MarkError(err)
 		slog.Default().ErrorContext(ctx, "downgrade reminders failed", slog.String("err", err.Error()))
 	} else if n > 0 {
 		slog.Default().InfoContext(ctx, "downgrade reminders queued", slog.Int("count", n))
 	}
 	if n, err := e.RunBirthdayGifts(ctx); err != nil {
+		ok = false
+		w.tracker.MarkError(err)
 		slog.Default().ErrorContext(ctx, "birthday gifts failed", slog.String("err", err.Error()))
 	} else if n > 0 {
 		slog.Default().InfoContext(ctx, "birthday gifts queued", slog.Int("count", n))
+	}
+
+	// Record success only when every daily job completed without error.
+	if ok {
+		w.tracker.MarkSuccess()
 	}
 }


### PR DESCRIPTION
This PR promotes `beta` → `master` (prod). It now bundles **two** things, both already on beta:

1. **Email size-code labels** (original PR, `34b5421`) — readable tailored/bottoms sizes in confirmation/shipment emails.
2. **A backend audit: critical + high + medium fixes** (9 commits) — payments, reliability, security, performance.

`go build ./...` + `go vet ./...` green across the module after each change; migration `0062` was applied and verified idempotent on `grbpwr_beta`. Tests requiring a live DB (`tls=custom`) were not run in the dev sandbox.

---

## 🔴 Critical
- **Idempotent transactional refunds** — deterministic Stripe idempotency key derived from the refund scope, so retries / concurrent identical refunds can't double-charge; migration `0061` dedupes + adds `UNIQUE(order_id, order_item_id)` on `refunded_order_item`; ledger-based stock restore can't double-restore. `DeliveredOrder` now reads `FOR UPDATE`.
- **Worker panic recovery** — a panic in any worker tick no longer crashes the whole `:8081` process.
- **HTTP server timeouts** — `ReadHeaderTimeout` / `IdleTimeout` / `MaxHeaderBytes` (slow-loris); `WriteTimeout`/`ReadTimeout` deliberately omitted to preserve h2c gRPC streaming + large media uploads.
- **Payment-monitor lifecycle** — detach the SubmitOrder monitor from the request ctx (was dying instantly); cancel all monitors on shutdown before the DB closes; stop leaking superseded monitors.
- **Boot resilience** — revalidation is non-fatal (no-op fallback) instead of blocking startup.

## 🟠 High
- Per-iteration timeouts in all workers; Resend client 15s HTTP timeout + response-body-leak fix; DO Spaces validated at boot (`BucketExists`).
- gRPC hardening: `MaxSendMsgSize`, `MaxConcurrentStreams`, keepalive (no `MaxConnectionAge` — it would tear down the loopback gateway connection).
- CORS: dropped credentialed `*.vercel.app` / `*.github.io` wildcards; localhost gated behind `HTTP_ALLOW_DEV_ORIGINS` (default false).
- DB pool: `max_open` 5→15, conn lifetime 2m→5m, config-driven (shared cluster cap = 76).
- Lightweight observability (no new deps): worker last-success tracking + admin-JWT-gated `GET /statusz` (DB pool, worker liveness, breaker state, runtime). `/livez` and `/readyz` unchanged.
- Migration `0062`: indexes on `customer_order(order_status_id, placed)`, `payment(expired_at)`, `send_email_request(sent, next_retry_at)`, `subscriber(created_at)`.

## 🟡 Medium
- Rate-limit `GetOrderInvoice` / `CancelOrderInvoice` (IP + order ref) and admin `Login/Create/Delete/ChangePassword` (IP + username).
- `X-Forwarded-For` parsed against `TRUST_PROXY_HOPS` (default 1) — no more left-most spoofing of the rate-limit key.
- Shipping cost refunded only once (`shipping_refunded` flag, migration `0063`).
- Exponential backoff on consecutive worker errors (mirrors the existing ga4sync pattern).

## ✉️ Email size-code labels (original PR)
`FormatSizeName` in `internal/dto/mail.go` normalizes compound tailored/bottoms codes (`label_measurement{ta|bo}_{m|f}`, migrations 0018/0019) for confirmation/shipment emails: `xs_44ta_m` → `XS · 44`. Plain letters, shoe sizes and unknown values pass through unchanged. Covered by `internal/dto/mail_test.go`.

---

## Migrations (auto-applied on deploy)
`0061` refunded_order_item dedupe + UNIQUE · `0062` perf indexes (verified on beta) · `0063` add `shipping_refunded` (additive). All `information_schema`-guarded / data-safe against existing prod data.

## ⚠️ Before merging to master (prod)
- [ ] **Exercise payment flows on beta**: checkout, full + partial refund, cancel, webhook confirm — the payment path changed substantially.
- [ ] Confirm the client-IP middleware populates context on the **auth gateway path** (admin rate limiting depends on it).
- [ ] Review new prod config in `.do/app.yaml`: `MYSQL_MAX_OPEN_CONNECTIONS=15` + lifetimes (cluster cap 76, shared prod+beta+admin); set `TRUST_PROXY_HOPS=1`; leave `HTTP_ALLOW_DEV_ORIGINS` unset.
- [ ] IDOR on the invoice endpoints is **mitigated (rate limit), not closed** — full fix needs an email/token request field + frontend coordination (`TODO(security)` in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
