### PR TITLE
feat(admin): tech card (техкарта / tech pack) — full feature

### DIFF
--- a/internal/apisrv/admin/content.go
+++ b/internal/apisrv/admin/content.go
@@ -45,6 +45,10 @@ func (s *Server) DeleteFromBucket(ctx context.Context, req *pb_admin.DeleteFromB
 	resp := &pb_admin.DeleteFromBucketResponse{}
 	err := s.repo.Media().DeleteMediaById(ctx, int(req.Id))
 	if err != nil {
+		if s.repo.IsErrForeignKeyViolation(err) {
+			return nil, status.Error(codes.FailedPrecondition,
+				"media is still referenced (product, archive, model, fitting or tech card) and cannot be deleted")
+		}
 		slog.Default().ErrorContext(ctx, "can't delete object from bucket",
 			slog.String("err", err.Error()),
 		)

--- a/internal/apisrv/admin/fitting.go
+++ b/internal/apisrv/admin/fitting.go
@@ -23,7 +23,7 @@ func (s *Server) AddFitting(ctx context.Context, req *pb_admin.AddFittingRequest
 	id, err := s.repo.Fittings().AddFitting(ctx, fi)
 	if err != nil {
 		if s.repo.IsErrForeignKeyViolation(err) {
-			return nil, status.Error(codes.InvalidArgument, "product_id, model_id, size_id, or media_id does not reference an existing record")
+			return nil, status.Error(codes.InvalidArgument, "tech_card_id, product_id, model_id, size_id, or media_id does not reference an existing record")
 		}
 		slog.Default().ErrorContext(ctx, "can't add fitting",
 			slog.String("err", err.Error()),
@@ -37,7 +37,7 @@ func (s *Server) AddFitting(ctx context.Context, req *pb_admin.AddFittingRequest
 // product and/or model.
 func (s *Server) ListFittings(ctx context.Context, req *pb_admin.ListFittingsRequest) (*pb_admin.ListFittingsResponse, error) {
 	fittings, total, err := s.repo.Fittings().ListFittings(ctx, int(req.Limit), int(req.Offset),
-		dto.ConvertPBCommonOrderFactorToEntity(req.OrderFactor), int(req.ProductId), int(req.ModelId))
+		dto.ConvertPBCommonOrderFactorToEntity(req.OrderFactor), int(req.ProductId), int(req.ModelId), int(req.TechCardId))
 	if err != nil {
 		slog.Default().ErrorContext(ctx, "can't list fittings",
 			slog.String("err", err.Error()),
@@ -84,7 +84,7 @@ func (s *Server) UpdateFitting(ctx context.Context, req *pb_admin.UpdateFittingR
 			return nil, status.Errorf(codes.NotFound, "fitting not found")
 		}
 		if s.repo.IsErrForeignKeyViolation(err) {
-			return nil, status.Error(codes.InvalidArgument, "product_id, model_id, size_id, or media_id does not reference an existing record")
+			return nil, status.Error(codes.InvalidArgument, "tech_card_id, product_id, model_id, size_id, or media_id does not reference an existing record")
 		}
 		slog.Default().ErrorContext(ctx, "can't update fitting",
 			slog.String("err", err.Error()),

--- a/internal/apisrv/admin/techcard.go
+++ b/internal/apisrv/admin/techcard.go
@@ -1,0 +1,137 @@
+package admin
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"github.com/jekabolt/grbpwr-manager/internal/dto"
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	pb_admin "github.com/jekabolt/grbpwr-manager/proto/gen/admin"
+	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// techCardFKMsg is returned when a tech card references a missing category, base
+// model, base sample size, size, product or media row.
+const techCardFKMsg = "tech card references a non-existent category, model, size, product or media"
+
+// CreateTechCard creates a new tech card with its nested sections.
+func (s *Server) CreateTechCard(ctx context.Context, req *pb_admin.CreateTechCardRequest) (*pb_admin.CreateTechCardResponse, error) {
+	tc, err := dto.ConvertPbTechCardInsertToEntity(req.TechCard)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	id, err := s.repo.TechCards().AddTechCard(ctx, tc)
+	if err != nil {
+		if s.repo.IsErrForeignKeyViolation(err) {
+			return nil, status.Error(codes.InvalidArgument, techCardFKMsg)
+		}
+		slog.Default().ErrorContext(ctx, "can't add tech card",
+			slog.String("err", err.Error()),
+		)
+		return nil, status.Errorf(codes.Internal, "can't add tech card")
+	}
+	return &pb_admin.CreateTechCardResponse{Id: int32(id)}, nil
+}
+
+// GetTechCard returns a tech card by id with its nested sections resolved.
+func (s *Server) GetTechCard(ctx context.Context, req *pb_admin.GetTechCardRequest) (*pb_admin.GetTechCardResponse, error) {
+	if req.Id <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "tech card id is required")
+	}
+	tc, err := s.repo.TechCards().GetTechCardById(ctx, int(req.Id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, status.Errorf(codes.NotFound, "tech card not found")
+		}
+		slog.Default().ErrorContext(ctx, "can't get tech card by id",
+			slog.String("err", err.Error()),
+		)
+		return nil, status.Errorf(codes.Internal, "can't get tech card")
+	}
+	return &pb_admin.GetTechCardResponse{TechCard: dto.ConvertEntityTechCardToPb(tc)}, nil
+}
+
+// UpdateTechCard updates a tech card, replacing its nested sections.
+func (s *Server) UpdateTechCard(ctx context.Context, req *pb_admin.UpdateTechCardRequest) (*pb_admin.UpdateTechCardResponse, error) {
+	if req.Id <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "tech card id is required")
+	}
+	tc, err := dto.ConvertPbTechCardInsertToEntity(req.TechCard)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := s.repo.TechCards().UpdateTechCard(ctx, int(req.Id), tc); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, status.Errorf(codes.NotFound, "tech card not found")
+		}
+		if s.repo.IsErrForeignKeyViolation(err) {
+			return nil, status.Error(codes.InvalidArgument, techCardFKMsg)
+		}
+		slog.Default().ErrorContext(ctx, "can't update tech card",
+			slog.String("err", err.Error()),
+		)
+		return nil, status.Errorf(codes.Internal, "can't update tech card")
+	}
+	return &pb_admin.UpdateTechCardResponse{}, nil
+}
+
+// DeleteTechCard deletes a tech card by id (nested sections cascade).
+func (s *Server) DeleteTechCard(ctx context.Context, req *pb_admin.DeleteTechCardRequest) (*pb_admin.DeleteTechCardResponse, error) {
+	if req.Id <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "tech card id is required")
+	}
+	if err := s.repo.TechCards().DeleteTechCard(ctx, int(req.Id)); err != nil {
+		slog.Default().ErrorContext(ctx, "can't delete tech card",
+			slog.String("err", err.Error()),
+		)
+		return nil, status.Errorf(codes.Internal, "can't delete tech card")
+	}
+	return &pb_admin.DeleteTechCardResponse{}, nil
+}
+
+// ListTechCards returns a paged list of tech-card headers with optional filters.
+func (s *Server) ListTechCards(ctx context.Context, req *pb_admin.ListTechCardsRequest) (*pb_admin.ListTechCardsResponse, error) {
+	stage, err := dto.ConvertPbTechCardStageToEntityString(req.Stage)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid stage filter: %v", err)
+	}
+
+	gender := ""
+	if req.Gender != pb_common.GenderEnum_GENDER_ENUM_UNKNOWN {
+		g, err := dto.ConvertPbGenderEnumToEntityGenderEnum(req.Gender)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid gender filter: %v", err)
+		}
+		gender = string(g)
+	}
+
+	filter := entity.TechCardListFilter{
+		Stage:     stage,
+		Gender:    gender,
+		Brand:     strings.TrimSpace(req.Brand),
+		Season:    strings.TrimSpace(req.Season),
+		Name:      strings.TrimSpace(req.Name),
+		ProductId: int(req.ProductId),
+	}
+
+	cards, total, err := s.repo.TechCards().ListTechCards(ctx, int(req.Limit), int(req.Offset),
+		dto.ConvertPBCommonOrderFactorToEntity(req.OrderFactor), filter)
+	if err != nil {
+		slog.Default().ErrorContext(ctx, "can't list tech cards",
+			slog.String("err", err.Error()),
+		)
+		return nil, status.Errorf(codes.Internal, "can't list tech cards")
+	}
+
+	items := make([]*pb_common.TechCardListItem, 0, len(cards))
+	for i := range cards {
+		items = append(items, dto.ConvertEntityTechCardToListItemPb(&cards[i]))
+	}
+	return &pb_admin.ListTechCardsResponse{TechCards: items, Total: int32(total)}, nil
+}

--- a/internal/apisrv/admin/techcard.go
+++ b/internal/apisrv/admin/techcard.go
@@ -19,6 +19,9 @@ import (
 // model, base sample size, size, product or media row.
 const techCardFKMsg = "tech card references a non-existent category, model, size, product or media"
 
+// techCardDupMsg is returned when style_number collides within the same season.
+const techCardDupMsg = "a tech card with this style_number and season already exists"
+
 // CreateTechCard creates a new tech card with its nested sections.
 func (s *Server) CreateTechCard(ctx context.Context, req *pb_admin.CreateTechCardRequest) (*pb_admin.CreateTechCardResponse, error) {
 	tc, err := dto.ConvertPbTechCardInsertToEntity(req.TechCard)
@@ -28,6 +31,9 @@ func (s *Server) CreateTechCard(ctx context.Context, req *pb_admin.CreateTechCar
 
 	id, err := s.repo.TechCards().AddTechCard(ctx, tc)
 	if err != nil {
+		if s.repo.IsErrUniqueViolation(err) {
+			return nil, status.Error(codes.InvalidArgument, techCardDupMsg)
+		}
 		if s.repo.IsErrForeignKeyViolation(err) {
 			return nil, status.Error(codes.InvalidArgument, techCardFKMsg)
 		}
@@ -69,6 +75,9 @@ func (s *Server) UpdateTechCard(ctx context.Context, req *pb_admin.UpdateTechCar
 	if err := s.repo.TechCards().UpdateTechCard(ctx, int(req.Id), tc); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Errorf(codes.NotFound, "tech card not found")
+		}
+		if s.repo.IsErrUniqueViolation(err) {
+			return nil, status.Error(codes.InvalidArgument, techCardDupMsg)
 		}
 		if s.repo.IsErrForeignKeyViolation(err) {
 			return nil, status.Error(codes.InvalidArgument, techCardFKMsg)

--- a/internal/apisrv/admin/techcard.go
+++ b/internal/apisrv/admin/techcard.go
@@ -17,7 +17,7 @@ import (
 
 // techCardFKMsg is returned when a tech card references a missing category, base
 // model, base sample size, size, product or media row.
-const techCardFKMsg = "tech card references a non-existent category, model, size, product or media"
+const techCardFKMsg = "tech card references a non-existent category, model, size, product, media or fitting"
 
 // techCardDupMsg is returned when style_number collides within the same season.
 const techCardDupMsg = "a tech card with this style_number and season already exists"

--- a/internal/apisrv/admin/techcard_route_test.go
+++ b/internal/apisrv/admin/techcard_route_test.go
@@ -1,0 +1,63 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	pb_admin "github.com/jekabolt/grbpwr-manager/proto/gen/admin"
+)
+
+// routeStubServer records which tech-card RPC the gateway dispatched to.
+type routeStubServer struct {
+	pb_admin.UnimplementedAdminServiceServer
+	lastCall string
+	lastID   int32
+}
+
+func (s *routeStubServer) GetTechCard(ctx context.Context, req *pb_admin.GetTechCardRequest) (*pb_admin.GetTechCardResponse, error) {
+	s.lastCall = "Get"
+	s.lastID = req.Id
+	return &pb_admin.GetTechCardResponse{}, nil
+}
+
+func (s *routeStubServer) ListTechCards(ctx context.Context, req *pb_admin.ListTechCardsRequest) (*pb_admin.ListTechCardsResponse, error) {
+	s.lastCall = "List"
+	return &pb_admin.ListTechCardsResponse{}, nil
+}
+
+// TestTechCardListRouteNotShadowed pins the grpc-gateway route-ordering invariant
+// documented on the proto: GET /tech-card/list must reach ListTechCards, not
+// GetTechCard with id="list". The mux prepends handlers and first-match wins, so
+// the literal /list route is declared after /{id}; this test fails if that order
+// regresses.
+func TestTechCardListRouteNotShadowed(t *testing.T) {
+	stub := &routeStubServer{}
+	mux := runtime.NewServeMux()
+	if err := pb_admin.RegisterAdminServiceHandlerServer(context.Background(), mux, stub); err != nil {
+		t.Fatalf("register handler: %v", err)
+	}
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/admin/tech-card/list")
+	if err != nil {
+		t.Fatalf("GET /tech-card/list: %v", err)
+	}
+	resp.Body.Close()
+	if stub.lastCall != "List" {
+		t.Fatalf("GET /tech-card/list dispatched to %q (id=%d), want ListTechCards", stub.lastCall, stub.lastID)
+	}
+
+	stub.lastCall, stub.lastID = "", 0
+	resp2, err := http.Get(ts.URL + "/api/admin/tech-card/42")
+	if err != nil {
+		t.Fatalf("GET /tech-card/42: %v", err)
+	}
+	resp2.Body.Close()
+	if stub.lastCall != "Get" || stub.lastID != 42 {
+		t.Fatalf("GET /tech-card/42 dispatched to %q (id=%d), want GetTechCard id=42", stub.lastCall, stub.lastID)
+	}
+}

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -322,6 +322,16 @@ type (
 		ListFittings(ctx context.Context, limit, offset int, orderFactor entity.OrderFactor, productID, modelID int) ([]entity.Fitting, int, error)
 	}
 
+	// TechCards manages garment tech packs (техкарта): the header, size range,
+	// linked products, sketch media, callouts and revision log.
+	TechCards interface {
+		AddTechCard(ctx context.Context, tc *entity.TechCardInsert) (int, error)
+		UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardInsert) error
+		DeleteTechCard(ctx context.Context, id int) error
+		GetTechCardById(ctx context.Context, id int) (*entity.TechCard, error)
+		ListTechCards(ctx context.Context, limit, offset int, orderFactor entity.OrderFactor, filter entity.TechCardListFilter) ([]entity.TechCard, int, error)
+	}
+
 	// BQClient is the BigQuery analytics client interface. Implementations can be mocked for testing.
 	BQClient interface {
 		CircuitBreakerState() circuitbreaker.State
@@ -513,6 +523,7 @@ type (
 		Promo() Promo
 		Models() Models
 		Fittings() Fittings
+		TechCards() TechCards
 		Admin() Admin
 		Cache() Cache
 		Mail() Mail

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -319,7 +319,7 @@ type (
 		UpdateFitting(ctx context.Context, id int, f *entity.FittingInsert) error
 		DeleteFitting(ctx context.Context, id int) error
 		GetFittingById(ctx context.Context, id int) (*entity.Fitting, error)
-		ListFittings(ctx context.Context, limit, offset int, orderFactor entity.OrderFactor, productID, modelID int) ([]entity.Fitting, int, error)
+		ListFittings(ctx context.Context, limit, offset int, orderFactor entity.OrderFactor, productID, modelID, techCardID int) ([]entity.Fitting, int, error)
 	}
 
 	// TechCards manages garment tech packs (техкарта): the header, size range,

--- a/internal/dto/fitting.go
+++ b/internal/dto/fitting.go
@@ -42,8 +42,12 @@ func ConvertPbFittingInsertToEntity(pb *pb_common.FittingInsert) (*entity.Fittin
 	if pb == nil {
 		return nil, fmt.Errorf("fitting insert is nil")
 	}
-	if pb.ProductId <= 0 {
-		return nil, fmt.Errorf("fitting product_id is required")
+	if pb.ProductId < 0 || pb.TechCardId < 0 {
+		return nil, fmt.Errorf("fitting product_id and tech_card_id must not be negative")
+	}
+	// A fitting must anchor to the style and/or the specific colour sample.
+	if pb.ProductId <= 0 && pb.TechCardId <= 0 {
+		return nil, fmt.Errorf("fitting requires product_id or tech_card_id")
 	}
 	if pb.FittingDate == nil {
 		return nil, fmt.Errorf("fitting_date is required")
@@ -99,7 +103,8 @@ func ConvertPbFittingInsertToEntity(pb *pb_common.FittingInsert) (*entity.Fittin
 	fittingDate := time.Date(ft.Year(), ft.Month(), ft.Day(), 0, 0, 0, 0, time.UTC)
 
 	return &entity.FittingInsert{
-		ProductId:   int(pb.ProductId),
+		TechCardId:  nullInt32FromPb(pb.TechCardId),
+		ProductId:   nullInt32FromPb(pb.ProductId),
 		ModelId:     nullInt32FromPb(pb.ModelId),
 		FittingDate: fittingDate,
 		Comment:     nullStringFromPb(pb.Comment),
@@ -136,7 +141,8 @@ func ConvertEntityFittingToPb(f *entity.Fitting) *pb_common.Fitting {
 	return &pb_common.Fitting{
 		Id: int32(f.Id),
 		Fitting: &pb_common.FittingInsert{
-			ProductId:   int32(f.ProductId),
+			TechCardId:  pbInt32FromNull(f.TechCardId),
+			ProductId:   pbInt32FromNull(f.ProductId),
 			ModelId:     pbInt32FromNull(f.ModelId),
 			FittingDate: timestamppb.New(f.FittingDate),
 			Comment:     pbStringFromNull(f.Comment),

--- a/internal/dto/fitting_test.go
+++ b/internal/dto/fitting_test.go
@@ -30,7 +30,7 @@ func TestConvertPbFittingInsertToEntity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got.ProductId != 42 || !got.ModelId.Valid || got.ModelId.Int32 != 7 {
+	if !got.ProductId.Valid || got.ProductId.Int32 != 42 || !got.ModelId.Valid || got.ModelId.Int32 != 7 {
 		t.Errorf("product/model mismatch: %+v", got)
 	}
 	if got.Status != entity.FittingDone || got.Verdict != entity.FittingApproved {
@@ -55,6 +55,15 @@ func TestConvertPbFittingInsertToEntity(t *testing.T) {
 		t.Errorf("model id 0 should be NULL, got %+v", def.ModelId)
 	}
 
+	// a tech-card-only fitting (no product yet, e.g. a proto) is valid.
+	tc, err := ConvertPbFittingInsertToEntity(&pb_common.FittingInsert{TechCardId: 8, FittingDate: date})
+	if err != nil {
+		t.Fatalf("tech-card-only: %v", err)
+	}
+	if !tc.TechCardId.Valid || tc.TechCardId.Int32 != 8 || tc.ProductId.Valid {
+		t.Errorf("tech-card-only anchor mismatch: tc=%+v prod=%+v", tc.TechCardId, tc.ProductId)
+	}
+
 	// fitting_date is normalized to the UTC calendar date regardless of time-of-day.
 	noon := timestamppb.New(time.Date(2026, 6, 19, 15, 30, 0, 0, time.UTC))
 	norm, err := ConvertPbFittingInsertToEntity(&pb_common.FittingInsert{ProductId: 1, FittingDate: noon})
@@ -67,13 +76,13 @@ func TestConvertPbFittingInsertToEntity(t *testing.T) {
 
 	// invalid cases (incl. out-of-range enum values that must be rejected, not defaulted)
 	bad := map[string]*pb_common.FittingInsert{
-		"nil":            nil,
-		"no product":     {ProductId: 0, FittingDate: date},
-		"no date":        {ProductId: 1},
-		"size id zero":   {ProductId: 1, FittingDate: date, Sizes: []*pb_common.FittingSizeInsert{{SizeId: 0}}},
-		"duplicate size": {ProductId: 1, FittingDate: date, Sizes: []*pb_common.FittingSizeInsert{{SizeId: 4}, {SizeId: 4}}},
-		"bad status":     {ProductId: 1, FittingDate: date, Status: pb_common.FittingStatus(99)},
-		"bad verdict":    {ProductId: 1, FittingDate: date, Verdict: pb_common.FittingVerdict(99)},
+		"nil":                  nil,
+		"no anchor":            {ProductId: 0, FittingDate: date},
+		"no date":              {ProductId: 1},
+		"size id zero":         {ProductId: 1, FittingDate: date, Sizes: []*pb_common.FittingSizeInsert{{SizeId: 0}}},
+		"duplicate size":       {ProductId: 1, FittingDate: date, Sizes: []*pb_common.FittingSizeInsert{{SizeId: 4}, {SizeId: 4}}},
+		"bad status":           {ProductId: 1, FittingDate: date, Status: pb_common.FittingStatus(99)},
+		"bad verdict":          {ProductId: 1, FittingDate: date, Verdict: pb_common.FittingVerdict(99)},
 		"recorded_by too long": {ProductId: 1, FittingDate: date, RecordedBy: string(make([]byte, 256))},
 	}
 	for name, in := range bad {
@@ -87,7 +96,8 @@ func TestConvertEntityFittingToPb(t *testing.T) {
 	f := &entity.Fitting{
 		Id: 3,
 		FittingInsert: entity.FittingInsert{
-			ProductId:   42,
+			TechCardId:  nullInt32FromPb(8),
+			ProductId:   nullInt32FromPb(42),
 			FittingDate: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
 			Status:      entity.FittingPlanned,
 			Verdict:     entity.FittingPending,
@@ -96,8 +106,8 @@ func TestConvertEntityFittingToPb(t *testing.T) {
 		Media: []entity.MediaFull{{Id: 11}, {Id: 12}},
 	}
 	pb := ConvertEntityFittingToPb(f)
-	if pb.Id != 3 || pb.Fitting.ProductId != 42 {
-		t.Errorf("id/product mismatch: %+v", pb)
+	if pb.Id != 3 || pb.Fitting.ProductId != 42 || pb.Fitting.TechCardId != 8 {
+		t.Errorf("id/product/tech_card mismatch: %+v", pb)
 	}
 	if pb.Fitting.Status != pb_common.FittingStatus_FITTING_STATUS_PLANNED ||
 		pb.Fitting.Verdict != pb_common.FittingVerdict_FITTING_VERDICT_PENDING {

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -295,6 +295,28 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		return nil, err
 	}
 
+	// production (Phase 3)
+	construction, err := parseTechCardConstruction(pb.Construction)
+	if err != nil {
+		return nil, err
+	}
+	operations, err := parseTechCardOperations(pb.Operations)
+	if err != nil {
+		return nil, err
+	}
+	labels, err := parseTechCardLabels(pb.Labels)
+	if err != nil {
+		return nil, err
+	}
+	packaging, err := parseTechCardPackaging(pb.Packaging)
+	if err != nil {
+		return nil, err
+	}
+	costing, err := parseTechCardCosting(pb.Costing)
+	if err != nil {
+		return nil, err
+	}
+
 	return &entity.TechCardInsert{
 		StyleNumber:       pb.StyleNumber,
 		Name:              pb.Name,
@@ -337,6 +359,11 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		BomItems:          bomItems,
 		Colorways:         colorways,
 		PomPoints:         pomPoints,
+		Construction:      construction,
+		Operations:        operations,
+		Labels:            labels,
+		Packaging:         packaging,
+		Costing:           costing,
 	}, nil
 }
 
@@ -433,6 +460,11 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			BomItems:          techCardBomItemsToPb(tc.BomItems),
 			Colorways:         techCardColorwaysToPb(tc.Colorways),
 			PomPoints:         techCardPomPointsToPb(tc.PomPoints),
+			Construction:      techCardConstructionToPb(tc.Construction),
+			Operations:        techCardOperationsToPb(tc.Operations),
+			Labels:            techCardLabelsToPb(tc.Labels),
+			Packaging:         techCardPackagingToPb(tc.Packaging),
+			Costing:           techCardCostingToPb(tc),
 		},
 		ResolvedMedia: resolved,
 	}

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -282,7 +282,7 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 
 	// materials (Phase 2). Colorways are parsed first so BOM colorway_index can be
 	// range-checked against them.
-	colorways, err := parseTechCardColorways(pb.Colorways)
+	colorways, err := parseTechCardColorways(pb.Colorways, productIds)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +502,7 @@ func pbTechCardMediaKind(k entity.TechCardMediaKind) pb_common.TechCardMediaKind
 
 // --- materials (Phase 2): parse pb -> entity ---
 
-func parseTechCardColorways(pbs []*pb_common.TechCardColorway) ([]entity.TechCardColorway, error) {
+func parseTechCardColorways(pbs []*pb_common.TechCardColorway, productIds []int) ([]entity.TechCardColorway, error) {
 	out := make([]entity.TechCardColorway, 0, len(pbs))
 	for _, c := range pbs {
 		if c.Name == "" {
@@ -516,6 +516,13 @@ func parseTechCardColorways(pbs []*pb_common.TechCardColorway) ([]entity.TechCar
 		}
 		if c.ProductId < 0 {
 			return nil, fmt.Errorf("colorway product_id must not be negative")
+		}
+		// Soft consistency: a colourway's published product must be one of the tech
+		// card's linked products (tech_card_product), so a colourway cannot point at
+		// a product outside the card. tech_card_product stays the catalog-SKU list;
+		// this only keeps the two in sync at write time.
+		if c.ProductId > 0 && !slices.Contains(productIds, int(c.ProductId)) {
+			return nil, fmt.Errorf("colorway product_id %d must be one of the tech card's product_ids", c.ProductId)
 		}
 		status := entity.LabDipPending
 		if c.LabDipStatus != pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_UNKNOWN {

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -64,7 +64,7 @@ var techCardApprovalStateEntityToPb = func() map[entity.TechCardApprovalState]pb
 
 var techCardUnitPbToEntity = map[pb_common.TechCardMeasurementUnit]entity.TechCardMeasurementUnit{
 	pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_CM: entity.TechCardUnitCm,
-	pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_IN: entity.TechCardUnitIn,
+	pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_MM: entity.TechCardUnitMm,
 }
 
 var techCardUnitEntityToPb = func() map[entity.TechCardMeasurementUnit]pb_common.TechCardMeasurementUnit {
@@ -504,6 +504,10 @@ func pbTechCardMediaKind(k entity.TechCardMediaKind) pb_common.TechCardMediaKind
 
 func parseTechCardColorways(pbs []*pb_common.TechCardColorway, productIds []int) ([]entity.TechCardColorway, error) {
 	out := make([]entity.TechCardColorway, 0, len(pbs))
+	// Non-empty codes must be unique within the card (DB enforces
+	// uniq_tech_card_colorway_code); dedupe here so a collision fails as a precise
+	// InvalidArgument, not a misleading style_number/season unique-violation.
+	seenCode := make(map[string]bool, len(pbs))
 	for _, c := range pbs {
 		if c.Name == "" {
 			return nil, fmt.Errorf("colorway name is required")
@@ -513,6 +517,12 @@ func parseTechCardColorways(pbs []*pb_common.TechCardColorway, productIds []int)
 		}
 		if len(c.Code) > maxVarchar64 {
 			return nil, fmt.Errorf("colorway code must be at most %d characters", maxVarchar64)
+		}
+		if c.Code != "" {
+			if seenCode[c.Code] {
+				return nil, fmt.Errorf("colorways contain a duplicate code: %q", c.Code)
+			}
+			seenCode[c.Code] = true
 		}
 		if c.ProductId < 0 {
 			return nil, fmt.Errorf("colorway product_id must not be negative")
@@ -661,12 +671,25 @@ func parseTechCardPomPoints(pbs []*pb_common.TechCardPomPoint, sizeIds []int) ([
 		if err := validateDecimalScale(baseValue, "pom base_value", pomMaxFrac, pomLimit); err != nil {
 			return nil, err
 		}
-		tolerance, err := nullDecimalFromPb(p.Tolerance)
+		tolPlus, err := nullDecimalFromPb(p.TolerancePlus)
 		if err != nil {
-			return nil, fmt.Errorf("pom tolerance: %w", err)
+			return nil, fmt.Errorf("pom tolerance_plus: %w", err)
 		}
-		if err := validateDecimalScale(tolerance, "pom tolerance", pomMaxFrac, pomLimit); err != nil {
+		if err := validateDecimalScale(tolPlus, "pom tolerance_plus", pomMaxFrac, pomLimit); err != nil {
 			return nil, err
+		}
+		tolMinus, err := nullDecimalFromPb(p.ToleranceMinus)
+		if err != nil {
+			return nil, fmt.Errorf("pom tolerance_minus: %w", err)
+		}
+		if err := validateDecimalScale(tolMinus, "pom tolerance_minus", pomMaxFrac, pomLimit); err != nil {
+			return nil, err
+		}
+		// Symmetric-tolerance ergonomic: if only one side is given, mirror it.
+		if tolPlus.Valid && !tolMinus.Valid {
+			tolMinus = tolPlus
+		} else if tolMinus.Valid && !tolPlus.Valid {
+			tolPlus = tolMinus
 		}
 
 		grades := make([]entity.TechCardPomGrade, 0, len(p.Grades))
@@ -707,14 +730,15 @@ func parseTechCardPomPoints(pbs []*pb_common.TechCardPomPoint, sizeIds []int) ([
 		}
 
 		out = append(out, entity.TechCardPomPoint{
-			Section:      nullStringFromPb(p.Section),
-			Code:         nullStringFromPb(p.Code),
-			Name:         p.Name,
-			HowToMeasure: nullStringFromPb(p.HowToMeasure),
-			BaseValue:    baseValue,
-			Tolerance:    tolerance,
-			Grades:       grades,
-			Actuals:      actuals,
+			Section:        nullStringFromPb(p.Section),
+			Code:           nullStringFromPb(p.Code),
+			Name:           p.Name,
+			HowToMeasure:   nullStringFromPb(p.HowToMeasure),
+			BaseValue:      baseValue,
+			TolerancePlus:  tolPlus,
+			ToleranceMinus: tolMinus,
+			Grades:         grades,
+			Actuals:        actuals,
 		})
 	}
 	return out, nil
@@ -790,14 +814,15 @@ func techCardPomPointsToPb(points []entity.TechCardPomPoint) []*pb_common.TechCa
 			})
 		}
 		out = append(out, &pb_common.TechCardPomPoint{
-			Section:      pbStringFromNull(p.Section),
-			Code:         pbStringFromNull(p.Code),
-			Name:         p.Name,
-			HowToMeasure: pbStringFromNull(p.HowToMeasure),
-			BaseValue:    pbDecimalFromNull(p.BaseValue),
-			Tolerance:    pbDecimalFromNull(p.Tolerance),
-			Grades:       grades,
-			Actuals:      actuals,
+			Section:        pbStringFromNull(p.Section),
+			Code:           pbStringFromNull(p.Code),
+			Name:           p.Name,
+			HowToMeasure:   pbStringFromNull(p.HowToMeasure),
+			BaseValue:      pbDecimalFromNull(p.BaseValue),
+			TolerancePlus:  pbDecimalFromNull(p.TolerancePlus),
+			ToleranceMinus: pbDecimalFromNull(p.ToleranceMinus),
+			Grades:         grades,
+			Actuals:        actuals,
 		})
 	}
 	return out

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -3,6 +3,7 @@ package dto
 import (
 	"database/sql"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
@@ -30,6 +31,22 @@ var techCardStagePbToEntity = map[pb_common.TechCardStage]entity.TechCardStage{
 var techCardStageEntityToPb = func() map[entity.TechCardStage]pb_common.TechCardStage {
 	m := make(map[entity.TechCardStage]pb_common.TechCardStage, len(techCardStagePbToEntity))
 	for k, v := range techCardStagePbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
+var techCardApprovalStatePbToEntity = map[pb_common.TechCardApprovalState]entity.TechCardApprovalState{
+	pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_DRAFT:     entity.TechCardApprovalDraft,
+	pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_IN_REVIEW: entity.TechCardApprovalInReview,
+	pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_APPROVED:  entity.TechCardApprovalApproved,
+	pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_RELEASED:  entity.TechCardApprovalReleased,
+	pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_OBSOLETE:  entity.TechCardApprovalObsolete,
+}
+
+var techCardApprovalStateEntityToPb = func() map[entity.TechCardApprovalState]pb_common.TechCardApprovalState {
+	m := make(map[entity.TechCardApprovalState]pb_common.TechCardApprovalState, len(techCardApprovalStatePbToEntity))
+	for k, v := range techCardApprovalStatePbToEntity {
 		m[v] = k
 	}
 	return m
@@ -78,6 +95,7 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		{"designer", pb.Designer, maxVarchar255},
 		{"constructor", pb.Constructor, maxVarchar255},
 		{"technologist", pb.Technologist, maxVarchar255},
+		{"approved_by", pb.ApprovedBy, maxVarchar255},
 	} {
 		if len(c.val) > c.max {
 			return nil, fmt.Errorf("%s must be at most %d characters", c.field, c.max)
@@ -94,6 +112,15 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 			return nil, fmt.Errorf("unknown tech card stage: %v", pb.Stage)
 		}
 		stage = s
+	}
+
+	approvalState := entity.TechCardApprovalDraft
+	if pb.ApprovalState != pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_UNKNOWN {
+		a, ok := techCardApprovalStatePbToEntity[pb.ApprovalState]
+		if !ok {
+			return nil, fmt.Errorf("unknown tech card approval state: %v", pb.ApprovalState)
+		}
+		approvalState = a
 	}
 
 	gender, err := nullGenderFromPb(pb.TargetGender)
@@ -123,6 +150,14 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		return nil, err
 	}
 
+	// base_sample_size_id, when set, must be part of the declared size range: the
+	// POM grade radiates from the base size, so a base outside the graded columns
+	// would leave the future measurement chart without an origin. An empty size
+	// range is allowed (the grade may not be defined yet at the proto stage).
+	if pb.BaseSampleSizeId > 0 && len(sizeIds) > 0 && !slices.Contains(sizeIds, int(pb.BaseSampleSizeId)) {
+		return nil, fmt.Errorf("base_sample_size_id %d must be one of size_ids", pb.BaseSampleSizeId)
+	}
+
 	media := make([]entity.TechCardMediaItem, 0, len(pb.Media))
 	for _, m := range pb.Media {
 		if m.MediaId <= 0 {
@@ -144,11 +179,15 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		if len(c.Part) > maxVarchar255 || len(c.Dimensions) > maxVarchar255 {
 			return nil, fmt.Errorf("callout part and dimensions must be at most %d characters", maxVarchar255)
 		}
+		if c.MediaId < 0 {
+			return nil, fmt.Errorf("callout media_id must not be negative")
+		}
 		callouts = append(callouts, entity.TechCardCallout{
 			Number:      int(c.Number),
 			Part:        nullStringFromPb(c.Part),
 			Description: nullStringFromPb(c.Description),
 			Dimensions:  nullStringFromPb(c.Dimensions),
+			MediaId:     nullInt32FromPb(c.MediaId),
 		})
 	}
 
@@ -179,6 +218,9 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		TargetGender:      gender,
 		Stage:             stage,
 		Status:            nullStringFromPb(pb.Status),
+		ApprovalState:     approvalState,
+		ApprovedBy:        nullStringFromPb(pb.ApprovedBy),
+		ReleasedAt:        nullTimeFromPbTimestamp(pb.ReleasedAt),
 		Version:           nullStringFromPb(pb.Version),
 		RevisionDate:      nullDateFromPbTimestamp(pb.RevisionDate),
 		BaseModelId:       nullInt32FromPb(pb.BaseModelId),
@@ -236,6 +278,7 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Part:        pbStringFromNull(c.Part),
 			Description: pbStringFromNull(c.Description),
 			Dimensions:  pbStringFromNull(c.Dimensions),
+			MediaId:     pbInt32FromNull(c.MediaId),
 		})
 	}
 
@@ -267,6 +310,9 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			TargetGender:      pbGenderFromNull(tc.TargetGender),
 			Stage:             pbTechCardStage(tc.Stage),
 			Status:            pbStringFromNull(tc.Status),
+			ApprovalState:     pbTechCardApprovalState(tc.ApprovalState),
+			ApprovedBy:        pbStringFromNull(tc.ApprovedBy),
+			ReleasedAt:        pbTimestampFromNullTime(tc.ReleasedAt),
 			Version:           pbStringFromNull(tc.Version),
 			RevisionDate:      pbTimestampFromNullTime(tc.RevisionDate),
 			BaseModelId:       pbInt32FromNull(tc.BaseModelId),
@@ -304,16 +350,17 @@ func ConvertEntityTechCardToListItemPb(tc *entity.TechCard) *pb_common.TechCardL
 		return nil
 	}
 	return &pb_common.TechCardListItem{
-		Id:           int32(tc.Id),
-		StyleNumber:  tc.StyleNumber,
-		Name:         tc.Name,
-		Brand:        pbStringFromNull(tc.Brand),
-		Stage:        pbTechCardStage(tc.Stage),
-		Status:       pbStringFromNull(tc.Status),
-		TargetGender: pbGenderFromNull(tc.TargetGender),
-		Season:       pbStringFromNull(tc.Season),
-		CreatedAt:    timestamppb.New(tc.CreatedAt),
-		UpdatedAt:    timestamppb.New(tc.UpdatedAt),
+		Id:            int32(tc.Id),
+		StyleNumber:   tc.StyleNumber,
+		Name:          tc.Name,
+		Brand:         pbStringFromNull(tc.Brand),
+		Stage:         pbTechCardStage(tc.Stage),
+		Status:        pbStringFromNull(tc.Status),
+		ApprovalState: pbTechCardApprovalState(tc.ApprovalState),
+		TargetGender:  pbGenderFromNull(tc.TargetGender),
+		Season:        pbStringFromNull(tc.Season),
+		CreatedAt:     timestamppb.New(tc.CreatedAt),
+		UpdatedAt:     timestamppb.New(tc.UpdatedAt),
 	}
 }
 
@@ -335,6 +382,13 @@ func pbTechCardStage(s entity.TechCardStage) pb_common.TechCardStage {
 		return v
 	}
 	return pb_common.TechCardStage_TECH_CARD_STAGE_UNKNOWN
+}
+
+func pbTechCardApprovalState(s entity.TechCardApprovalState) pb_common.TechCardApprovalState {
+	if v, ok := techCardApprovalStateEntityToPb[s]; ok {
+		return v
+	}
+	return pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_UNKNOWN
 }
 
 func pbTechCardMediaKind(k entity.TechCardMediaKind) pb_common.TechCardMediaKind {
@@ -386,6 +440,15 @@ func pbDecimalFromNull(nd decimal.NullDecimal) *pb_decimal.Decimal {
 		return nil
 	}
 	return &pb_decimal.Decimal{Value: nd.Decimal.String()}
+}
+
+// nullTimeFromPbTimestamp maps an optional timestamp to a nullable instant,
+// preserving the full time (the column is a TIMESTAMP, e.g. released_at).
+func nullTimeFromPbTimestamp(ts *timestamppb.Timestamp) sql.NullTime {
+	if ts == nil {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: ts.AsTime().UTC(), Valid: true}
 }
 
 // nullDateFromPbTimestamp maps an optional timestamp to a nullable DATE value,

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -52,6 +52,19 @@ var techCardApprovalStateEntityToPb = func() map[entity.TechCardApprovalState]pb
 	return m
 }()
 
+var techCardUnitPbToEntity = map[pb_common.TechCardMeasurementUnit]entity.TechCardMeasurementUnit{
+	pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_CM: entity.TechCardUnitCm,
+	pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_IN: entity.TechCardUnitIn,
+}
+
+var techCardUnitEntityToPb = func() map[entity.TechCardMeasurementUnit]pb_common.TechCardMeasurementUnit {
+	m := make(map[entity.TechCardMeasurementUnit]pb_common.TechCardMeasurementUnit, len(techCardUnitPbToEntity))
+	for k, v := range techCardUnitPbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
 var techCardMediaKindPbToEntity = map[pb_common.TechCardMediaKind]entity.TechCardMediaKind{
 	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_FRONT:   entity.TechCardMediaFront,
 	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_BACK:    entity.TechCardMediaBack,
@@ -123,6 +136,15 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		approvalState = a
 	}
 
+	unit := entity.TechCardUnitCm
+	if pb.MeasurementUnit != pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_UNKNOWN {
+		u, ok := techCardUnitPbToEntity[pb.MeasurementUnit]
+		if !ok {
+			return nil, fmt.Errorf("unknown tech card measurement unit: %v", pb.MeasurementUnit)
+		}
+		unit = u
+	}
+
 	gender, err := nullGenderFromPb(pb.TargetGender)
 	if err != nil {
 		return nil, err
@@ -136,9 +158,15 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 	if err != nil {
 		return nil, fmt.Errorf("target_cost: %w", err)
 	}
+	if err := validateMoney(targetCost, "target_cost"); err != nil {
+		return nil, err
+	}
 	targetRetail, err := nullDecimalFromPb(pb.TargetRetailPrice)
 	if err != nil {
 		return nil, fmt.Errorf("target_retail_price: %w", err)
+	}
+	if err := validateMoney(targetRetail, "target_retail_price"); err != nil {
+		return nil, err
 	}
 
 	sizeIds, err := dedupePositiveIDs(pb.SizeIds, "size_ids")
@@ -231,6 +259,7 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		TargetCost:        targetCost,
 		TargetRetailPrice: targetRetail,
 		Currency:          nullStringFromPb(pb.Currency),
+		MeasurementUnit:   unit,
 		Description:       nullStringFromPb(pb.Description),
 		Silhouette:        nullStringFromPb(pb.Silhouette),
 		Collar:            nullStringFromPb(pb.Collar),
@@ -323,6 +352,7 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			TargetCost:        pbDecimalFromNull(tc.TargetCost),
 			TargetRetailPrice: pbDecimalFromNull(tc.TargetRetailPrice),
 			Currency:          pbStringFromNull(tc.Currency),
+			MeasurementUnit:   pbTechCardMeasurementUnit(tc.MeasurementUnit),
 			Description:       pbStringFromNull(tc.Description),
 			Silhouette:        pbStringFromNull(tc.Silhouette),
 			Collar:            pbStringFromNull(tc.Collar),
@@ -391,6 +421,13 @@ func pbTechCardApprovalState(s entity.TechCardApprovalState) pb_common.TechCardA
 	return pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_UNKNOWN
 }
 
+func pbTechCardMeasurementUnit(u entity.TechCardMeasurementUnit) pb_common.TechCardMeasurementUnit {
+	if v, ok := techCardUnitEntityToPb[u]; ok {
+		return v
+	}
+	return pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_CM
+}
+
 func pbTechCardMediaKind(k entity.TechCardMediaKind) pb_common.TechCardMediaKind {
 	if v, ok := techCardMediaKindEntityToPb[k]; ok {
 		return v
@@ -422,6 +459,26 @@ func dedupePositiveIDs(ids []int32, field string) ([]int, error) {
 		out = append(out, int(v))
 	}
 	return out, nil
+}
+
+// validateMoney rejects values that won't fit DECIMAL(10,2): negative, more than
+// 2 fraction digits, or 100000000 and up — so they fail as InvalidArgument
+// instead of a MySQL out-of-range Internal error (mirroring the varchar length
+// checks above).
+func validateMoney(nd decimal.NullDecimal, field string) error {
+	if !nd.Valid {
+		return nil
+	}
+	if nd.Decimal.IsNegative() {
+		return fmt.Errorf("%s must not be negative", field)
+	}
+	if nd.Decimal.Exponent() < -2 {
+		return fmt.Errorf("%s must have at most 2 decimal places", field)
+	}
+	if nd.Decimal.Abs().GreaterThanOrEqual(decimal.NewFromInt(100_000_000)) {
+		return fmt.Errorf("%s must be less than 100000000", field)
+	}
+	return nil
 }
 
 func nullDecimalFromPb(d *pb_decimal.Decimal) (decimal.NullDecimal, error) {

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -16,8 +16,18 @@ import (
 // Column length bounds for tech-card varchar fields, mirroring the schema so that
 // over-length input fails as InvalidArgument rather than a MySQL 1406 Internal error.
 const (
+	maxVarchar32 = 32
 	maxVarchar64 = 64
 	maxCurrency  = 3
+
+	// Decimal bounds mirroring the Phase 2 column types so over-range input fails
+	// as InvalidArgument, not a MySQL out-of-range Internal error.
+	bomQtyMaxFrac   = 3 // consumption/quantity DECIMAL(10,3)
+	bomQtyLimit     = 10_000_000
+	bomPriceMaxFrac = 4 // unit_price DECIMAL(12,4)
+	bomPriceLimit   = 100_000_000
+	pomMaxFrac      = 2 // POM values DECIMAL(8,2)
+	pomLimit        = 1_000_000
 )
 
 var techCardStagePbToEntity = map[pb_common.TechCardStage]entity.TechCardStage{
@@ -76,6 +86,40 @@ var techCardMediaKindPbToEntity = map[pb_common.TechCardMediaKind]entity.TechCar
 var techCardMediaKindEntityToPb = func() map[entity.TechCardMediaKind]pb_common.TechCardMediaKind {
 	m := make(map[entity.TechCardMediaKind]pb_common.TechCardMediaKind, len(techCardMediaKindPbToEntity))
 	for k, v := range techCardMediaKindPbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
+var techCardBomSectionPbToEntity = map[pb_common.TechCardBomSection]entity.TechCardBomSection{
+	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC:      entity.BomSectionFabric,
+	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_LINING:      entity.BomSectionLining,
+	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_INTERLINING: entity.BomSectionInterlining,
+	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_INSULATION:  entity.BomSectionInsulation,
+	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_HARDWARE:    entity.BomSectionHardware,
+	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_THREAD:      entity.BomSectionThread,
+	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_LABEL:       entity.BomSectionLabel,
+	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_PACKAGING:   entity.BomSectionPackaging,
+}
+
+var techCardBomSectionEntityToPb = func() map[entity.TechCardBomSection]pb_common.TechCardBomSection {
+	m := make(map[entity.TechCardBomSection]pb_common.TechCardBomSection, len(techCardBomSectionPbToEntity))
+	for k, v := range techCardBomSectionPbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
+var techCardLabDipPbToEntity = map[pb_common.TechCardLabDipStatus]entity.TechCardLabDipStatus{
+	pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_PENDING:   entity.LabDipPending,
+	pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_SUBMITTED: entity.LabDipSubmitted,
+	pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_APPROVED:  entity.LabDipApproved,
+	pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_REJECTED:  entity.LabDipRejected,
+}
+
+var techCardLabDipEntityToPb = func() map[entity.TechCardLabDipStatus]pb_common.TechCardLabDipStatus {
+	m := make(map[entity.TechCardLabDipStatus]pb_common.TechCardLabDipStatus, len(techCardLabDipPbToEntity))
+	for k, v := range techCardLabDipPbToEntity {
 		m[v] = k
 	}
 	return m
@@ -236,6 +280,21 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		})
 	}
 
+	// materials (Phase 2). Colorways are parsed first so BOM colorway_index can be
+	// range-checked against them.
+	colorways, err := parseTechCardColorways(pb.Colorways)
+	if err != nil {
+		return nil, err
+	}
+	bomItems, err := parseTechCardBomItems(pb.BomItems, len(colorways))
+	if err != nil {
+		return nil, err
+	}
+	pomPoints, err := parseTechCardPomPoints(pb.PomPoints, sizeIds)
+	if err != nil {
+		return nil, err
+	}
+
 	return &entity.TechCardInsert{
 		StyleNumber:       pb.StyleNumber,
 		Name:              pb.Name,
@@ -275,6 +334,9 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		Media:             media,
 		Callouts:          callouts,
 		Revisions:         revisions,
+		BomItems:          bomItems,
+		Colorways:         colorways,
+		PomPoints:         pomPoints,
 	}, nil
 }
 
@@ -368,6 +430,9 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Media:             media,
 			Callouts:          callouts,
 			Revisions:         revisions,
+			BomItems:          techCardBomItemsToPb(tc.BomItems),
+			Colorways:         techCardColorwaysToPb(tc.Colorways),
+			PomPoints:         techCardPomPointsToPb(tc.PomPoints),
 		},
 		ResolvedMedia: resolved,
 	}
@@ -435,6 +500,316 @@ func pbTechCardMediaKind(k entity.TechCardMediaKind) pb_common.TechCardMediaKind
 	return pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_PREVIEW
 }
 
+// --- materials (Phase 2): parse pb -> entity ---
+
+func parseTechCardColorways(pbs []*pb_common.TechCardColorway) ([]entity.TechCardColorway, error) {
+	out := make([]entity.TechCardColorway, 0, len(pbs))
+	for _, c := range pbs {
+		if c.Name == "" {
+			return nil, fmt.Errorf("colorway name is required")
+		}
+		if len(c.Name) > maxVarchar255 {
+			return nil, fmt.Errorf("colorway name must be at most %d characters", maxVarchar255)
+		}
+		if len(c.Code) > maxVarchar64 {
+			return nil, fmt.Errorf("colorway code must be at most %d characters", maxVarchar64)
+		}
+		if c.ProductId < 0 {
+			return nil, fmt.Errorf("colorway product_id must not be negative")
+		}
+		status := entity.LabDipPending
+		if c.LabDipStatus != pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_UNKNOWN {
+			s, ok := techCardLabDipPbToEntity[c.LabDipStatus]
+			if !ok {
+				return nil, fmt.Errorf("unknown lab dip status: %v", c.LabDipStatus)
+			}
+			status = s
+		}
+		out = append(out, entity.TechCardColorway{
+			Code:         nullStringFromPb(c.Code),
+			Name:         c.Name,
+			LabDipStatus: status,
+			ProductId:    nullInt32FromPb(c.ProductId),
+			Comment:      nullStringFromPb(c.Comment),
+		})
+	}
+	return out, nil
+}
+
+func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int) ([]entity.TechCardBomItem, error) {
+	out := make([]entity.TechCardBomItem, 0, len(pbs))
+	for _, b := range pbs {
+		section, ok := techCardBomSectionPbToEntity[b.Section]
+		if !ok {
+			return nil, fmt.Errorf("bom item section is required and must be valid")
+		}
+		if b.Name == "" {
+			return nil, fmt.Errorf("bom item name is required")
+		}
+		for _, c := range []struct {
+			field string
+			val   string
+			max   int
+		}{
+			{"bom name", b.Name, maxVarchar255},
+			{"bom placement", b.Placement, maxVarchar255},
+			{"bom supplier", b.Supplier, maxVarchar255},
+			{"bom supplier_ref", b.SupplierRef, maxVarchar255},
+			{"bom color", b.Color, maxVarchar255},
+			{"bom composition", b.Composition, maxVarchar255},
+			{"bom spec", b.Spec, maxVarchar255},
+			{"bom unit", b.Unit, maxVarchar32},
+		} {
+			if len(c.val) > c.max {
+				return nil, fmt.Errorf("%s must be at most %d characters", c.field, c.max)
+			}
+		}
+		if b.Currency != "" && len(b.Currency) != maxCurrency {
+			return nil, fmt.Errorf("bom currency must be a 3-letter ISO 4217 code")
+		}
+		consumption, err := nullDecimalFromPb(b.Consumption)
+		if err != nil {
+			return nil, fmt.Errorf("bom consumption: %w", err)
+		}
+		if err := validateDecimalScale(consumption, "bom consumption", bomQtyMaxFrac, bomQtyLimit); err != nil {
+			return nil, err
+		}
+		quantity, err := nullDecimalFromPb(b.Quantity)
+		if err != nil {
+			return nil, fmt.Errorf("bom quantity: %w", err)
+		}
+		if err := validateDecimalScale(quantity, "bom quantity", bomQtyMaxFrac, bomQtyLimit); err != nil {
+			return nil, err
+		}
+		unitPrice, err := nullDecimalFromPb(b.UnitPrice)
+		if err != nil {
+			return nil, fmt.Errorf("bom unit_price: %w", err)
+		}
+		if err := validateDecimalScale(unitPrice, "bom unit_price", bomPriceMaxFrac, bomPriceLimit); err != nil {
+			return nil, err
+		}
+
+		colors := make([]entity.TechCardBomColorwayColor, 0, len(b.ColorwayColors))
+		seen := make(map[int]bool, len(b.ColorwayColors))
+		for _, cc := range b.ColorwayColors {
+			idx := int(cc.ColorwayIndex)
+			if idx < 0 || idx >= colorwayCount {
+				return nil, fmt.Errorf("bom colorway_index %d out of range (have %d colorways)", idx, colorwayCount)
+			}
+			if seen[idx] {
+				return nil, fmt.Errorf("bom item has duplicate colorway_index %d", idx)
+			}
+			seen[idx] = true
+			if len(cc.Color) > maxVarchar255 || len(cc.Pantone) > maxVarchar64 {
+				return nil, fmt.Errorf("bom colorway color/pantone too long")
+			}
+			colors = append(colors, entity.TechCardBomColorwayColor{
+				ColorwayIndex: idx,
+				Color:         nullStringFromPb(cc.Color),
+				Pantone:       nullStringFromPb(cc.Pantone),
+			})
+		}
+
+		out = append(out, entity.TechCardBomItem{
+			Section:        section,
+			Name:           b.Name,
+			Placement:      nullStringFromPb(b.Placement),
+			Supplier:       nullStringFromPb(b.Supplier),
+			SupplierRef:    nullStringFromPb(b.SupplierRef),
+			Color:          nullStringFromPb(b.Color),
+			Composition:    nullStringFromPb(b.Composition),
+			Spec:           nullStringFromPb(b.Spec),
+			Consumption:    consumption,
+			Unit:           nullStringFromPb(b.Unit),
+			Quantity:       quantity,
+			UnitPrice:      unitPrice,
+			Currency:       nullStringFromPb(b.Currency),
+			Comment:        nullStringFromPb(b.Comment),
+			ColorwayColors: colors,
+		})
+	}
+	return out, nil
+}
+
+func parseTechCardPomPoints(pbs []*pb_common.TechCardPomPoint, sizeIds []int) ([]entity.TechCardPomPoint, error) {
+	sizeSet := make(map[int]bool, len(sizeIds))
+	for _, s := range sizeIds {
+		sizeSet[s] = true
+	}
+	out := make([]entity.TechCardPomPoint, 0, len(pbs))
+	for _, p := range pbs {
+		if p.Name == "" {
+			return nil, fmt.Errorf("pom point name is required")
+		}
+		if len(p.Name) > maxVarchar255 || len(p.Section) > maxVarchar255 {
+			return nil, fmt.Errorf("pom point name/section must be at most %d characters", maxVarchar255)
+		}
+		if len(p.Code) > maxVarchar32 {
+			return nil, fmt.Errorf("pom code must be at most %d characters", maxVarchar32)
+		}
+		baseValue, err := nullDecimalFromPb(p.BaseValue)
+		if err != nil {
+			return nil, fmt.Errorf("pom base_value: %w", err)
+		}
+		if err := validateDecimalScale(baseValue, "pom base_value", pomMaxFrac, pomLimit); err != nil {
+			return nil, err
+		}
+		tolerance, err := nullDecimalFromPb(p.Tolerance)
+		if err != nil {
+			return nil, fmt.Errorf("pom tolerance: %w", err)
+		}
+		if err := validateDecimalScale(tolerance, "pom tolerance", pomMaxFrac, pomLimit); err != nil {
+			return nil, err
+		}
+
+		grades := make([]entity.TechCardPomGrade, 0, len(p.Grades))
+		seenSize := make(map[int]bool, len(p.Grades))
+		for _, g := range p.Grades {
+			sid := int(g.SizeId)
+			if !sizeSet[sid] {
+				return nil, fmt.Errorf("pom grade size_id %d must be one of size_ids", sid)
+			}
+			if seenSize[sid] {
+				return nil, fmt.Errorf("pom point has duplicate grade for size_id %d", sid)
+			}
+			seenSize[sid] = true
+			val, err := requiredDecimalFromPb(g.Value, "pom grade value", pomMaxFrac, pomLimit)
+			if err != nil {
+				return nil, err
+			}
+			grades = append(grades, entity.TechCardPomGrade{SizeId: sid, Value: val})
+		}
+
+		actuals := make([]entity.TechCardPomActual, 0, len(p.Actuals))
+		for _, a := range p.Actuals {
+			if a.FittingId < 0 {
+				return nil, fmt.Errorf("pom actual fitting_id must not be negative")
+			}
+			if len(a.Label) > maxVarchar64 {
+				return nil, fmt.Errorf("pom actual label must be at most %d characters", maxVarchar64)
+			}
+			val, err := requiredDecimalFromPb(a.Value, "pom actual value", pomMaxFrac, pomLimit)
+			if err != nil {
+				return nil, err
+			}
+			actuals = append(actuals, entity.TechCardPomActual{
+				FittingId: nullInt32FromPb(a.FittingId),
+				Label:     nullStringFromPb(a.Label),
+				Value:     val,
+			})
+		}
+
+		out = append(out, entity.TechCardPomPoint{
+			Section:      nullStringFromPb(p.Section),
+			Code:         nullStringFromPb(p.Code),
+			Name:         p.Name,
+			HowToMeasure: nullStringFromPb(p.HowToMeasure),
+			BaseValue:    baseValue,
+			Tolerance:    tolerance,
+			Grades:       grades,
+			Actuals:      actuals,
+		})
+	}
+	return out, nil
+}
+
+// --- materials (Phase 2): emit entity -> pb ---
+
+func techCardColorwaysToPb(cws []entity.TechCardColorway) []*pb_common.TechCardColorway {
+	out := make([]*pb_common.TechCardColorway, 0, len(cws))
+	for _, c := range cws {
+		out = append(out, &pb_common.TechCardColorway{
+			Code:         pbStringFromNull(c.Code),
+			Name:         c.Name,
+			LabDipStatus: pbLabDipStatus(c.LabDipStatus),
+			ProductId:    pbInt32FromNull(c.ProductId),
+			Comment:      pbStringFromNull(c.Comment),
+		})
+	}
+	return out
+}
+
+func techCardBomItemsToPb(items []entity.TechCardBomItem) []*pb_common.TechCardBomItem {
+	out := make([]*pb_common.TechCardBomItem, 0, len(items))
+	for i := range items {
+		b := &items[i]
+		colors := make([]*pb_common.TechCardBomColorwayColor, 0, len(b.ColorwayColors))
+		for _, cc := range b.ColorwayColors {
+			colors = append(colors, &pb_common.TechCardBomColorwayColor{
+				ColorwayIndex: int32(cc.ColorwayIndex),
+				Color:         pbStringFromNull(cc.Color),
+				Pantone:       pbStringFromNull(cc.Pantone),
+			})
+		}
+		out = append(out, &pb_common.TechCardBomItem{
+			Section:        pbBomSection(b.Section),
+			Name:           b.Name,
+			Placement:      pbStringFromNull(b.Placement),
+			Supplier:       pbStringFromNull(b.Supplier),
+			SupplierRef:    pbStringFromNull(b.SupplierRef),
+			Color:          pbStringFromNull(b.Color),
+			Composition:    pbStringFromNull(b.Composition),
+			Spec:           pbStringFromNull(b.Spec),
+			Consumption:    pbDecimalFromNull(b.Consumption),
+			Unit:           pbStringFromNull(b.Unit),
+			Quantity:       pbDecimalFromNull(b.Quantity),
+			UnitPrice:      pbDecimalFromNull(b.UnitPrice),
+			Currency:       pbStringFromNull(b.Currency),
+			Comment:        pbStringFromNull(b.Comment),
+			ColorwayColors: colors,
+			LineTotal:      pbDecimalFromNull(b.LineTotal()),
+		})
+	}
+	return out
+}
+
+func techCardPomPointsToPb(points []entity.TechCardPomPoint) []*pb_common.TechCardPomPoint {
+	out := make([]*pb_common.TechCardPomPoint, 0, len(points))
+	for i := range points {
+		p := &points[i]
+		grades := make([]*pb_common.TechCardPomGrade, 0, len(p.Grades))
+		for _, g := range p.Grades {
+			grades = append(grades, &pb_common.TechCardPomGrade{
+				SizeId: int32(g.SizeId),
+				Value:  pbDecimalFromDecimal(g.Value),
+			})
+		}
+		actuals := make([]*pb_common.TechCardPomActual, 0, len(p.Actuals))
+		for _, a := range p.Actuals {
+			actuals = append(actuals, &pb_common.TechCardPomActual{
+				FittingId: pbInt32FromNull(a.FittingId),
+				Label:     pbStringFromNull(a.Label),
+				Value:     pbDecimalFromDecimal(a.Value),
+			})
+		}
+		out = append(out, &pb_common.TechCardPomPoint{
+			Section:      pbStringFromNull(p.Section),
+			Code:         pbStringFromNull(p.Code),
+			Name:         p.Name,
+			HowToMeasure: pbStringFromNull(p.HowToMeasure),
+			BaseValue:    pbDecimalFromNull(p.BaseValue),
+			Tolerance:    pbDecimalFromNull(p.Tolerance),
+			Grades:       grades,
+			Actuals:      actuals,
+		})
+	}
+	return out
+}
+
+func pbBomSection(s entity.TechCardBomSection) pb_common.TechCardBomSection {
+	if v, ok := techCardBomSectionEntityToPb[s]; ok {
+		return v
+	}
+	return pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_UNKNOWN
+}
+
+func pbLabDipStatus(s entity.TechCardLabDipStatus) pb_common.TechCardLabDipStatus {
+	if v, ok := techCardLabDipEntityToPb[s]; ok {
+		return v
+	}
+	return pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_PENDING
+}
+
 // --- shared helpers ---
 
 func intsToInt32(in []int) []int32 {
@@ -497,6 +872,45 @@ func pbDecimalFromNull(nd decimal.NullDecimal) *pb_decimal.Decimal {
 		return nil
 	}
 	return &pb_decimal.Decimal{Value: nd.Decimal.String()}
+}
+
+func pbDecimalFromDecimal(d decimal.Decimal) *pb_decimal.Decimal {
+	return &pb_decimal.Decimal{Value: d.String()}
+}
+
+// validateDecimalScale rejects a non-null value that won't fit its column:
+// negative, more than maxFrac fraction digits, or >= limit (mirrors validateMoney
+// but parameterised for the Phase 2 decimal columns).
+func validateDecimalScale(nd decimal.NullDecimal, field string, maxFrac int, limit int64) error {
+	if !nd.Valid {
+		return nil
+	}
+	if nd.Decimal.IsNegative() {
+		return fmt.Errorf("%s must not be negative", field)
+	}
+	if nd.Decimal.Exponent() < int32(-maxFrac) {
+		return fmt.Errorf("%s must have at most %d decimal places", field, maxFrac)
+	}
+	if nd.Decimal.Abs().GreaterThanOrEqual(decimal.NewFromInt(limit)) {
+		return fmt.Errorf("%s must be less than %d", field, limit)
+	}
+	return nil
+}
+
+// requiredDecimalFromPb parses a required decimal column (NOT NULL), erroring when
+// absent or out of range.
+func requiredDecimalFromPb(d *pb_decimal.Decimal, field string, maxFrac int, limit int64) (decimal.Decimal, error) {
+	nd, err := nullDecimalFromPb(d)
+	if err != nil {
+		return decimal.Decimal{}, fmt.Errorf("%s: %w", field, err)
+	}
+	if !nd.Valid {
+		return decimal.Decimal{}, fmt.Errorf("%s is required", field)
+	}
+	if err := validateDecimalScale(nd, field, maxFrac, limit); err != nil {
+		return decimal.Decimal{}, err
+	}
+	return nd.Decimal, nil
 }
 
 // nullTimeFromPbTimestamp maps an optional timestamp to a nullable instant,

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -1,0 +1,406 @@
+package dto
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
+	"github.com/shopspring/decimal"
+	pb_decimal "google.golang.org/genproto/googleapis/type/decimal"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Column length bounds for tech-card varchar fields, mirroring the schema so that
+// over-length input fails as InvalidArgument rather than a MySQL 1406 Internal error.
+const (
+	maxVarchar64 = 64
+	maxCurrency  = 3
+)
+
+var techCardStagePbToEntity = map[pb_common.TechCardStage]entity.TechCardStage{
+	pb_common.TechCardStage_TECH_CARD_STAGE_PROTO: entity.TechCardStageProto,
+	pb_common.TechCardStage_TECH_CARD_STAGE_FIT:   entity.TechCardStageFit,
+	pb_common.TechCardStage_TECH_CARD_STAGE_SMS:   entity.TechCardStageSMS,
+	pb_common.TechCardStage_TECH_CARD_STAGE_PP:    entity.TechCardStagePP,
+	pb_common.TechCardStage_TECH_CARD_STAGE_PROD:  entity.TechCardStageProd,
+}
+
+var techCardStageEntityToPb = func() map[entity.TechCardStage]pb_common.TechCardStage {
+	m := make(map[entity.TechCardStage]pb_common.TechCardStage, len(techCardStagePbToEntity))
+	for k, v := range techCardStagePbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
+var techCardMediaKindPbToEntity = map[pb_common.TechCardMediaKind]entity.TechCardMediaKind{
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_FRONT:   entity.TechCardMediaFront,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_BACK:    entity.TechCardMediaBack,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_DETAIL:  entity.TechCardMediaDetail,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_LINING:  entity.TechCardMediaLining,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_PREVIEW: entity.TechCardMediaPreview,
+}
+
+var techCardMediaKindEntityToPb = func() map[entity.TechCardMediaKind]pb_common.TechCardMediaKind {
+	m := make(map[entity.TechCardMediaKind]pb_common.TechCardMediaKind, len(techCardMediaKindPbToEntity))
+	for k, v := range techCardMediaKindPbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
+// ConvertPbTechCardInsertToEntity converts a pb_common.TechCardInsert to an
+// entity.TechCardInsert, validating identifiers, lengths, enums and child lists.
+func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.TechCardInsert, error) {
+	if pb == nil {
+		return nil, fmt.Errorf("tech card insert is nil")
+	}
+	if pb.StyleNumber == "" {
+		return nil, fmt.Errorf("style_number is required")
+	}
+	if pb.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	for _, c := range []struct {
+		field string
+		val   string
+		max   int
+	}{
+		{"style_number", pb.StyleNumber, maxVarchar255},
+		{"name", pb.Name, maxVarchar255},
+		{"brand", pb.Brand, maxVarchar255},
+		{"season", pb.Season, maxVarchar255},
+		{"collection", pb.Collection, maxVarchar255},
+		{"status", pb.Status, maxVarchar255},
+		{"version", pb.Version, maxVarchar64},
+		{"designer", pb.Designer, maxVarchar255},
+		{"constructor", pb.Constructor, maxVarchar255},
+		{"technologist", pb.Technologist, maxVarchar255},
+	} {
+		if len(c.val) > c.max {
+			return nil, fmt.Errorf("%s must be at most %d characters", c.field, c.max)
+		}
+	}
+	if pb.Currency != "" && len(pb.Currency) != maxCurrency {
+		return nil, fmt.Errorf("currency must be a 3-letter ISO 4217 code")
+	}
+
+	stage := entity.TechCardStageProto
+	if pb.Stage != pb_common.TechCardStage_TECH_CARD_STAGE_UNKNOWN {
+		s, ok := techCardStagePbToEntity[pb.Stage]
+		if !ok {
+			return nil, fmt.Errorf("unknown tech card stage: %v", pb.Stage)
+		}
+		stage = s
+	}
+
+	gender, err := nullGenderFromPb(pb.TargetGender)
+	if err != nil {
+		return nil, err
+	}
+
+	if pb.CategoryId < 0 || pb.BaseModelId < 0 || pb.BaseSampleSizeId < 0 {
+		return nil, fmt.Errorf("category_id, base_model_id and base_sample_size_id must not be negative")
+	}
+
+	targetCost, err := nullDecimalFromPb(pb.TargetCost)
+	if err != nil {
+		return nil, fmt.Errorf("target_cost: %w", err)
+	}
+	targetRetail, err := nullDecimalFromPb(pb.TargetRetailPrice)
+	if err != nil {
+		return nil, fmt.Errorf("target_retail_price: %w", err)
+	}
+
+	sizeIds, err := dedupePositiveIDs(pb.SizeIds, "size_ids")
+	if err != nil {
+		return nil, err
+	}
+	productIds, err := dedupePositiveIDs(pb.ProductIds, "product_ids")
+	if err != nil {
+		return nil, err
+	}
+
+	media := make([]entity.TechCardMediaItem, 0, len(pb.Media))
+	for _, m := range pb.Media {
+		if m.MediaId <= 0 {
+			return nil, fmt.Errorf("tech card media media_id must be positive")
+		}
+		kind := entity.TechCardMediaPreview
+		if m.Kind != pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_UNKNOWN {
+			k, ok := techCardMediaKindPbToEntity[m.Kind]
+			if !ok {
+				return nil, fmt.Errorf("unknown tech card media kind: %v", m.Kind)
+			}
+			kind = k
+		}
+		media = append(media, entity.TechCardMediaItem{MediaId: int(m.MediaId), Kind: kind})
+	}
+
+	callouts := make([]entity.TechCardCallout, 0, len(pb.Callouts))
+	for _, c := range pb.Callouts {
+		if len(c.Part) > maxVarchar255 || len(c.Dimensions) > maxVarchar255 {
+			return nil, fmt.Errorf("callout part and dimensions must be at most %d characters", maxVarchar255)
+		}
+		callouts = append(callouts, entity.TechCardCallout{
+			Number:      int(c.Number),
+			Part:        nullStringFromPb(c.Part),
+			Description: nullStringFromPb(c.Description),
+			Dimensions:  nullStringFromPb(c.Dimensions),
+		})
+	}
+
+	revisions := make([]entity.TechCardRevision, 0, len(pb.Revisions))
+	for _, r := range pb.Revisions {
+		if len(r.Version) > maxVarchar64 {
+			return nil, fmt.Errorf("revision version must be at most %d characters", maxVarchar64)
+		}
+		if len(r.Author) > maxVarchar255 || len(r.Section) > maxVarchar255 {
+			return nil, fmt.Errorf("revision author and section must be at most %d characters", maxVarchar255)
+		}
+		revisions = append(revisions, entity.TechCardRevision{
+			Version:      nullStringFromPb(r.Version),
+			RevisionDate: nullDateFromPbTimestamp(r.RevisionDate),
+			Author:       nullStringFromPb(r.Author),
+			Section:      nullStringFromPb(r.Section),
+			ChangeNote:   nullStringFromPb(r.ChangeNote),
+		})
+	}
+
+	return &entity.TechCardInsert{
+		StyleNumber:       pb.StyleNumber,
+		Name:              pb.Name,
+		Brand:             nullStringFromPb(pb.Brand),
+		Season:            nullStringFromPb(pb.Season),
+		Collection:        nullStringFromPb(pb.Collection),
+		CategoryId:        nullInt32FromPb(pb.CategoryId),
+		TargetGender:      gender,
+		Stage:             stage,
+		Status:            nullStringFromPb(pb.Status),
+		Version:           nullStringFromPb(pb.Version),
+		RevisionDate:      nullDateFromPbTimestamp(pb.RevisionDate),
+		BaseModelId:       nullInt32FromPb(pb.BaseModelId),
+		BaseSampleSizeId:  nullInt32FromPb(pb.BaseSampleSizeId),
+		Designer:          nullStringFromPb(pb.Designer),
+		Constructor:       nullStringFromPb(pb.Constructor),
+		Technologist:      nullStringFromPb(pb.Technologist),
+		TargetCost:        targetCost,
+		TargetRetailPrice: targetRetail,
+		Currency:          nullStringFromPb(pb.Currency),
+		Description:       nullStringFromPb(pb.Description),
+		Silhouette:        nullStringFromPb(pb.Silhouette),
+		Collar:            nullStringFromPb(pb.Collar),
+		Fastening:         nullStringFromPb(pb.Fastening),
+		Pockets:           nullStringFromPb(pb.Pockets),
+		SleeveCuff:        nullStringFromPb(pb.SleeveCuff),
+		ExtraDetails:      nullStringFromPb(pb.ExtraDetails),
+		Topstitching:      nullStringFromPb(pb.Topstitching),
+		AuxMaterials:      nullStringFromPb(pb.AuxMaterials),
+		Notes:             nullStringFromPb(pb.Notes),
+		SizeIds:           sizeIds,
+		ProductIds:        productIds,
+		Media:             media,
+		Callouts:          callouts,
+		Revisions:         revisions,
+	}, nil
+}
+
+// ConvertEntityTechCardToPb converts an entity.TechCard to pb_common.TechCard.
+func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
+	if tc == nil {
+		return nil
+	}
+
+	media := make([]*pb_common.TechCardMediaItem, 0, len(tc.Media))
+	for _, m := range tc.Media {
+		media = append(media, &pb_common.TechCardMediaItem{
+			MediaId: int32(m.MediaId),
+			Kind:    pbTechCardMediaKind(m.Kind),
+		})
+	}
+
+	resolved := make([]*pb_common.TechCardMediaFull, 0, len(tc.ResolvedMedia))
+	for i := range tc.ResolvedMedia {
+		resolved = append(resolved, &pb_common.TechCardMediaFull{
+			Media: ConvertEntityToCommonMedia(&tc.ResolvedMedia[i].Media),
+			Kind:  pbTechCardMediaKind(tc.ResolvedMedia[i].Kind),
+		})
+	}
+
+	callouts := make([]*pb_common.TechCardCallout, 0, len(tc.Callouts))
+	for _, c := range tc.Callouts {
+		callouts = append(callouts, &pb_common.TechCardCallout{
+			Number:      int32(c.Number),
+			Part:        pbStringFromNull(c.Part),
+			Description: pbStringFromNull(c.Description),
+			Dimensions:  pbStringFromNull(c.Dimensions),
+		})
+	}
+
+	revisions := make([]*pb_common.TechCardRevision, 0, len(tc.Revisions))
+	for _, r := range tc.Revisions {
+		revisions = append(revisions, &pb_common.TechCardRevision{
+			Version:      pbStringFromNull(r.Version),
+			RevisionDate: pbTimestampFromNullTime(r.RevisionDate),
+			Author:       pbStringFromNull(r.Author),
+			Section:      pbStringFromNull(r.Section),
+			ChangeNote:   pbStringFromNull(r.ChangeNote),
+		})
+	}
+
+	sizeIds := intsToInt32(tc.SizeIds)
+	productIds := intsToInt32(tc.ProductIds)
+
+	return &pb_common.TechCard{
+		Id:        int32(tc.Id),
+		CreatedAt: timestamppb.New(tc.CreatedAt),
+		UpdatedAt: timestamppb.New(tc.UpdatedAt),
+		TechCard: &pb_common.TechCardInsert{
+			StyleNumber:       tc.StyleNumber,
+			Name:              tc.Name,
+			Brand:             pbStringFromNull(tc.Brand),
+			Season:            pbStringFromNull(tc.Season),
+			Collection:        pbStringFromNull(tc.Collection),
+			CategoryId:        pbInt32FromNull(tc.CategoryId),
+			TargetGender:      pbGenderFromNull(tc.TargetGender),
+			Stage:             pbTechCardStage(tc.Stage),
+			Status:            pbStringFromNull(tc.Status),
+			Version:           pbStringFromNull(tc.Version),
+			RevisionDate:      pbTimestampFromNullTime(tc.RevisionDate),
+			BaseModelId:       pbInt32FromNull(tc.BaseModelId),
+			BaseSampleSizeId:  pbInt32FromNull(tc.BaseSampleSizeId),
+			Designer:          pbStringFromNull(tc.Designer),
+			Constructor:       pbStringFromNull(tc.Constructor),
+			Technologist:      pbStringFromNull(tc.Technologist),
+			TargetCost:        pbDecimalFromNull(tc.TargetCost),
+			TargetRetailPrice: pbDecimalFromNull(tc.TargetRetailPrice),
+			Currency:          pbStringFromNull(tc.Currency),
+			Description:       pbStringFromNull(tc.Description),
+			Silhouette:        pbStringFromNull(tc.Silhouette),
+			Collar:            pbStringFromNull(tc.Collar),
+			Fastening:         pbStringFromNull(tc.Fastening),
+			Pockets:           pbStringFromNull(tc.Pockets),
+			SleeveCuff:        pbStringFromNull(tc.SleeveCuff),
+			ExtraDetails:      pbStringFromNull(tc.ExtraDetails),
+			Topstitching:      pbStringFromNull(tc.Topstitching),
+			AuxMaterials:      pbStringFromNull(tc.AuxMaterials),
+			Notes:             pbStringFromNull(tc.Notes),
+			SizeIds:           sizeIds,
+			ProductIds:        productIds,
+			Media:             media,
+			Callouts:          callouts,
+			Revisions:         revisions,
+		},
+		ResolvedMedia: resolved,
+	}
+}
+
+// ConvertEntityTechCardToListItemPb converts a header-only entity.TechCard to a
+// lightweight pb_common.TechCardListItem for list views.
+func ConvertEntityTechCardToListItemPb(tc *entity.TechCard) *pb_common.TechCardListItem {
+	if tc == nil {
+		return nil
+	}
+	return &pb_common.TechCardListItem{
+		Id:           int32(tc.Id),
+		StyleNumber:  tc.StyleNumber,
+		Name:         tc.Name,
+		Brand:        pbStringFromNull(tc.Brand),
+		Stage:        pbTechCardStage(tc.Stage),
+		Status:       pbStringFromNull(tc.Status),
+		TargetGender: pbGenderFromNull(tc.TargetGender),
+		Season:       pbStringFromNull(tc.Season),
+		CreatedAt:    timestamppb.New(tc.CreatedAt),
+		UpdatedAt:    timestamppb.New(tc.UpdatedAt),
+	}
+}
+
+// ConvertPbTechCardStageToEntityString maps a stage filter enum to its entity
+// string, returning "" for UNKNOWN (no filter).
+func ConvertPbTechCardStageToEntityString(s pb_common.TechCardStage) (string, error) {
+	if s == pb_common.TechCardStage_TECH_CARD_STAGE_UNKNOWN {
+		return "", nil
+	}
+	e, ok := techCardStagePbToEntity[s]
+	if !ok {
+		return "", fmt.Errorf("unknown tech card stage: %v", s)
+	}
+	return string(e), nil
+}
+
+func pbTechCardStage(s entity.TechCardStage) pb_common.TechCardStage {
+	if v, ok := techCardStageEntityToPb[s]; ok {
+		return v
+	}
+	return pb_common.TechCardStage_TECH_CARD_STAGE_UNKNOWN
+}
+
+func pbTechCardMediaKind(k entity.TechCardMediaKind) pb_common.TechCardMediaKind {
+	if v, ok := techCardMediaKindEntityToPb[k]; ok {
+		return v
+	}
+	return pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_PREVIEW
+}
+
+// --- shared helpers ---
+
+func intsToInt32(in []int) []int32 {
+	out := make([]int32, 0, len(in))
+	for _, v := range in {
+		out = append(out, int32(v))
+	}
+	return out
+}
+
+func dedupePositiveIDs(ids []int32, field string) ([]int, error) {
+	out := make([]int, 0, len(ids))
+	seen := make(map[int]bool, len(ids))
+	for _, v := range ids {
+		if v <= 0 {
+			return nil, fmt.Errorf("%s must be positive", field)
+		}
+		if seen[int(v)] {
+			return nil, fmt.Errorf("%s contains a duplicate: %d", field, v)
+		}
+		seen[int(v)] = true
+		out = append(out, int(v))
+	}
+	return out, nil
+}
+
+func nullDecimalFromPb(d *pb_decimal.Decimal) (decimal.NullDecimal, error) {
+	if d == nil || d.Value == "" {
+		return decimal.NullDecimal{}, nil
+	}
+	v, err := decimal.NewFromString(d.Value)
+	if err != nil {
+		return decimal.NullDecimal{}, fmt.Errorf("invalid decimal %q: %w", d.Value, err)
+	}
+	return decimal.NullDecimal{Decimal: v, Valid: true}, nil
+}
+
+func pbDecimalFromNull(nd decimal.NullDecimal) *pb_decimal.Decimal {
+	if !nd.Valid {
+		return nil
+	}
+	return &pb_decimal.Decimal{Value: nd.Decimal.String()}
+}
+
+// nullDateFromPbTimestamp maps an optional timestamp to a nullable DATE value,
+// normalised to UTC midnight (the column is a DATE).
+func nullDateFromPbTimestamp(ts *timestamppb.Timestamp) sql.NullTime {
+	if ts == nil {
+		return sql.NullTime{}
+	}
+	t := ts.AsTime().UTC()
+	return sql.NullTime{Time: time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC), Valid: true}
+}
+
+func pbTimestampFromNullTime(nt sql.NullTime) *timestamppb.Timestamp {
+	if !nt.Valid {
+		return nil
+	}
+	return timestamppb.New(nt.Time)
+}

--- a/internal/dto/techcard_production.go
+++ b/internal/dto/techcard_production.go
@@ -1,0 +1,413 @@
+package dto
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
+	"github.com/shopspring/decimal"
+	pb_decimal "google.golang.org/genproto/googleapis/type/decimal"
+)
+
+// Decimal bounds for the Phase 3 production/costing columns.
+const (
+	maxVarchar128 = 128
+
+	costMaxFrac = 2 // cost articles DECIMAL(12,2)
+	costLimit   = 10_000_000_000
+	markupFrac  = 3 // markup_multiplier DECIMAL(6,3)
+	markupLimit = 1_000
+	weightFrac  = 3 // weight DECIMAL(8,3)
+	weightLimit = 100_000
+	stitchFrac  = 2 // stitches_per_cm DECIMAL(5,2)
+	stitchLimit = 1_000
+)
+
+var techCardLabelTypePbToEntity = map[pb_common.TechCardLabelType]entity.TechCardLabelType{
+	pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_MAIN:    entity.LabelTypeMain,
+	pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_SIZE:    entity.LabelTypeSize,
+	pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_CARE:    entity.LabelTypeCare,
+	pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_ORIGIN:  entity.LabelTypeOrigin,
+	pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_FLAG:    entity.LabelTypeFlag,
+	pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_HANGTAG: entity.LabelTypeHangtag,
+	pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_BARCODE: entity.LabelTypeBarcode,
+	pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_SPECIAL: entity.LabelTypeSpecial,
+}
+
+var techCardLabelTypeEntityToPb = func() map[entity.TechCardLabelType]pb_common.TechCardLabelType {
+	m := make(map[entity.TechCardLabelType]pb_common.TechCardLabelType, len(techCardLabelTypePbToEntity))
+	for k, v := range techCardLabelTypePbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
+// --- parse pb -> entity ---
+
+func parseTechCardConstruction(pb *pb_common.TechCardConstruction) (*entity.TechCardConstruction, error) {
+	if pb == nil {
+		return nil, nil
+	}
+	for _, c := range []struct {
+		field string
+		val   string
+		max   int
+	}{
+		{"construction main_stitch_type", pb.MainStitchType, maxVarchar255},
+		{"construction stitch_density", pb.StitchDensity, maxVarchar64},
+		{"construction overlock_threads", pb.OverlockThreads, maxVarchar32},
+		{"construction seam_allowances", pb.SeamAllowances, maxVarchar255},
+		{"construction hem_finish", pb.HemFinish, maxVarchar255},
+		{"construction pressing", pb.Pressing, maxVarchar255},
+		{"construction machine_class", pb.MachineClass, maxVarchar255},
+	} {
+		if len(c.val) > c.max {
+			return nil, fmt.Errorf("%s must be at most %d characters", c.field, c.max)
+		}
+	}
+	return &entity.TechCardConstruction{
+		MainStitchType:  nullStringFromPb(pb.MainStitchType),
+		StitchDensity:   nullStringFromPb(pb.StitchDensity),
+		OverlockThreads: nullStringFromPb(pb.OverlockThreads),
+		SeamAllowances:  nullStringFromPb(pb.SeamAllowances),
+		HemFinish:       nullStringFromPb(pb.HemFinish),
+		Pressing:        nullStringFromPb(pb.Pressing),
+		MachineClass:    nullStringFromPb(pb.MachineClass),
+		Notes:           nullStringFromPb(pb.Notes),
+	}, nil
+}
+
+func parseTechCardOperations(pbs []*pb_common.TechCardOperation) ([]entity.TechCardOperation, error) {
+	out := make([]entity.TechCardOperation, 0, len(pbs))
+	for _, o := range pbs {
+		if o.Node == "" {
+			return nil, fmt.Errorf("operation node is required")
+		}
+		if len(o.Node) > maxVarchar255 || len(o.SeamType) > maxVarchar255 || len(o.Thread) > maxVarchar255 {
+			return nil, fmt.Errorf("operation node/seam_type/thread must be at most %d characters", maxVarchar255)
+		}
+		if len(o.TopstitchWidth) > maxVarchar64 {
+			return nil, fmt.Errorf("operation topstitch_width must be at most %d characters", maxVarchar64)
+		}
+		stitches, err := nullDecimalFromPb(o.StitchesPerCm)
+		if err != nil {
+			return nil, fmt.Errorf("operation stitches_per_cm: %w", err)
+		}
+		if err := validateDecimalScale(stitches, "operation stitches_per_cm", stitchFrac, stitchLimit); err != nil {
+			return nil, err
+		}
+		out = append(out, entity.TechCardOperation{
+			Node:           o.Node,
+			Description:    nullStringFromPb(o.Description),
+			SeamType:       nullStringFromPb(o.SeamType),
+			StitchesPerCm:  stitches,
+			TopstitchWidth: nullStringFromPb(o.TopstitchWidth),
+			Thread:         nullStringFromPb(o.Thread),
+			Note:           nullStringFromPb(o.Note),
+		})
+	}
+	return out, nil
+}
+
+func parseTechCardLabels(pbs []*pb_common.TechCardLabel) ([]entity.TechCardLabel, error) {
+	out := make([]entity.TechCardLabel, 0, len(pbs))
+	for _, l := range pbs {
+		lt, ok := techCardLabelTypePbToEntity[l.LabelType]
+		if !ok {
+			return nil, fmt.Errorf("label label_type is required and must be valid")
+		}
+		if len(l.Content) > maxVarchar255 || len(l.Placement) > maxVarchar255 || len(l.Attachment) > maxVarchar255 {
+			return nil, fmt.Errorf("label content/placement/attachment must be at most %d characters", maxVarchar255)
+		}
+		if len(l.Size) > maxVarchar64 {
+			return nil, fmt.Errorf("label size must be at most %d characters", maxVarchar64)
+		}
+		out = append(out, entity.TechCardLabel{
+			LabelType:  lt,
+			Content:    nullStringFromPb(l.Content),
+			Placement:  nullStringFromPb(l.Placement),
+			Attachment: nullStringFromPb(l.Attachment),
+			Size:       nullStringFromPb(l.Size),
+			Note:       nullStringFromPb(l.Note),
+		})
+	}
+	return out, nil
+}
+
+func parseTechCardPackaging(pb *pb_common.TechCardPackaging) (*entity.TechCardPackaging, error) {
+	if pb == nil {
+		return nil, nil
+	}
+	for _, c := range []struct {
+		field string
+		val   string
+		max   int
+	}{
+		{"packaging folding_method", pb.FoldingMethod, maxVarchar255},
+		{"packaging polybag", pb.Polybag, maxVarchar255},
+		{"packaging bag_sticker", pb.BagSticker, maxVarchar255},
+		{"packaging inserts", pb.Inserts, maxVarchar255},
+		{"packaging box_marking", pb.BoxMarking, maxVarchar255},
+		{"packaging box_dimensions", pb.BoxDimensions, maxVarchar128},
+	} {
+		if len(c.val) > c.max {
+			return nil, fmt.Errorf("%s must be at most %d characters", c.field, c.max)
+		}
+	}
+	if pb.UnitsPerBox < 0 {
+		return nil, fmt.Errorf("packaging units_per_box must not be negative")
+	}
+	weightNet, err := nullDecimalFromPb(pb.WeightNet)
+	if err != nil {
+		return nil, fmt.Errorf("packaging weight_net: %w", err)
+	}
+	if err := validateDecimalScale(weightNet, "packaging weight_net", weightFrac, weightLimit); err != nil {
+		return nil, err
+	}
+	weightGross, err := nullDecimalFromPb(pb.WeightGross)
+	if err != nil {
+		return nil, fmt.Errorf("packaging weight_gross: %w", err)
+	}
+	if err := validateDecimalScale(weightGross, "packaging weight_gross", weightFrac, weightLimit); err != nil {
+		return nil, err
+	}
+	return &entity.TechCardPackaging{
+		FoldingMethod: nullStringFromPb(pb.FoldingMethod),
+		Polybag:       nullStringFromPb(pb.Polybag),
+		BagSticker:    nullStringFromPb(pb.BagSticker),
+		Inserts:       nullStringFromPb(pb.Inserts),
+		UnitsPerBox:   nullInt32FromPb(pb.UnitsPerBox),
+		BoxMarking:    nullStringFromPb(pb.BoxMarking),
+		BoxDimensions: nullStringFromPb(pb.BoxDimensions),
+		WeightNet:     weightNet,
+		WeightGross:   weightGross,
+		Notes:         nullStringFromPb(pb.Notes),
+	}, nil
+}
+
+func parseTechCardCosting(pb *pb_common.TechCardCosting) (*entity.TechCardCosting, error) {
+	if pb == nil {
+		return nil, nil
+	}
+	if pb.Currency != "" && len(pb.Currency) != maxCurrency {
+		return nil, fmt.Errorf("costing currency must be a 3-letter ISO 4217 code")
+	}
+	cost := func(d *pb_decimal.Decimal, field string) (decimal.NullDecimal, error) {
+		nd, err := nullDecimalFromPb(d)
+		if err != nil {
+			return nd, fmt.Errorf("costing %s: %w", field, err)
+		}
+		return nd, validateDecimalScale(nd, "costing "+field, costMaxFrac, costLimit)
+	}
+	cmt, err := cost(pb.CmtCost, "cmt_cost")
+	if err != nil {
+		return nil, err
+	}
+	hardware, err := cost(pb.HardwareCost, "hardware_cost")
+	if err != nil {
+		return nil, err
+	}
+	packaging, err := cost(pb.PackagingCost, "packaging_cost")
+	if err != nil {
+		return nil, err
+	}
+	logistics, err := cost(pb.LogisticsCost, "logistics_cost")
+	if err != nil {
+		return nil, err
+	}
+	overhead, err := cost(pb.OverheadCost, "overhead_cost")
+	if err != nil {
+		return nil, err
+	}
+	wholesale, err := cost(pb.WholesalePrice, "wholesale_price")
+	if err != nil {
+		return nil, err
+	}
+	retail, err := cost(pb.RetailPrice, "retail_price")
+	if err != nil {
+		return nil, err
+	}
+	defect, err := nullDecimalFromPb(pb.DefectPercent)
+	if err != nil {
+		return nil, fmt.Errorf("costing defect_percent: %w", err)
+	}
+	if err := validateDecimalScale(defect, "costing defect_percent", costMaxFrac, 1_000); err != nil {
+		return nil, err
+	}
+	if defect.Valid && defect.Decimal.GreaterThan(decimal.NewFromInt(100)) {
+		return nil, fmt.Errorf("costing defect_percent must be between 0 and 100")
+	}
+	markup, err := nullDecimalFromPb(pb.MarkupMultiplier)
+	if err != nil {
+		return nil, fmt.Errorf("costing markup_multiplier: %w", err)
+	}
+	if err := validateDecimalScale(markup, "costing markup_multiplier", markupFrac, markupLimit); err != nil {
+		return nil, err
+	}
+	return &entity.TechCardCosting{
+		CmtCost:          cmt,
+		HardwareCost:     hardware,
+		PackagingCost:    packaging,
+		LogisticsCost:    logistics,
+		OverheadCost:     overhead,
+		DefectPercent:    defect,
+		MarkupMultiplier: markup,
+		WholesalePrice:   wholesale,
+		RetailPrice:      retail,
+		Currency:         nullStringFromPb(pb.Currency),
+		Notes:            nullStringFromPb(pb.Notes),
+	}, nil
+}
+
+// --- emit entity -> pb ---
+
+func techCardConstructionToPb(c *entity.TechCardConstruction) *pb_common.TechCardConstruction {
+	if c == nil {
+		return nil
+	}
+	return &pb_common.TechCardConstruction{
+		MainStitchType:  pbStringFromNull(c.MainStitchType),
+		StitchDensity:   pbStringFromNull(c.StitchDensity),
+		OverlockThreads: pbStringFromNull(c.OverlockThreads),
+		SeamAllowances:  pbStringFromNull(c.SeamAllowances),
+		HemFinish:       pbStringFromNull(c.HemFinish),
+		Pressing:        pbStringFromNull(c.Pressing),
+		MachineClass:    pbStringFromNull(c.MachineClass),
+		Notes:           pbStringFromNull(c.Notes),
+	}
+}
+
+func techCardOperationsToPb(ops []entity.TechCardOperation) []*pb_common.TechCardOperation {
+	out := make([]*pb_common.TechCardOperation, 0, len(ops))
+	for _, o := range ops {
+		out = append(out, &pb_common.TechCardOperation{
+			Node:           o.Node,
+			Description:    pbStringFromNull(o.Description),
+			SeamType:       pbStringFromNull(o.SeamType),
+			StitchesPerCm:  pbDecimalFromNull(o.StitchesPerCm),
+			TopstitchWidth: pbStringFromNull(o.TopstitchWidth),
+			Thread:         pbStringFromNull(o.Thread),
+			Note:           pbStringFromNull(o.Note),
+		})
+	}
+	return out
+}
+
+func techCardLabelsToPb(labels []entity.TechCardLabel) []*pb_common.TechCardLabel {
+	out := make([]*pb_common.TechCardLabel, 0, len(labels))
+	for _, l := range labels {
+		out = append(out, &pb_common.TechCardLabel{
+			LabelType:  techCardLabelTypeEntityToPb[l.LabelType],
+			Content:    pbStringFromNull(l.Content),
+			Placement:  pbStringFromNull(l.Placement),
+			Attachment: pbStringFromNull(l.Attachment),
+			Size:       pbStringFromNull(l.Size),
+			Note:       pbStringFromNull(l.Note),
+		})
+	}
+	return out
+}
+
+func techCardPackagingToPb(p *entity.TechCardPackaging) *pb_common.TechCardPackaging {
+	if p == nil {
+		return nil
+	}
+	return &pb_common.TechCardPackaging{
+		FoldingMethod: pbStringFromNull(p.FoldingMethod),
+		Polybag:       pbStringFromNull(p.Polybag),
+		BagSticker:    pbStringFromNull(p.BagSticker),
+		Inserts:       pbStringFromNull(p.Inserts),
+		UnitsPerBox:   pbInt32FromNull(p.UnitsPerBox),
+		BoxMarking:    pbStringFromNull(p.BoxMarking),
+		BoxDimensions: pbStringFromNull(p.BoxDimensions),
+		WeightNet:     pbDecimalFromNull(p.WeightNet),
+		WeightGross:   pbDecimalFromNull(p.WeightGross),
+		Notes:         pbStringFromNull(p.Notes),
+	}
+}
+
+// techCardCostingToPb emits the stored costing articles plus the computed
+// materials rollup and total. Returns nil when no costing row exists.
+func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
+	if tc.Costing == nil {
+		return nil
+	}
+	c := tc.Costing
+	materialsTotal, materialsCost := bomMaterialsRollup(tc.BomItems, c.Currency)
+	out := &pb_common.TechCardCosting{
+		CmtCost:          pbDecimalFromNull(c.CmtCost),
+		HardwareCost:     pbDecimalFromNull(c.HardwareCost),
+		PackagingCost:    pbDecimalFromNull(c.PackagingCost),
+		LogisticsCost:    pbDecimalFromNull(c.LogisticsCost),
+		OverheadCost:     pbDecimalFromNull(c.OverheadCost),
+		DefectPercent:    pbDecimalFromNull(c.DefectPercent),
+		MarkupMultiplier: pbDecimalFromNull(c.MarkupMultiplier),
+		WholesalePrice:   pbDecimalFromNull(c.WholesalePrice),
+		RetailPrice:      pbDecimalFromNull(c.RetailPrice),
+		Currency:         pbStringFromNull(c.Currency),
+		Notes:            pbStringFromNull(c.Notes),
+		MaterialsTotal:   materialsTotal,
+		MaterialsCost:    pbDecimalFromDecimal(materialsCost.Round(costMaxFrac)),
+	}
+
+	// total_cost = (materials in costing currency + cmt+hardware+packaging+
+	// logistics+overhead) grossed up by the defect/reserve %. Single-currency,
+	// best-effort: cross-currency materials are surfaced in materials_total.
+	total := materialsCost
+	for _, d := range []decimal.NullDecimal{c.CmtCost, c.HardwareCost, c.PackagingCost, c.LogisticsCost, c.OverheadCost} {
+		if d.Valid {
+			total = total.Add(d.Decimal)
+		}
+	}
+	if c.DefectPercent.Valid {
+		total = total.Mul(decimal.NewFromInt(1).Add(c.DefectPercent.Decimal.Div(decimal.NewFromInt(100))))
+	}
+	out.TotalCost = pbDecimalFromDecimal(total.Round(costMaxFrac))
+	return out
+}
+
+// bomMaterialsRollup sums BOM line totals grouped by the line's currency (first-
+// seen order preserved), and returns the subtotal foldable into costingCurrency
+// (matching-currency lines plus currency-less lines).
+func bomMaterialsRollup(items []entity.TechCardBomItem, costingCurrency sql.NullString) ([]*pb_common.TechCardCostLine, decimal.Decimal) {
+	byCcy := map[string]decimal.Decimal{}
+	order := make([]string, 0)
+	for i := range items {
+		lt := items[i].LineTotal()
+		if !lt.Valid {
+			continue
+		}
+		ccy := ""
+		if items[i].Currency.Valid {
+			ccy = items[i].Currency.String
+		}
+		if _, ok := byCcy[ccy]; !ok {
+			order = append(order, ccy)
+		}
+		byCcy[ccy] = byCcy[ccy].Add(lt.Decimal)
+	}
+
+	lines := make([]*pb_common.TechCardCostLine, 0, len(order))
+	for _, ccy := range order {
+		lines = append(lines, &pb_common.TechCardCostLine{
+			Currency: ccy,
+			Amount:   pbDecimalFromDecimal(byCcy[ccy].Round(costMaxFrac)),
+		})
+	}
+
+	target := ""
+	if costingCurrency.Valid {
+		target = costingCurrency.String
+	}
+	materialsCost := decimal.Zero
+	if v, ok := byCcy[target]; ok {
+		materialsCost = materialsCost.Add(v)
+	}
+	if target != "" {
+		if v, ok := byCcy[""]; ok { // currency-less lines fold into the costing currency
+			materialsCost = materialsCost.Add(v)
+		}
+	}
+	return lines, materialsCost
+}

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -1,0 +1,172 @@
+package dto
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
+	"github.com/shopspring/decimal"
+	pb_decimal "google.golang.org/genproto/googleapis/type/decimal"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestConvertPbTechCardInsertToEntity(t *testing.T) {
+	revDate := timestamppb.New(time.Date(2026, 6, 19, 15, 30, 0, 0, time.UTC))
+	valid := &pb_common.TechCardInsert{
+		StyleNumber:       "ST-001",
+		Name:              "Field Jacket",
+		Brand:             "grbpwr",
+		Season:            "FW25",
+		Stage:             pb_common.TechCardStage_TECH_CARD_STAGE_FIT,
+		TargetGender:      pb_common.GenderEnum_GENDER_ENUM_MALE,
+		CategoryId:        3,
+		BaseModelId:       7,
+		BaseSampleSizeId:  4,
+		Currency:          "EUR",
+		TargetCost:        &pb_decimal.Decimal{Value: "42.50"},
+		TargetRetailPrice: &pb_decimal.Decimal{Value: "180.00"},
+		RevisionDate:      revDate,
+		Description:       "boxy field jacket",
+		SizeIds:           []int32{4, 5, 6},
+		ProductIds:        []int32{100, 101},
+		Media: []*pb_common.TechCardMediaItem{
+			{MediaId: 11, Kind: pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_FRONT},
+			{MediaId: 12}, // unset kind -> defaults to preview
+		},
+		Callouts: []*pb_common.TechCardCallout{
+			{Number: 1, Part: "collar", Description: "two-piece", Dimensions: "h=4cm"},
+		},
+		Revisions: []*pb_common.TechCardRevision{
+			{Version: "v2", RevisionDate: revDate, Author: "tech", Section: "POM", ChangeNote: "graded"},
+		},
+	}
+
+	got, err := ConvertPbTechCardInsertToEntity(valid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.StyleNumber != "ST-001" || got.Name != "Field Jacket" {
+		t.Errorf("identity mismatch: %+v", got)
+	}
+	if got.Stage != entity.TechCardStageFit {
+		t.Errorf("stage mismatch: %v", got.Stage)
+	}
+	if !got.TargetGender.Valid || got.TargetGender.String != string(entity.Male) {
+		t.Errorf("gender mismatch: %+v", got.TargetGender)
+	}
+	if !got.CategoryId.Valid || got.CategoryId.Int32 != 3 || !got.BaseModelId.Valid || got.BaseSampleSizeId.Int32 != 4 {
+		t.Errorf("fk fields mismatch: %+v", got)
+	}
+	if !got.TargetCost.Valid || !got.TargetCost.Decimal.Equal(decimal.RequireFromString("42.50")) {
+		t.Errorf("target_cost mismatch: %+v", got.TargetCost)
+	}
+	if want := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC); !got.RevisionDate.Valid || !got.RevisionDate.Time.Equal(want) {
+		t.Errorf("revision_date not normalized: %+v", got.RevisionDate)
+	}
+	if len(got.SizeIds) != 3 || got.SizeIds[2] != 6 || len(got.ProductIds) != 2 {
+		t.Errorf("size/product ids mismatch: %+v %+v", got.SizeIds, got.ProductIds)
+	}
+	if len(got.Media) != 2 || got.Media[0].Kind != entity.TechCardMediaFront || got.Media[1].Kind != entity.TechCardMediaPreview {
+		t.Errorf("media mismatch: %+v", got.Media)
+	}
+	if len(got.Callouts) != 1 || got.Callouts[0].Number != 1 || !got.Callouts[0].Part.Valid {
+		t.Errorf("callouts mismatch: %+v", got.Callouts)
+	}
+	if len(got.Revisions) != 1 || got.Revisions[0].Section.String != "POM" {
+		t.Errorf("revisions mismatch: %+v", got.Revisions)
+	}
+
+	// defaults: unset stage becomes proto; zero fk ids become NULL.
+	def, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{StyleNumber: "ST-002", Name: "Tee"})
+	if err != nil {
+		t.Fatalf("defaults: %v", err)
+	}
+	if def.Stage != entity.TechCardStageProto {
+		t.Errorf("stage default mismatch: %v", def.Stage)
+	}
+	if def.BaseModelId.Valid || def.CategoryId.Valid || def.TargetCost.Valid {
+		t.Errorf("zero fields should be NULL: %+v", def)
+	}
+
+	// invalid cases.
+	bad := map[string]*pb_common.TechCardInsert{
+		"nil":              nil,
+		"no style":         {Name: "x"},
+		"no name":          {StyleNumber: "x"},
+		"neg category":     {StyleNumber: "x", Name: "y", CategoryId: -1},
+		"bad currency":     {StyleNumber: "x", Name: "y", Currency: "EURO"},
+		"dup size":         {StyleNumber: "x", Name: "y", SizeIds: []int32{4, 4}},
+		"dup product":      {StyleNumber: "x", Name: "y", ProductIds: []int32{1, 1}},
+		"size id zero":     {StyleNumber: "x", Name: "y", SizeIds: []int32{0}},
+		"media id zero":    {StyleNumber: "x", Name: "y", Media: []*pb_common.TechCardMediaItem{{MediaId: 0}}},
+		"version too long": {StyleNumber: "x", Name: "y", Version: string(make([]byte, 65))},
+	}
+	for name, in := range bad {
+		if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {
+			t.Errorf("case %q: expected error, got nil", name)
+		}
+	}
+}
+
+func TestConvertEntityTechCardToPb(t *testing.T) {
+	tc := &entity.TechCard{
+		Id: 9,
+		TechCardInsert: entity.TechCardInsert{
+			StyleNumber:  "ST-001",
+			Name:         "Field Jacket",
+			Stage:        entity.TechCardStageProd,
+			TargetGender: nullStringFromPb(string(entity.Female)),
+			TargetCost:   decimal.NullDecimal{Decimal: decimal.RequireFromString("42.50"), Valid: true},
+			SizeIds:      []int{4, 5},
+			ProductIds:   []int{100},
+			Media:        []entity.TechCardMediaItem{{MediaId: 11, Kind: entity.TechCardMediaFront}},
+			Callouts:     []entity.TechCardCallout{{Number: 1}},
+			Revisions:    []entity.TechCardRevision{{Version: nullStringFromPb("v1")}},
+		},
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		ResolvedMedia: []entity.TechCardMediaFull{{Media: entity.MediaFull{Id: 11}, Kind: entity.TechCardMediaFront}},
+	}
+
+	pb := ConvertEntityTechCardToPb(tc)
+	if pb.Id != 9 || pb.TechCard.StyleNumber != "ST-001" {
+		t.Errorf("id/style mismatch: %+v", pb)
+	}
+	if pb.TechCard.Stage != pb_common.TechCardStage_TECH_CARD_STAGE_PROD {
+		t.Errorf("stage mismatch: %v", pb.TechCard.Stage)
+	}
+	if pb.TechCard.TargetGender != pb_common.GenderEnum_GENDER_ENUM_FEMALE {
+		t.Errorf("gender mismatch: %v", pb.TechCard.TargetGender)
+	}
+	if pb.TechCard.TargetCost == nil || pb.TechCard.TargetCost.Value != "42.5" {
+		t.Errorf("target_cost mismatch: %+v", pb.TechCard.TargetCost)
+	}
+	if len(pb.TechCard.Media) != 1 || pb.TechCard.Media[0].Kind != pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_FRONT {
+		t.Errorf("media item mismatch: %+v", pb.TechCard.Media)
+	}
+	if len(pb.ResolvedMedia) != 1 || pb.ResolvedMedia[0].Media.Id != 11 {
+		t.Errorf("resolved media mismatch: %+v", pb.ResolvedMedia)
+	}
+	if len(pb.TechCard.SizeIds) != 2 || len(pb.TechCard.Callouts) != 1 || len(pb.TechCard.Revisions) != 1 {
+		t.Errorf("child sections mismatch: %+v", pb.TechCard)
+	}
+}
+
+// ListItem conversion produces a lightweight header.
+func TestConvertEntityTechCardToListItemPb(t *testing.T) {
+	tc := &entity.TechCard{
+		Id: 5,
+		TechCardInsert: entity.TechCardInsert{
+			StyleNumber: "ST-003",
+			Name:        "Pants",
+			Stage:       entity.TechCardStagePP,
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	li := ConvertEntityTechCardToListItemPb(tc)
+	if li.Id != 5 || li.StyleNumber != "ST-003" || li.Stage != pb_common.TechCardStage_TECH_CARD_STAGE_PP {
+		t.Errorf("list item mismatch: %+v", li)
+	}
+}

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -286,11 +286,25 @@ func TestConvertTechCardMaterials(t *testing.T) {
 			PomPoints: []*pb_common.TechCardPomPoint{{Name: "p", Grades: []*pb_common.TechCardPomGrade{{SizeId: 4}}}}},
 		"bom price too many decimals": {StyleNumber: "x", Name: "y",
 			BomItems: []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "m", UnitPrice: &pb_decimal.Decimal{Value: "1.23456"}}}},
+		"colorway product not in card": {StyleNumber: "x", Name: "y",
+			Colorways: []*pb_common.TechCardColorway{{Name: "a", ProductId: 999}}},
 	}
 	for name, in := range bad {
 		if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {
 			t.Errorf("case %q: expected error, got nil", name)
 		}
+	}
+
+	// a colourway whose product is one of the card's linked products is valid.
+	okCw, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{
+		StyleNumber: "ST-011", Name: "Coat", ProductIds: []int32{100},
+		Colorways: []*pb_common.TechCardColorway{{Name: "Black", ProductId: 100}},
+	})
+	if err != nil {
+		t.Fatalf("colorway linked to a card product should be valid: %v", err)
+	}
+	if !okCw.Colorways[0].ProductId.Valid || okCw.Colorways[0].ProductId.Int32 != 100 {
+		t.Errorf("colorway product_id mismatch: %+v", okCw.Colorways[0].ProductId)
 	}
 }
 

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -22,7 +22,7 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 		ApprovalState:     pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_APPROVED,
 		ApprovedBy:        "lead",
 		ReleasedAt:        revDate,
-		MeasurementUnit:   pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_IN,
+		MeasurementUnit:   pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_MM,
 		TargetGender:      pb_common.GenderEnum_GENDER_ENUM_MALE,
 		CategoryId:        3,
 		BaseModelId:       7,
@@ -86,7 +86,7 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 	if got.Callouts[0].MediaId.Int32 != 11 {
 		t.Errorf("callout media_id mismatch: %+v", got.Callouts[0].MediaId)
 	}
-	if got.MeasurementUnit != entity.TechCardUnitIn {
+	if got.MeasurementUnit != entity.TechCardUnitMm {
 		t.Errorf("measurement_unit mismatch: %v", got.MeasurementUnit)
 	}
 
@@ -147,7 +147,7 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 			Name:            "Field Jacket",
 			Stage:           entity.TechCardStageProd,
 			ApprovalState:   entity.TechCardApprovalReleased,
-			MeasurementUnit: entity.TechCardUnitIn,
+			MeasurementUnit: entity.TechCardUnitMm,
 			TargetGender:    nullStringFromPb(string(entity.Female)),
 			TargetCost:      decimal.NullDecimal{Decimal: decimal.RequireFromString("42.50"), Valid: true},
 			SizeIds:         []int{4, 5},
@@ -174,7 +174,7 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 	if pb.TechCard.Callouts[0].MediaId != 11 {
 		t.Errorf("callout media_id round-trip mismatch: %v", pb.TechCard.Callouts[0].MediaId)
 	}
-	if pb.TechCard.MeasurementUnit != pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_IN {
+	if pb.TechCard.MeasurementUnit != pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_MM {
 		t.Errorf("measurement_unit round-trip mismatch: %v", pb.TechCard.MeasurementUnit)
 	}
 	if pb.TechCard.TargetGender != pb_common.GenderEnum_GENDER_ENUM_FEMALE {
@@ -218,11 +218,11 @@ func TestConvertTechCardMaterials(t *testing.T) {
 		},
 		PomPoints: []*pb_common.TechCardPomPoint{
 			{
-				Name:      "Chest width",
-				Code:      "A",
-				Section:   "BODY",
-				BaseValue: &pb_decimal.Decimal{Value: "56"},
-				Tolerance: &pb_decimal.Decimal{Value: "1"},
+				Name:          "Chest width",
+				Code:          "A",
+				Section:       "BODY",
+				BaseValue:     &pb_decimal.Decimal{Value: "56"},
+				TolerancePlus: &pb_decimal.Decimal{Value: "1"}, // minus unset -> mirrors to 1
 				Grades: []*pb_common.TechCardPomGrade{
 					{SizeId: 4, Value: &pb_decimal.Decimal{Value: "54"}},
 					{SizeId: 5, Value: &pb_decimal.Decimal{Value: "56"}},
@@ -255,6 +255,13 @@ func TestConvertTechCardMaterials(t *testing.T) {
 	}
 	if len(got.PomPoints[0].Actuals) != 1 || !got.PomPoints[0].Actuals[0].FittingId.Valid || got.PomPoints[0].Actuals[0].FittingId.Int32 != 3 {
 		t.Errorf("pom actuals mismatch: %+v", got.PomPoints[0].Actuals)
+	}
+	// tolerance_minus was unset, so it mirrors tolerance_plus.
+	if tp := got.PomPoints[0].TolerancePlus; !tp.Valid || tp.Decimal.String() != "1" {
+		t.Errorf("tolerance_plus mismatch: %+v", tp)
+	}
+	if tm := got.PomPoints[0].ToleranceMinus; !tm.Valid || tm.Decimal.String() != "1" {
+		t.Errorf("tolerance_minus should mirror plus: %+v", tm)
 	}
 
 	// round-trip back to pb: computed line_total + matrix + grades survive.

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -315,6 +315,92 @@ func TestConvertTechCardMaterials(t *testing.T) {
 	}
 }
 
+func TestConvertTechCardProductionAndCosting(t *testing.T) {
+	dec := func(s string) *pb_decimal.Decimal { return &pb_decimal.Decimal{Value: s} }
+	in := &pb_common.TechCardInsert{
+		StyleNumber: "ST-020",
+		Name:        "Coat",
+		BomItems: []*pb_common.TechCardBomItem{
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "shell", Quantity: dec("2"), UnitPrice: dec("10"), Currency: "EUR"},
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_LINING, Name: "lining", Quantity: dec("1"), UnitPrice: dec("5"), Currency: "EUR"},
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_HARDWARE, Name: "zip", Quantity: dec("1"), UnitPrice: dec("3"), Currency: "USD"},
+		},
+		Construction: &pb_common.TechCardConstruction{MainStitchType: "lockstitch", StitchDensity: "3-4"},
+		Operations: []*pb_common.TechCardOperation{
+			{Node: "collar", SeamType: "lockstitch", StitchesPerCm: dec("3.5")},
+		},
+		Labels: []*pb_common.TechCardLabel{
+			{LabelType: pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_MAIN, Content: "grbpwr", Placement: "neck"},
+		},
+		Packaging: &pb_common.TechCardPackaging{FoldingMethod: "flat", UnitsPerBox: 10, WeightNet: dec("0.8")},
+		Costing:   &pb_common.TechCardCosting{CmtCost: dec("10"), DefectPercent: dec("10"), Currency: "EUR"},
+	}
+
+	got, err := ConvertPbTechCardInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Construction == nil || got.Construction.MainStitchType.String != "lockstitch" {
+		t.Errorf("construction mismatch: %+v", got.Construction)
+	}
+	if len(got.Operations) != 1 || got.Operations[0].Node != "collar" {
+		t.Errorf("operations mismatch: %+v", got.Operations)
+	}
+	if len(got.Labels) != 1 || got.Labels[0].LabelType != entity.LabelTypeMain {
+		t.Errorf("labels mismatch: %+v", got.Labels)
+	}
+	if got.Packaging == nil || !got.Packaging.UnitsPerBox.Valid || got.Packaging.UnitsPerBox.Int32 != 10 {
+		t.Errorf("packaging mismatch: %+v", got.Packaging)
+	}
+	if got.Costing == nil || !got.Costing.CmtCost.Valid {
+		t.Fatalf("costing mismatch: %+v", got.Costing)
+	}
+
+	// round-trip to pb: production sections + computed costing rollup.
+	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
+	if pb.TechCard.Construction.MainStitchType != "lockstitch" || len(pb.TechCard.Operations) != 1 {
+		t.Errorf("pb construction/operations mismatch: %+v", pb.TechCard)
+	}
+	if pb.TechCard.Labels[0].LabelType != pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_MAIN || pb.TechCard.Packaging.UnitsPerBox != 10 {
+		t.Errorf("pb labels/packaging mismatch: %+v", pb.TechCard)
+	}
+	cost := pb.TechCard.Costing
+	if cost == nil {
+		t.Fatalf("costing not emitted")
+	}
+	// materials_cost = EUR lines only (20+5); USD line stays out of the single-currency subtotal.
+	if cost.MaterialsCost == nil || cost.MaterialsCost.Value != "25" {
+		t.Errorf("materials_cost mismatch: %+v", cost.MaterialsCost)
+	}
+	// total_cost = (25 materials + 10 cmt) * (1 + 10/100) = 38.5
+	if cost.TotalCost == nil || cost.TotalCost.Value != "38.5" {
+		t.Errorf("total_cost mismatch: %+v", cost.TotalCost)
+	}
+	// materials_total surfaces both currencies (no conversion).
+	byCcy := map[string]string{}
+	for _, l := range cost.MaterialsTotal {
+		byCcy[l.Currency] = l.Amount.Value
+	}
+	if byCcy["EUR"] != "25" || byCcy["USD"] != "3" {
+		t.Errorf("materials_total mismatch: %+v", byCcy)
+	}
+
+	// invalid cases.
+	bad := map[string]*pb_common.TechCardInsert{
+		"label type unknown":  {StyleNumber: "x", Name: "y", Labels: []*pb_common.TechCardLabel{{Content: "x"}}},
+		"operation no node":   {StyleNumber: "x", Name: "y", Operations: []*pb_common.TechCardOperation{{SeamType: "x"}}},
+		"defect over 100":     {StyleNumber: "x", Name: "y", Costing: &pb_common.TechCardCosting{DefectPercent: dec("150")}},
+		"costing bad ccy":     {StyleNumber: "x", Name: "y", Costing: &pb_common.TechCardCosting{Currency: "EURO"}},
+		"neg cmt":             {StyleNumber: "x", Name: "y", Costing: &pb_common.TechCardCosting{CmtCost: dec("-1")}},
+		"stitches too scaled": {StyleNumber: "x", Name: "y", Operations: []*pb_common.TechCardOperation{{Node: "n", StitchesPerCm: dec("1.234")}}},
+	}
+	for name, bi := range bad {
+		if _, err := ConvertPbTechCardInsertToEntity(bi); err == nil {
+			t.Errorf("case %q: expected error, got nil", name)
+		}
+	}
+}
+
 // ListItem conversion produces a lightweight header.
 func TestConvertEntityTechCardToListItemPb(t *testing.T) {
 	tc := &entity.TechCard{

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -22,6 +22,7 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 		ApprovalState:     pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_APPROVED,
 		ApprovedBy:        "lead",
 		ReleasedAt:        revDate,
+		MeasurementUnit:   pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_IN,
 		TargetGender:      pb_common.GenderEnum_GENDER_ENUM_MALE,
 		CategoryId:        3,
 		BaseModelId:       7,
@@ -85,6 +86,9 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 	if got.Callouts[0].MediaId.Int32 != 11 {
 		t.Errorf("callout media_id mismatch: %+v", got.Callouts[0].MediaId)
 	}
+	if got.MeasurementUnit != entity.TechCardUnitIn {
+		t.Errorf("measurement_unit mismatch: %v", got.MeasurementUnit)
+	}
 
 	// defaults: unset stage becomes proto; zero fk ids become NULL.
 	def, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{StyleNumber: "ST-002", Name: "Tee"})
@@ -96,6 +100,9 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 	}
 	if def.ApprovalState != entity.TechCardApprovalDraft {
 		t.Errorf("approval_state default mismatch: %v", def.ApprovalState)
+	}
+	if def.MeasurementUnit != entity.TechCardUnitCm {
+		t.Errorf("measurement_unit default mismatch: %v", def.MeasurementUnit)
 	}
 	if def.BaseModelId.Valid || def.CategoryId.Valid || def.TargetCost.Valid {
 		t.Errorf("zero fields should be NULL: %+v", def)
@@ -121,6 +128,9 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 		"base not in range": {StyleNumber: "x", Name: "y", BaseSampleSizeId: 9, SizeIds: []int32{4, 5}},
 		"media id zero":     {StyleNumber: "x", Name: "y", Media: []*pb_common.TechCardMediaItem{{MediaId: 0}}},
 		"version too long":  {StyleNumber: "x", Name: "y", Version: string(make([]byte, 65))},
+		"neg cost":          {StyleNumber: "x", Name: "y", TargetCost: &pb_decimal.Decimal{Value: "-1"}},
+		"cost overflow":     {StyleNumber: "x", Name: "y", TargetCost: &pb_decimal.Decimal{Value: "100000000"}},
+		"cost decimals":     {StyleNumber: "x", Name: "y", TargetRetailPrice: &pb_decimal.Decimal{Value: "1.999"}},
 	}
 	for name, in := range bad {
 		if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {
@@ -133,17 +143,18 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 	tc := &entity.TechCard{
 		Id: 9,
 		TechCardInsert: entity.TechCardInsert{
-			StyleNumber:   "ST-001",
-			Name:          "Field Jacket",
-			Stage:         entity.TechCardStageProd,
-			ApprovalState: entity.TechCardApprovalReleased,
-			TargetGender:  nullStringFromPb(string(entity.Female)),
-			TargetCost:    decimal.NullDecimal{Decimal: decimal.RequireFromString("42.50"), Valid: true},
-			SizeIds:       []int{4, 5},
-			ProductIds:    []int{100},
-			Media:         []entity.TechCardMediaItem{{MediaId: 11, Kind: entity.TechCardMediaFront}},
-			Callouts:      []entity.TechCardCallout{{Number: 1, MediaId: nullInt32FromPb(11)}},
-			Revisions:     []entity.TechCardRevision{{Version: nullStringFromPb("v1")}},
+			StyleNumber:     "ST-001",
+			Name:            "Field Jacket",
+			Stage:           entity.TechCardStageProd,
+			ApprovalState:   entity.TechCardApprovalReleased,
+			MeasurementUnit: entity.TechCardUnitIn,
+			TargetGender:    nullStringFromPb(string(entity.Female)),
+			TargetCost:      decimal.NullDecimal{Decimal: decimal.RequireFromString("42.50"), Valid: true},
+			SizeIds:         []int{4, 5},
+			ProductIds:      []int{100},
+			Media:           []entity.TechCardMediaItem{{MediaId: 11, Kind: entity.TechCardMediaFront}},
+			Callouts:        []entity.TechCardCallout{{Number: 1, MediaId: nullInt32FromPb(11)}},
+			Revisions:       []entity.TechCardRevision{{Version: nullStringFromPb("v1")}},
 		},
 		CreatedAt:     time.Now(),
 		UpdatedAt:     time.Now(),
@@ -162,6 +173,9 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 	}
 	if pb.TechCard.Callouts[0].MediaId != 11 {
 		t.Errorf("callout media_id round-trip mismatch: %v", pb.TechCard.Callouts[0].MediaId)
+	}
+	if pb.TechCard.MeasurementUnit != pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_IN {
+		t.Errorf("measurement_unit round-trip mismatch: %v", pb.TechCard.MeasurementUnit)
 	}
 	if pb.TechCard.TargetGender != pb_common.GenderEnum_GENDER_ENUM_FEMALE {
 		t.Errorf("gender mismatch: %v", pb.TechCard.TargetGender)

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -19,6 +19,9 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 		Brand:             "grbpwr",
 		Season:            "FW25",
 		Stage:             pb_common.TechCardStage_TECH_CARD_STAGE_FIT,
+		ApprovalState:     pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_APPROVED,
+		ApprovedBy:        "lead",
+		ReleasedAt:        revDate,
 		TargetGender:      pb_common.GenderEnum_GENDER_ENUM_MALE,
 		CategoryId:        3,
 		BaseModelId:       7,
@@ -35,7 +38,7 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 			{MediaId: 12}, // unset kind -> defaults to preview
 		},
 		Callouts: []*pb_common.TechCardCallout{
-			{Number: 1, Part: "collar", Description: "two-piece", Dimensions: "h=4cm"},
+			{Number: 1, Part: "collar", Description: "two-piece", Dimensions: "h=4cm", MediaId: 11},
 		},
 		Revisions: []*pb_common.TechCardRevision{
 			{Version: "v2", RevisionDate: revDate, Author: "tech", Section: "POM", ChangeNote: "graded"},
@@ -76,6 +79,12 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 	if len(got.Revisions) != 1 || got.Revisions[0].Section.String != "POM" {
 		t.Errorf("revisions mismatch: %+v", got.Revisions)
 	}
+	if got.ApprovalState != entity.TechCardApprovalApproved || got.ApprovedBy.String != "lead" || !got.ReleasedAt.Valid {
+		t.Errorf("approval mismatch: state=%v by=%+v released=%+v", got.ApprovalState, got.ApprovedBy, got.ReleasedAt)
+	}
+	if got.Callouts[0].MediaId.Int32 != 11 {
+		t.Errorf("callout media_id mismatch: %+v", got.Callouts[0].MediaId)
+	}
 
 	// defaults: unset stage becomes proto; zero fk ids become NULL.
 	def, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{StyleNumber: "ST-002", Name: "Tee"})
@@ -85,22 +94,33 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 	if def.Stage != entity.TechCardStageProto {
 		t.Errorf("stage default mismatch: %v", def.Stage)
 	}
+	if def.ApprovalState != entity.TechCardApprovalDraft {
+		t.Errorf("approval_state default mismatch: %v", def.ApprovalState)
+	}
 	if def.BaseModelId.Valid || def.CategoryId.Valid || def.TargetCost.Valid {
 		t.Errorf("zero fields should be NULL: %+v", def)
 	}
 
+	// base_sample_size_id is allowed when the size range is still empty (early proto).
+	if _, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{
+		StyleNumber: "ST-004", Name: "Coat", BaseSampleSizeId: 9,
+	}); err != nil {
+		t.Errorf("base size with empty size range should be allowed: %v", err)
+	}
+
 	// invalid cases.
 	bad := map[string]*pb_common.TechCardInsert{
-		"nil":              nil,
-		"no style":         {Name: "x"},
-		"no name":          {StyleNumber: "x"},
-		"neg category":     {StyleNumber: "x", Name: "y", CategoryId: -1},
-		"bad currency":     {StyleNumber: "x", Name: "y", Currency: "EURO"},
-		"dup size":         {StyleNumber: "x", Name: "y", SizeIds: []int32{4, 4}},
-		"dup product":      {StyleNumber: "x", Name: "y", ProductIds: []int32{1, 1}},
-		"size id zero":     {StyleNumber: "x", Name: "y", SizeIds: []int32{0}},
-		"media id zero":    {StyleNumber: "x", Name: "y", Media: []*pb_common.TechCardMediaItem{{MediaId: 0}}},
-		"version too long": {StyleNumber: "x", Name: "y", Version: string(make([]byte, 65))},
+		"nil":               nil,
+		"no style":          {Name: "x"},
+		"no name":           {StyleNumber: "x"},
+		"neg category":      {StyleNumber: "x", Name: "y", CategoryId: -1},
+		"bad currency":      {StyleNumber: "x", Name: "y", Currency: "EURO"},
+		"dup size":          {StyleNumber: "x", Name: "y", SizeIds: []int32{4, 4}},
+		"dup product":       {StyleNumber: "x", Name: "y", ProductIds: []int32{1, 1}},
+		"size id zero":      {StyleNumber: "x", Name: "y", SizeIds: []int32{0}},
+		"base not in range": {StyleNumber: "x", Name: "y", BaseSampleSizeId: 9, SizeIds: []int32{4, 5}},
+		"media id zero":     {StyleNumber: "x", Name: "y", Media: []*pb_common.TechCardMediaItem{{MediaId: 0}}},
+		"version too long":  {StyleNumber: "x", Name: "y", Version: string(make([]byte, 65))},
 	}
 	for name, in := range bad {
 		if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {
@@ -113,16 +133,17 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 	tc := &entity.TechCard{
 		Id: 9,
 		TechCardInsert: entity.TechCardInsert{
-			StyleNumber:  "ST-001",
-			Name:         "Field Jacket",
-			Stage:        entity.TechCardStageProd,
-			TargetGender: nullStringFromPb(string(entity.Female)),
-			TargetCost:   decimal.NullDecimal{Decimal: decimal.RequireFromString("42.50"), Valid: true},
-			SizeIds:      []int{4, 5},
-			ProductIds:   []int{100},
-			Media:        []entity.TechCardMediaItem{{MediaId: 11, Kind: entity.TechCardMediaFront}},
-			Callouts:     []entity.TechCardCallout{{Number: 1}},
-			Revisions:    []entity.TechCardRevision{{Version: nullStringFromPb("v1")}},
+			StyleNumber:   "ST-001",
+			Name:          "Field Jacket",
+			Stage:         entity.TechCardStageProd,
+			ApprovalState: entity.TechCardApprovalReleased,
+			TargetGender:  nullStringFromPb(string(entity.Female)),
+			TargetCost:    decimal.NullDecimal{Decimal: decimal.RequireFromString("42.50"), Valid: true},
+			SizeIds:       []int{4, 5},
+			ProductIds:    []int{100},
+			Media:         []entity.TechCardMediaItem{{MediaId: 11, Kind: entity.TechCardMediaFront}},
+			Callouts:      []entity.TechCardCallout{{Number: 1, MediaId: nullInt32FromPb(11)}},
+			Revisions:     []entity.TechCardRevision{{Version: nullStringFromPb("v1")}},
 		},
 		CreatedAt:     time.Now(),
 		UpdatedAt:     time.Now(),
@@ -135,6 +156,12 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 	}
 	if pb.TechCard.Stage != pb_common.TechCardStage_TECH_CARD_STAGE_PROD {
 		t.Errorf("stage mismatch: %v", pb.TechCard.Stage)
+	}
+	if pb.TechCard.ApprovalState != pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_RELEASED {
+		t.Errorf("approval_state mismatch: %v", pb.TechCard.ApprovalState)
+	}
+	if pb.TechCard.Callouts[0].MediaId != 11 {
+		t.Errorf("callout media_id round-trip mismatch: %v", pb.TechCard.Callouts[0].MediaId)
 	}
 	if pb.TechCard.TargetGender != pb_common.GenderEnum_GENDER_ENUM_FEMALE {
 		t.Errorf("gender mismatch: %v", pb.TechCard.TargetGender)

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -194,6 +194,106 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 	}
 }
 
+func TestConvertTechCardMaterials(t *testing.T) {
+	valid := &pb_common.TechCardInsert{
+		StyleNumber: "ST-010",
+		Name:        "Parka",
+		SizeIds:     []int32{4, 5},
+		Colorways: []*pb_common.TechCardColorway{
+			{Code: "BLK", Name: "Black", LabDipStatus: pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_APPROVED},
+			{Name: "White"}, // unset lab dip -> pending
+		},
+		BomItems: []*pb_common.TechCardBomItem{
+			{
+				Section:   pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC,
+				Name:      "Main shell",
+				Quantity:  &pb_decimal.Decimal{Value: "2"},
+				UnitPrice: &pb_decimal.Decimal{Value: "10.5"},
+				Currency:  "EUR",
+				ColorwayColors: []*pb_common.TechCardBomColorwayColor{
+					{ColorwayIndex: 0, Color: "black", Pantone: "Black C"},
+					{ColorwayIndex: 1, Color: "white"},
+				},
+			},
+		},
+		PomPoints: []*pb_common.TechCardPomPoint{
+			{
+				Name:      "Chest width",
+				Code:      "A",
+				Section:   "BODY",
+				BaseValue: &pb_decimal.Decimal{Value: "56"},
+				Tolerance: &pb_decimal.Decimal{Value: "1"},
+				Grades: []*pb_common.TechCardPomGrade{
+					{SizeId: 4, Value: &pb_decimal.Decimal{Value: "54"}},
+					{SizeId: 5, Value: &pb_decimal.Decimal{Value: "56"}},
+				},
+				Actuals: []*pb_common.TechCardPomActual{
+					{FittingId: 3, Label: "fit1", Value: &pb_decimal.Decimal{Value: "55.5"}},
+				},
+			},
+		},
+	}
+
+	got, err := ConvertPbTechCardInsertToEntity(valid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Colorways) != 2 || got.Colorways[0].LabDipStatus != entity.LabDipApproved || got.Colorways[1].LabDipStatus != entity.LabDipPending {
+		t.Errorf("colorways mismatch: %+v", got.Colorways)
+	}
+	if len(got.BomItems) != 1 || got.BomItems[0].Section != entity.BomSectionFabric || len(got.BomItems[0].ColorwayColors) != 2 {
+		t.Fatalf("bom mismatch: %+v", got.BomItems)
+	}
+	if lt := got.BomItems[0].LineTotal(); !lt.Valid || !lt.Decimal.Equal(decimal.RequireFromString("21")) {
+		t.Errorf("line_total mismatch: %+v", lt)
+	}
+	if got.BomItems[0].ColorwayColors[1].ColorwayIndex != 1 {
+		t.Errorf("colorway_index mismatch: %+v", got.BomItems[0].ColorwayColors)
+	}
+	if len(got.PomPoints) != 1 || len(got.PomPoints[0].Grades) != 2 || got.PomPoints[0].Grades[0].SizeId != 4 {
+		t.Fatalf("pom grades mismatch: %+v", got.PomPoints)
+	}
+	if len(got.PomPoints[0].Actuals) != 1 || !got.PomPoints[0].Actuals[0].FittingId.Valid || got.PomPoints[0].Actuals[0].FittingId.Int32 != 3 {
+		t.Errorf("pom actuals mismatch: %+v", got.PomPoints[0].Actuals)
+	}
+
+	// round-trip back to pb: computed line_total + matrix + grades survive.
+	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
+	if len(pb.TechCard.Colorways) != 2 || pb.TechCard.Colorways[0].LabDipStatus != pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_APPROVED {
+		t.Errorf("pb colorways mismatch: %+v", pb.TechCard.Colorways)
+	}
+	if len(pb.TechCard.BomItems) != 1 || pb.TechCard.BomItems[0].LineTotal == nil || pb.TechCard.BomItems[0].LineTotal.Value != "21" {
+		t.Errorf("pb line_total mismatch: %+v", pb.TechCard.BomItems[0].GetLineTotal())
+	}
+	if pb.TechCard.BomItems[0].Section != pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC || len(pb.TechCard.BomItems[0].ColorwayColors) != 2 {
+		t.Errorf("pb bom mismatch: %+v", pb.TechCard.BomItems[0])
+	}
+	if len(pb.TechCard.PomPoints) != 1 || len(pb.TechCard.PomPoints[0].Grades) != 2 || pb.TechCard.PomPoints[0].Grades[0].Value.Value != "54" {
+		t.Errorf("pb pom mismatch: %+v", pb.TechCard.PomPoints)
+	}
+
+	// invalid cases.
+	bad := map[string]*pb_common.TechCardInsert{
+		"bom section unknown": {StyleNumber: "x", Name: "y", BomItems: []*pb_common.TechCardBomItem{{Name: "m"}}},
+		"bom no name":         {StyleNumber: "x", Name: "y", BomItems: []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC}}},
+		"colorway no name":    {StyleNumber: "x", Name: "y", Colorways: []*pb_common.TechCardColorway{{Code: "X"}}},
+		"colorway idx range": {StyleNumber: "x", Name: "y",
+			Colorways: []*pb_common.TechCardColorway{{Name: "a"}},
+			BomItems:  []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "m", ColorwayColors: []*pb_common.TechCardBomColorwayColor{{ColorwayIndex: 5}}}}},
+		"pom grade not in range": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
+			PomPoints: []*pb_common.TechCardPomPoint{{Name: "p", Grades: []*pb_common.TechCardPomGrade{{SizeId: 9, Value: &pb_decimal.Decimal{Value: "1"}}}}}},
+		"pom grade value missing": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
+			PomPoints: []*pb_common.TechCardPomPoint{{Name: "p", Grades: []*pb_common.TechCardPomGrade{{SizeId: 4}}}}},
+		"bom price too many decimals": {StyleNumber: "x", Name: "y",
+			BomItems: []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "m", UnitPrice: &pb_decimal.Decimal{Value: "1.23456"}}}},
+	}
+	for name, in := range bad {
+		if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {
+			t.Errorf("case %q: expected error, got nil", name)
+		}
+	}
+}
+
 // ListItem conversion produces a lightweight header.
 func TestConvertEntityTechCardToListItemPb(t *testing.T) {
 	tc := &entity.TechCard{

--- a/internal/entity/fitting.go
+++ b/internal/entity/fitting.go
@@ -45,9 +45,12 @@ type FittingSize struct {
 	FitNote sql.NullString `db:"fit_note"`
 }
 
-// FittingInsert is the writable payload for a fitting session.
+// FittingInsert is the writable payload for a fitting session. A fitting anchors
+// to a tech card (the style) and/or a specific product (the colour/SKU sample);
+// at least one of TechCardId / ProductId is set (enforced in the API layer).
 type FittingInsert struct {
-	ProductId   int            `db:"product_id"`
+	TechCardId  sql.NullInt32  `db:"tech_card_id"`
+	ProductId   sql.NullInt32  `db:"product_id"`
 	ModelId     sql.NullInt32  `db:"model_id"`
 	FittingDate time.Time      `db:"fitting_date"`
 	Comment     sql.NullString `db:"comment"`

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -60,6 +60,27 @@ func IsValidTechCardApprovalState(s TechCardApprovalState) bool {
 	return ValidTechCardApprovalStates[s]
 }
 
+// TechCardMeasurementUnit is the unit for the card's geometry (callout dimensions
+// and the future POM). It mirrors the common.TechCardMeasurementUnit proto enum
+// and is stored as a string in tech_card.measurement_unit.
+type TechCardMeasurementUnit string
+
+const (
+	TechCardUnitCm TechCardMeasurementUnit = "cm"
+	TechCardUnitIn TechCardMeasurementUnit = "in"
+)
+
+// ValidTechCardMeasurementUnits is the set of accepted measurement units.
+var ValidTechCardMeasurementUnits = map[TechCardMeasurementUnit]bool{
+	TechCardUnitCm: true,
+	TechCardUnitIn: true,
+}
+
+// IsValidTechCardMeasurementUnit reports whether u is an accepted unit.
+func IsValidTechCardMeasurementUnit(u TechCardMeasurementUnit) bool {
+	return ValidTechCardMeasurementUnits[u]
+}
+
 // TechCardMediaKind classifies a tech-card sketch image. It mirrors the
 // common.TechCardMediaKind proto enum and is stored as a string in
 // tech_card_media.kind.
@@ -120,28 +141,29 @@ type TechCardRevision struct {
 // TechCardInsert is the writable payload for a tech card (header + construction
 // description + child sections). Child slices are full replacements on update.
 type TechCardInsert struct {
-	StyleNumber       string                `db:"style_number"`
-	Name              string                `db:"name"`
-	Brand             sql.NullString        `db:"brand"`
-	Season            sql.NullString        `db:"season"`
-	Collection        sql.NullString        `db:"collection"`
-	CategoryId        sql.NullInt32         `db:"category_id"`
-	TargetGender      sql.NullString        `db:"target_gender"`
-	Stage             TechCardStage         `db:"stage"`
-	Status            sql.NullString        `db:"status"`
-	ApprovalState     TechCardApprovalState `db:"approval_state"`
-	ApprovedBy        sql.NullString        `db:"approved_by"`
-	ReleasedAt        sql.NullTime          `db:"released_at"`
-	Version           sql.NullString        `db:"version"`
-	RevisionDate      sql.NullTime          `db:"revision_date"`
-	BaseModelId       sql.NullInt32         `db:"base_model_id"`
-	BaseSampleSizeId  sql.NullInt32         `db:"base_sample_size_id"`
-	Designer          sql.NullString        `db:"designer"`
-	Constructor       sql.NullString        `db:"constructor"`
-	Technologist      sql.NullString        `db:"technologist"`
-	TargetCost        decimal.NullDecimal   `db:"target_cost"`
-	TargetRetailPrice decimal.NullDecimal   `db:"target_retail_price"`
-	Currency          sql.NullString        `db:"currency"`
+	StyleNumber       string                  `db:"style_number"`
+	Name              string                  `db:"name"`
+	Brand             sql.NullString          `db:"brand"`
+	Season            sql.NullString          `db:"season"`
+	Collection        sql.NullString          `db:"collection"`
+	CategoryId        sql.NullInt32           `db:"category_id"`
+	TargetGender      sql.NullString          `db:"target_gender"`
+	Stage             TechCardStage           `db:"stage"`
+	Status            sql.NullString          `db:"status"`
+	ApprovalState     TechCardApprovalState   `db:"approval_state"`
+	ApprovedBy        sql.NullString          `db:"approved_by"`
+	ReleasedAt        sql.NullTime            `db:"released_at"`
+	Version           sql.NullString          `db:"version"`
+	RevisionDate      sql.NullTime            `db:"revision_date"`
+	BaseModelId       sql.NullInt32           `db:"base_model_id"`
+	BaseSampleSizeId  sql.NullInt32           `db:"base_sample_size_id"`
+	Designer          sql.NullString          `db:"designer"`
+	Constructor       sql.NullString          `db:"constructor"`
+	Technologist      sql.NullString          `db:"technologist"`
+	TargetCost        decimal.NullDecimal     `db:"target_cost"`
+	TargetRetailPrice decimal.NullDecimal     `db:"target_retail_price"`
+	Currency          sql.NullString          `db:"currency"`
+	MeasurementUnit   TechCardMeasurementUnit `db:"measurement_unit"`
 	// construction description
 	Description  sql.NullString `db:"description"`
 	Silhouette   sql.NullString `db:"silhouette"`

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -67,13 +67,13 @@ type TechCardMeasurementUnit string
 
 const (
 	TechCardUnitCm TechCardMeasurementUnit = "cm"
-	TechCardUnitIn TechCardMeasurementUnit = "in"
+	TechCardUnitMm TechCardMeasurementUnit = "mm"
 )
 
 // ValidTechCardMeasurementUnits is the set of accepted measurement units.
 var ValidTechCardMeasurementUnits = map[TechCardMeasurementUnit]bool{
 	TechCardUnitCm: true,
-	TechCardUnitIn: true,
+	TechCardUnitMm: true,
 }
 
 // IsValidTechCardMeasurementUnit reports whether u is an accepted unit.
@@ -266,15 +266,16 @@ type TechCardPomActual struct {
 
 // TechCardPomPoint is a point of measure with its grade and actuals (Sheet «Измерения»).
 type TechCardPomPoint struct {
-	Id           int                 `db:"id"`
-	Section      sql.NullString      `db:"section"`
-	Code         sql.NullString      `db:"code"`
-	Name         string              `db:"name"`
-	HowToMeasure sql.NullString      `db:"how_to_measure"`
-	BaseValue    decimal.NullDecimal `db:"base_value"`
-	Tolerance    decimal.NullDecimal `db:"tolerance"`
-	Grades       []TechCardPomGrade  `db:"-"`
-	Actuals      []TechCardPomActual `db:"-"`
+	Id             int                 `db:"id"`
+	Section        sql.NullString      `db:"section"`
+	Code           sql.NullString      `db:"code"`
+	Name           string              `db:"name"`
+	HowToMeasure   sql.NullString      `db:"how_to_measure"`
+	BaseValue      decimal.NullDecimal `db:"base_value"`
+	TolerancePlus  decimal.NullDecimal `db:"tolerance_plus"`
+	ToleranceMinus decimal.NullDecimal `db:"tolerance_minus"`
+	Grades         []TechCardPomGrade  `db:"-"`
+	Actuals        []TechCardPomActual `db:"-"`
 }
 
 // TechCardInsert is the writable payload for a tech card (header + construction

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -1,0 +1,152 @@
+package entity
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// TechCardStage is the development stage of a tech card. It mirrors the
+// common.TechCardStage proto enum and is stored as a string in tech_card.stage.
+type TechCardStage string
+
+const (
+	TechCardStageProto TechCardStage = "proto" // prototype
+	TechCardStageFit   TechCardStage = "fit"   // fit sample
+	TechCardStageSMS   TechCardStage = "sms"   // salesman sample
+	TechCardStagePP    TechCardStage = "pp"    // pre-production
+	TechCardStageProd  TechCardStage = "prod"  // production
+)
+
+// ValidTechCardStages is the set of accepted tech-card stages.
+var ValidTechCardStages = map[TechCardStage]bool{
+	TechCardStageProto: true,
+	TechCardStageFit:   true,
+	TechCardStageSMS:   true,
+	TechCardStagePP:    true,
+	TechCardStageProd:  true,
+}
+
+// IsValidTechCardStage reports whether s is an accepted stage.
+func IsValidTechCardStage(s TechCardStage) bool {
+	return ValidTechCardStages[s]
+}
+
+// TechCardMediaKind classifies a tech-card sketch image. It mirrors the
+// common.TechCardMediaKind proto enum and is stored as a string in
+// tech_card_media.kind.
+type TechCardMediaKind string
+
+const (
+	TechCardMediaFront   TechCardMediaKind = "front"
+	TechCardMediaBack    TechCardMediaKind = "back"
+	TechCardMediaDetail  TechCardMediaKind = "detail"
+	TechCardMediaLining  TechCardMediaKind = "lining"
+	TechCardMediaPreview TechCardMediaKind = "preview"
+)
+
+// ValidTechCardMediaKinds is the set of accepted sketch-media kinds.
+var ValidTechCardMediaKinds = map[TechCardMediaKind]bool{
+	TechCardMediaFront:   true,
+	TechCardMediaBack:    true,
+	TechCardMediaDetail:  true,
+	TechCardMediaLining:  true,
+	TechCardMediaPreview: true,
+}
+
+// IsValidTechCardMediaKind reports whether k is an accepted media kind.
+func IsValidTechCardMediaKind(k TechCardMediaKind) bool {
+	return ValidTechCardMediaKinds[k]
+}
+
+// TechCardMediaItem is a writable sketch-media reference (id + kind).
+type TechCardMediaItem struct {
+	MediaId int               `db:"media_id"`
+	Kind    TechCardMediaKind `db:"kind"`
+}
+
+// TechCardMediaFull is a resolved sketch-media reference for display.
+type TechCardMediaFull struct {
+	Media MediaFull
+	Kind  TechCardMediaKind
+}
+
+// TechCardCallout is a numbered detail note pointing at the technical sketch.
+type TechCardCallout struct {
+	Number      int            `db:"callout_number"`
+	Part        sql.NullString `db:"part"`
+	Description sql.NullString `db:"description"`
+	Dimensions  sql.NullString `db:"dimensions"`
+}
+
+// TechCardRevision is one entry in the revision log.
+type TechCardRevision struct {
+	Version      sql.NullString `db:"version"`
+	RevisionDate sql.NullTime   `db:"revision_date"`
+	Author       sql.NullString `db:"author"`
+	Section      sql.NullString `db:"section"`
+	ChangeNote   sql.NullString `db:"change_note"`
+}
+
+// TechCardInsert is the writable payload for a tech card (header + construction
+// description + child sections). Child slices are full replacements on update.
+type TechCardInsert struct {
+	StyleNumber       string              `db:"style_number"`
+	Name              string              `db:"name"`
+	Brand             sql.NullString      `db:"brand"`
+	Season            sql.NullString      `db:"season"`
+	Collection        sql.NullString      `db:"collection"`
+	CategoryId        sql.NullInt32       `db:"category_id"`
+	TargetGender      sql.NullString      `db:"target_gender"`
+	Stage             TechCardStage       `db:"stage"`
+	Status            sql.NullString      `db:"status"`
+	Version           sql.NullString      `db:"version"`
+	RevisionDate      sql.NullTime        `db:"revision_date"`
+	BaseModelId       sql.NullInt32       `db:"base_model_id"`
+	BaseSampleSizeId  sql.NullInt32       `db:"base_sample_size_id"`
+	Designer          sql.NullString      `db:"designer"`
+	Constructor       sql.NullString      `db:"constructor"`
+	Technologist      sql.NullString      `db:"technologist"`
+	TargetCost        decimal.NullDecimal `db:"target_cost"`
+	TargetRetailPrice decimal.NullDecimal `db:"target_retail_price"`
+	Currency          sql.NullString      `db:"currency"`
+	// construction description
+	Description  sql.NullString `db:"description"`
+	Silhouette   sql.NullString `db:"silhouette"`
+	Collar       sql.NullString `db:"collar"`
+	Fastening    sql.NullString `db:"fastening"`
+	Pockets      sql.NullString `db:"pockets"`
+	SleeveCuff   sql.NullString `db:"sleeve_cuff"`
+	ExtraDetails sql.NullString `db:"extra_details"`
+	Topstitching sql.NullString `db:"topstitching"`
+	AuxMaterials sql.NullString `db:"aux_materials"`
+	Notes        sql.NullString `db:"notes"`
+	// child sections (in-memory only; persisted to their own tables)
+	SizeIds    []int               `db:"-"`
+	ProductIds []int               `db:"-"`
+	Media      []TechCardMediaItem `db:"-"`
+	Callouts   []TechCardCallout   `db:"-"`
+	Revisions  []TechCardRevision  `db:"-"`
+}
+
+// TechCardListFilter holds optional filters for listing tech cards. Empty/zero
+// fields mean "no filter".
+type TechCardListFilter struct {
+	Stage     string // tech_card.stage exact match
+	Gender    string // tech_card.target_gender exact match
+	Brand     string // case-insensitive substring on brand
+	Season    string // case-insensitive substring on season
+	Name      string // case-insensitive substring on name or style_number
+	ProductId int    // only cards linked to this product
+}
+
+// TechCard is a stored tech card (tech_card row + child sections + resolved media).
+type TechCard struct {
+	Id int `db:"id"`
+	TechCardInsert
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+	// ResolvedMedia carries the sketch media with their MediaFull resolved.
+	ResolvedMedia []TechCardMediaFull `db:"-"`
+}

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -138,6 +138,145 @@ type TechCardRevision struct {
 	ChangeNote   sql.NullString `db:"change_note"`
 }
 
+// TechCardBomSection groups a BOM line by material family. Mirrors the
+// common.TechCardBomSection proto enum; stored as a string in tech_card_bom_item.section.
+type TechCardBomSection string
+
+const (
+	BomSectionFabric      TechCardBomSection = "fabric"
+	BomSectionLining      TechCardBomSection = "lining"
+	BomSectionInterlining TechCardBomSection = "interlining"
+	BomSectionInsulation  TechCardBomSection = "insulation"
+	BomSectionHardware    TechCardBomSection = "hardware"
+	BomSectionThread      TechCardBomSection = "thread"
+	BomSectionLabel       TechCardBomSection = "label"
+	BomSectionPackaging   TechCardBomSection = "packaging"
+)
+
+// ValidTechCardBomSections is the set of accepted BOM sections.
+var ValidTechCardBomSections = map[TechCardBomSection]bool{
+	BomSectionFabric:      true,
+	BomSectionLining:      true,
+	BomSectionInterlining: true,
+	BomSectionInsulation:  true,
+	BomSectionHardware:    true,
+	BomSectionThread:      true,
+	BomSectionLabel:       true,
+	BomSectionPackaging:   true,
+}
+
+// IsValidTechCardBomSection reports whether s is an accepted BOM section.
+func IsValidTechCardBomSection(s TechCardBomSection) bool {
+	return ValidTechCardBomSections[s]
+}
+
+// TechCardLabDipStatus is the lab-dip lifecycle of a colourway. Mirrors the
+// common.TechCardLabDipStatus proto enum; stored in tech_card_colorway.lab_dip_status.
+type TechCardLabDipStatus string
+
+const (
+	LabDipPending   TechCardLabDipStatus = "pending"
+	LabDipSubmitted TechCardLabDipStatus = "submitted"
+	LabDipApproved  TechCardLabDipStatus = "approved"
+	LabDipRejected  TechCardLabDipStatus = "rejected"
+)
+
+// ValidTechCardLabDipStatuses is the set of accepted lab-dip statuses.
+var ValidTechCardLabDipStatuses = map[TechCardLabDipStatus]bool{
+	LabDipPending:   true,
+	LabDipSubmitted: true,
+	LabDipApproved:  true,
+	LabDipRejected:  true,
+}
+
+// IsValidTechCardLabDipStatus reports whether s is an accepted lab-dip status.
+func IsValidTechCardLabDipStatus(s TechCardLabDipStatus) bool {
+	return ValidTechCardLabDipStatuses[s]
+}
+
+// TechCardColorway is a development colourway (Sheet «Колористика»).
+type TechCardColorway struct {
+	Id           int                  `db:"id"`
+	Code         sql.NullString       `db:"code"`
+	Name         string               `db:"name"`
+	LabDipStatus TechCardLabDipStatus `db:"lab_dip_status"`
+	ProductId    sql.NullInt32        `db:"product_id"`
+	Comment      sql.NullString       `db:"comment"`
+}
+
+// TechCardBomColorwayColor is the colour of a BOM material in a colourway. On
+// write, ColorwayIndex points into TechCardInsert.Colorways (full-replace has no
+// stable colourway ids yet); on read it is resolved from the stored colorway id.
+type TechCardBomColorwayColor struct {
+	ColorwayIndex int            `db:"-"`
+	Color         sql.NullString `db:"color"`
+	Pantone       sql.NullString `db:"pantone"`
+}
+
+// TechCardBomItem is one bill-of-materials line (Sheet «Спецификация»).
+type TechCardBomItem struct {
+	Id          int                 `db:"id"`
+	Section     TechCardBomSection  `db:"section"`
+	Name        string              `db:"name"`
+	Placement   sql.NullString      `db:"placement"`
+	Supplier    sql.NullString      `db:"supplier"`
+	SupplierRef sql.NullString      `db:"supplier_ref"`
+	Color       sql.NullString      `db:"color"`
+	Composition sql.NullString      `db:"composition"`
+	Spec        sql.NullString      `db:"spec"`
+	Consumption decimal.NullDecimal `db:"consumption"`
+	Unit        sql.NullString      `db:"unit"`
+	Quantity    decimal.NullDecimal `db:"quantity"`
+	UnitPrice   decimal.NullDecimal `db:"unit_price"`
+	Currency    sql.NullString      `db:"currency"`
+	Comment     sql.NullString      `db:"comment"`
+	// ColorwayColors are the per-colourway colours (in-memory; persisted to
+	// tech_card_bom_colorway).
+	ColorwayColors []TechCardBomColorwayColor `db:"-"`
+}
+
+// LineTotal returns quantity*unit_price, falling back to consumption*unit_price
+// when quantity is unset. Invalid (no price) yields an invalid NullDecimal.
+func (b *TechCardBomItem) LineTotal() decimal.NullDecimal {
+	if !b.UnitPrice.Valid {
+		return decimal.NullDecimal{}
+	}
+	qty := b.Quantity
+	if !qty.Valid {
+		qty = b.Consumption
+	}
+	if !qty.Valid {
+		return decimal.NullDecimal{}
+	}
+	return decimal.NullDecimal{Decimal: qty.Decimal.Mul(b.UnitPrice.Decimal), Valid: true}
+}
+
+// TechCardPomGrade is the graded value of a POM point for a size.
+type TechCardPomGrade struct {
+	SizeId int             `db:"size_id"`
+	Value  decimal.Decimal `db:"value"`
+}
+
+// TechCardPomActual is an actual measured value, optionally from a fitting.
+type TechCardPomActual struct {
+	FittingId sql.NullInt32   `db:"fitting_id"`
+	Label     sql.NullString  `db:"label"`
+	Value     decimal.Decimal `db:"value"`
+}
+
+// TechCardPomPoint is a point of measure with its grade and actuals (Sheet «Измерения»).
+type TechCardPomPoint struct {
+	Id           int                 `db:"id"`
+	Section      sql.NullString      `db:"section"`
+	Code         sql.NullString      `db:"code"`
+	Name         string              `db:"name"`
+	HowToMeasure sql.NullString      `db:"how_to_measure"`
+	BaseValue    decimal.NullDecimal `db:"base_value"`
+	Tolerance    decimal.NullDecimal `db:"tolerance"`
+	Grades       []TechCardPomGrade  `db:"-"`
+	Actuals      []TechCardPomActual `db:"-"`
+}
+
 // TechCardInsert is the writable payload for a tech card (header + construction
 // description + child sections). Child slices are full replacements on update.
 type TechCardInsert struct {
@@ -181,6 +320,10 @@ type TechCardInsert struct {
 	Media      []TechCardMediaItem `db:"-"`
 	Callouts   []TechCardCallout   `db:"-"`
 	Revisions  []TechCardRevision  `db:"-"`
+	// materials (Phase 2)
+	BomItems  []TechCardBomItem  `db:"-"`
+	Colorways []TechCardColorway `db:"-"`
+	PomPoints []TechCardPomPoint `db:"-"`
 }
 
 // TechCardListFilter holds optional filters for listing tech cards. Empty/zero

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -33,6 +33,33 @@ func IsValidTechCardStage(s TechCardStage) bool {
 	return ValidTechCardStages[s]
 }
 
+// TechCardApprovalState is the gating release state of a tech card, orthogonal to
+// TechCardStage. It mirrors the common.TechCardApprovalState proto enum and is
+// stored as a string in tech_card.approval_state.
+type TechCardApprovalState string
+
+const (
+	TechCardApprovalDraft    TechCardApprovalState = "draft"
+	TechCardApprovalInReview TechCardApprovalState = "in_review"
+	TechCardApprovalApproved TechCardApprovalState = "approved"
+	TechCardApprovalReleased TechCardApprovalState = "released"
+	TechCardApprovalObsolete TechCardApprovalState = "obsolete"
+)
+
+// ValidTechCardApprovalStates is the set of accepted approval states.
+var ValidTechCardApprovalStates = map[TechCardApprovalState]bool{
+	TechCardApprovalDraft:    true,
+	TechCardApprovalInReview: true,
+	TechCardApprovalApproved: true,
+	TechCardApprovalReleased: true,
+	TechCardApprovalObsolete: true,
+}
+
+// IsValidTechCardApprovalState reports whether s is an accepted approval state.
+func IsValidTechCardApprovalState(s TechCardApprovalState) bool {
+	return ValidTechCardApprovalStates[s]
+}
+
 // TechCardMediaKind classifies a tech-card sketch image. It mirrors the
 // common.TechCardMediaKind proto enum and is stored as a string in
 // tech_card_media.kind.
@@ -78,6 +105,7 @@ type TechCardCallout struct {
 	Part        sql.NullString `db:"part"`
 	Description sql.NullString `db:"description"`
 	Dimensions  sql.NullString `db:"dimensions"`
+	MediaId     sql.NullInt32  `db:"media_id"` // sketch this callout is pinned to
 }
 
 // TechCardRevision is one entry in the revision log.
@@ -92,25 +120,28 @@ type TechCardRevision struct {
 // TechCardInsert is the writable payload for a tech card (header + construction
 // description + child sections). Child slices are full replacements on update.
 type TechCardInsert struct {
-	StyleNumber       string              `db:"style_number"`
-	Name              string              `db:"name"`
-	Brand             sql.NullString      `db:"brand"`
-	Season            sql.NullString      `db:"season"`
-	Collection        sql.NullString      `db:"collection"`
-	CategoryId        sql.NullInt32       `db:"category_id"`
-	TargetGender      sql.NullString      `db:"target_gender"`
-	Stage             TechCardStage       `db:"stage"`
-	Status            sql.NullString      `db:"status"`
-	Version           sql.NullString      `db:"version"`
-	RevisionDate      sql.NullTime        `db:"revision_date"`
-	BaseModelId       sql.NullInt32       `db:"base_model_id"`
-	BaseSampleSizeId  sql.NullInt32       `db:"base_sample_size_id"`
-	Designer          sql.NullString      `db:"designer"`
-	Constructor       sql.NullString      `db:"constructor"`
-	Technologist      sql.NullString      `db:"technologist"`
-	TargetCost        decimal.NullDecimal `db:"target_cost"`
-	TargetRetailPrice decimal.NullDecimal `db:"target_retail_price"`
-	Currency          sql.NullString      `db:"currency"`
+	StyleNumber       string                `db:"style_number"`
+	Name              string                `db:"name"`
+	Brand             sql.NullString        `db:"brand"`
+	Season            sql.NullString        `db:"season"`
+	Collection        sql.NullString        `db:"collection"`
+	CategoryId        sql.NullInt32         `db:"category_id"`
+	TargetGender      sql.NullString        `db:"target_gender"`
+	Stage             TechCardStage         `db:"stage"`
+	Status            sql.NullString        `db:"status"`
+	ApprovalState     TechCardApprovalState `db:"approval_state"`
+	ApprovedBy        sql.NullString        `db:"approved_by"`
+	ReleasedAt        sql.NullTime          `db:"released_at"`
+	Version           sql.NullString        `db:"version"`
+	RevisionDate      sql.NullTime          `db:"revision_date"`
+	BaseModelId       sql.NullInt32         `db:"base_model_id"`
+	BaseSampleSizeId  sql.NullInt32         `db:"base_sample_size_id"`
+	Designer          sql.NullString        `db:"designer"`
+	Constructor       sql.NullString        `db:"constructor"`
+	Technologist      sql.NullString        `db:"technologist"`
+	TargetCost        decimal.NullDecimal   `db:"target_cost"`
+	TargetRetailPrice decimal.NullDecimal   `db:"target_retail_price"`
+	Currency          sql.NullString        `db:"currency"`
 	// construction description
 	Description  sql.NullString `db:"description"`
 	Silhouette   sql.NullString `db:"silhouette"`

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -278,6 +278,101 @@ type TechCardPomPoint struct {
 	Actuals        []TechCardPomActual `db:"-"`
 }
 
+// TechCardLabelType classifies a label/tag. Mirrors the common.TechCardLabelType
+// proto enum; stored as a string in tech_card_label.label_type.
+type TechCardLabelType string
+
+const (
+	LabelTypeMain    TechCardLabelType = "main"
+	LabelTypeSize    TechCardLabelType = "size"
+	LabelTypeCare    TechCardLabelType = "care"
+	LabelTypeOrigin  TechCardLabelType = "origin"
+	LabelTypeFlag    TechCardLabelType = "flag"
+	LabelTypeHangtag TechCardLabelType = "hangtag"
+	LabelTypeBarcode TechCardLabelType = "barcode"
+	LabelTypeSpecial TechCardLabelType = "special"
+)
+
+// ValidTechCardLabelTypes is the set of accepted label types.
+var ValidTechCardLabelTypes = map[TechCardLabelType]bool{
+	LabelTypeMain:    true,
+	LabelTypeSize:    true,
+	LabelTypeCare:    true,
+	LabelTypeOrigin:  true,
+	LabelTypeFlag:    true,
+	LabelTypeHangtag: true,
+	LabelTypeBarcode: true,
+	LabelTypeSpecial: true,
+}
+
+// IsValidTechCardLabelType reports whether t is an accepted label type.
+func IsValidTechCardLabelType(t TechCardLabelType) bool {
+	return ValidTechCardLabelTypes[t]
+}
+
+// TechCardConstruction holds general workmanship parameters (Sheet «Обработка», 1:1).
+type TechCardConstruction struct {
+	MainStitchType  sql.NullString `db:"main_stitch_type"`
+	StitchDensity   sql.NullString `db:"stitch_density"`
+	OverlockThreads sql.NullString `db:"overlock_threads"`
+	SeamAllowances  sql.NullString `db:"seam_allowances"`
+	HemFinish       sql.NullString `db:"hem_finish"`
+	Pressing        sql.NullString `db:"pressing"`
+	MachineClass    sql.NullString `db:"machine_class"`
+	Notes           sql.NullString `db:"notes"`
+}
+
+// TechCardOperation is one per-node sewing operation (Sheet «Обработка»).
+type TechCardOperation struct {
+	Node           string              `db:"node"`
+	Description    sql.NullString      `db:"description"`
+	SeamType       sql.NullString      `db:"seam_type"`
+	StitchesPerCm  decimal.NullDecimal `db:"stitches_per_cm"`
+	TopstitchWidth sql.NullString      `db:"topstitch_width"`
+	Thread         sql.NullString      `db:"thread"`
+	Note           sql.NullString      `db:"note"`
+}
+
+// TechCardLabel is one label/tag spec (Sheet «Этикетки и упаковка»).
+type TechCardLabel struct {
+	LabelType  TechCardLabelType `db:"label_type"`
+	Content    sql.NullString    `db:"content"`
+	Placement  sql.NullString    `db:"placement"`
+	Attachment sql.NullString    `db:"attachment"`
+	Size       sql.NullString    `db:"size"`
+	Note       sql.NullString    `db:"note"`
+}
+
+// TechCardPackaging holds the packaging spec (Sheet «Этикетки и упаковка», 1:1).
+type TechCardPackaging struct {
+	FoldingMethod sql.NullString      `db:"folding_method"`
+	Polybag       sql.NullString      `db:"polybag"`
+	BagSticker    sql.NullString      `db:"bag_sticker"`
+	Inserts       sql.NullString      `db:"inserts"`
+	UnitsPerBox   sql.NullInt32       `db:"units_per_box"`
+	BoxMarking    sql.NullString      `db:"box_marking"`
+	BoxDimensions sql.NullString      `db:"box_dimensions"`
+	WeightNet     decimal.NullDecimal `db:"weight_net"`
+	WeightGross   decimal.NullDecimal `db:"weight_gross"`
+	Notes         sql.NullString      `db:"notes"`
+}
+
+// TechCardCosting holds the manually-entered cost articles (Sheet «Калькуляция», 1:1).
+// The materials rollup and total are computed on read (see dto), not stored.
+type TechCardCosting struct {
+	CmtCost          decimal.NullDecimal `db:"cmt_cost"`
+	HardwareCost     decimal.NullDecimal `db:"hardware_cost"`
+	PackagingCost    decimal.NullDecimal `db:"packaging_cost"`
+	LogisticsCost    decimal.NullDecimal `db:"logistics_cost"`
+	OverheadCost     decimal.NullDecimal `db:"overhead_cost"`
+	DefectPercent    decimal.NullDecimal `db:"defect_percent"`
+	MarkupMultiplier decimal.NullDecimal `db:"markup_multiplier"`
+	WholesalePrice   decimal.NullDecimal `db:"wholesale_price"`
+	RetailPrice      decimal.NullDecimal `db:"retail_price"`
+	Currency         sql.NullString      `db:"currency"`
+	Notes            sql.NullString      `db:"notes"`
+}
+
 // TechCardInsert is the writable payload for a tech card (header + construction
 // description + child sections). Child slices are full replacements on update.
 type TechCardInsert struct {
@@ -325,6 +420,12 @@ type TechCardInsert struct {
 	BomItems  []TechCardBomItem  `db:"-"`
 	Colorways []TechCardColorway `db:"-"`
 	PomPoints []TechCardPomPoint `db:"-"`
+	// production (Phase 3); 1:1 sections are nil when unset
+	Construction *TechCardConstruction `db:"-"`
+	Operations   []TechCardOperation   `db:"-"`
+	Labels       []TechCardLabel       `db:"-"`
+	Packaging    *TechCardPackaging    `db:"-"`
+	Costing      *TechCardCosting      `db:"-"`
 }
 
 // TechCardListFilter holds optional filters for listing tech cards. Empty/zero

--- a/internal/store/fitting/fitting.go
+++ b/internal/store/fitting/fitting.go
@@ -38,8 +38,8 @@ func (s *Store) AddFitting(ctx context.Context, f *entity.FittingInsert) (int, e
 	err := s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
 		var err error
 		id, err = storeutil.ExecNamedLastId(ctx, rep.DB(), `
-			INSERT INTO fitting (product_id, model_id, fitting_date, comment, status, verdict, recorded_by)
-			VALUES (:productId, :modelId, :fittingDate, :comment, :status, :verdict, :recordedBy)`,
+			INSERT INTO fitting (tech_card_id, product_id, model_id, fitting_date, comment, status, verdict, recorded_by)
+			VALUES (:techCardId, :productId, :modelId, :fittingDate, :comment, :status, :verdict, :recordedBy)`,
 			fittingParams(f))
 		if err != nil {
 			return fmt.Errorf("failed to insert fitting: %w", err)
@@ -73,6 +73,7 @@ func (s *Store) UpdateFitting(ctx context.Context, id int, f *entity.FittingInse
 		params["id"] = id
 		if err := storeutil.ExecNamed(ctx, rep.DB(), `
 			UPDATE fitting SET
+				tech_card_id = :techCardId,
 				product_id = :productId,
 				model_id = :modelId,
 				fitting_date = :fittingDate,
@@ -131,15 +132,19 @@ func (s *Store) GetFittingById(ctx context.Context, id int) (*entity.Fitting, er
 	return &f, nil
 }
 
-// ListFittings returns a paged list of fittings, optionally filtered by product
-// and/or model (pass 0 to ignore a filter), with sizes and resolved media, plus
-// the total number of matching fittings (ignoring pagination).
-func (s *Store) ListFittings(ctx context.Context, limit, offset int, orderFactor entity.OrderFactor, productID, modelID int) ([]entity.Fitting, int, error) {
+// ListFittings returns a paged list of fittings, optionally filtered by tech card,
+// product and/or model (pass 0 to ignore a filter), with sizes and resolved media,
+// plus the total number of matching fittings (ignoring pagination).
+func (s *Store) ListFittings(ctx context.Context, limit, offset int, orderFactor entity.OrderFactor, productID, modelID, techCardID int) ([]entity.Fitting, int, error) {
 	limit, offset = clampPagination(limit, offset)
 
 	// Shared filter for both the count and the page query.
 	filterParams := map[string]any{}
 	where := ""
+	if techCardID != 0 {
+		where += " AND tech_card_id = :techCardId"
+		filterParams["techCardId"] = techCardID
+	}
 	if productID != 0 {
 		where += " AND product_id = :productId"
 		filterParams["productId"] = productID
@@ -208,6 +213,7 @@ func clampPagination(limit, offset int) (int, int) {
 
 func fittingParams(f *entity.FittingInsert) map[string]any {
 	return map[string]any{
+		"techCardId":  f.TechCardId,
 		"productId":   f.ProductId,
 		"modelId":     f.ModelId,
 		"fittingDate": f.FittingDate,

--- a/internal/store/sql/0067_add_tech_card_core.sql
+++ b/internal/store/sql/0067_add_tech_card_core.sql
@@ -1,0 +1,122 @@
+-- +migrate Up
+-- Tech card (техкарта / tech pack) — the garment manufacturing spec a brand hands a
+-- factory. A tech card is a standalone "style" document with a development stage
+-- (proto|fit|sms|pp|prod) that links to zero or more catalog products it spawns
+-- (one style, many colorways). This migration adds the core skeleton: the header
+-- (identification + construction description), the size range (grade), product
+-- links, sketch/preview media, sketch callouts, and the revision log. Materials
+-- (BOM, colorways, POM) and production (operations, labels, packaging, costing)
+-- arrive in later migrations.
+
+-- tech_card: the tech pack header (Sheet «Титул»).
+CREATE TABLE tech_card (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  style_number VARCHAR(255) NOT NULL COMMENT 'style / article number (Артикул)',
+  name VARCHAR(255) NOT NULL COMMENT 'product name (Название изделия)',
+  brand VARCHAR(255) NULL,
+  season VARCHAR(255) NULL COMMENT 'free-text season (Сезон)',
+  collection VARCHAR(255) NULL COMMENT 'free-text collection (Коллекция)',
+  category_id INT NULL COMMENT 'FK category(id); optional category/type',
+  target_gender VARCHAR(16) NULL COMMENT 'male|female|unisex (common.GenderEnum); NULL = unset'
+    CHECK (target_gender IS NULL OR target_gender REGEXP '^(male|female|unisex)$'),
+  stage VARCHAR(16) NOT NULL DEFAULT 'proto' COMMENT 'proto|fit|sms|pp|prod'
+    CHECK (stage REGEXP '^(proto|fit|sms|pp|prod)$'),
+  status VARCHAR(255) NULL COMMENT 'freeform workflow status',
+  version VARCHAR(64) NULL COMMENT 'revision label (Версия / ревизия)',
+  revision_date DATE NULL COMMENT 'date of the current revision (Дата ревизии)',
+  base_model_id INT NULL COMMENT 'FK model(id); base fit model (Модель за основу)',
+  base_sample_size_id INT NULL COMMENT 'FK size(id); base sample size (Базовый размер образца)',
+  designer VARCHAR(255) NULL,
+  constructor VARCHAR(255) NULL,
+  technologist VARCHAR(255) NULL,
+  target_cost DECIMAL(10, 2) NULL COMMENT 'target cost (Целевая себестоимость)',
+  target_retail_price DECIMAL(10, 2) NULL COMMENT 'target retail price (Целевая розн. цена)',
+  currency VARCHAR(3) NULL COMMENT 'ISO 4217 for target cost/price and costing',
+  -- construction description (lower block of Sheet «Титул»)
+  description TEXT NULL COMMENT 'short product description',
+  silhouette TEXT NULL COMMENT 'silhouette / length',
+  collar TEXT NULL COMMENT 'collar / neckline',
+  fastening TEXT NULL COMMENT 'fastening',
+  pockets TEXT NULL,
+  sleeve_cuff TEXT NULL COMMENT 'sleeve / cuff',
+  extra_details TEXT NULL COMMENT 'additional details',
+  topstitching TEXT NULL COMMENT 'topstitching (general description)',
+  aux_materials TEXT NULL COMMENT 'applied / auxiliary materials',
+  notes TEXT NULL COMMENT 'additional notes',
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_tech_card_style_number (style_number),
+  INDEX idx_tech_card_created (created_at),
+  INDEX idx_tech_card_stage (stage),
+  FOREIGN KEY (category_id) REFERENCES category(id),
+  FOREIGN KEY (base_model_id) REFERENCES model(id) ON DELETE SET NULL,
+  FOREIGN KEY (base_sample_size_id) REFERENCES size(id)
+) COMMENT 'Garment tech pack (техкарта) header';
+
+-- tech_card_size: the size range / grade of a tech card (defines POM columns later).
+CREATE TABLE tech_card_size (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  size_id INT NOT NULL COMMENT 'FK size(id)',
+  display_order INT NOT NULL DEFAULT 0,
+  UNIQUE KEY uniq_tech_card_size (tech_card_id, size_id),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE,
+  FOREIGN KEY (size_id) REFERENCES size(id)
+) COMMENT 'Size range (grade) of a tech card';
+
+-- tech_card_product: catalog products spawned from / linked to a tech card.
+CREATE TABLE tech_card_product (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  product_id INT NOT NULL COMMENT 'FK product(id)',
+  display_order INT NOT NULL DEFAULT 0,
+  UNIQUE KEY uniq_tech_card_product (tech_card_id, product_id),
+  INDEX idx_tech_card_product_product (product_id),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES product(id) ON DELETE CASCADE
+) COMMENT 'Catalog products linked to a tech card';
+
+-- tech_card_media: sketch / preview media (Sheet «Тех. эскиз»).
+CREATE TABLE tech_card_media (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  media_id INT NOT NULL,
+  kind VARCHAR(16) NOT NULL DEFAULT 'preview' COMMENT 'front|back|detail|lining|preview'
+    CHECK (kind REGEXP '^(front|back|detail|lining|preview)$'),
+  display_order INT NOT NULL DEFAULT 0,
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE,
+  FOREIGN KEY (media_id) REFERENCES media(id)
+) COMMENT 'Sketch / preview media for a tech card';
+
+-- tech_card_callout: numbered sketch callouts / detail notes (Sheet «Тех. эскиз»).
+CREATE TABLE tech_card_callout (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  callout_number INT NOT NULL DEFAULT 0 COMMENT 'callout number on the sketch',
+  part VARCHAR(255) NULL COMMENT 'деталь / узел',
+  description TEXT NULL COMMENT 'описание, уточнение',
+  dimensions VARCHAR(255) NULL COMMENT 'размеры / привязка',
+  display_order INT NOT NULL DEFAULT 0,
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Sketch callouts (выноски) for a tech card';
+
+-- tech_card_revision: revision log (Sheet «История примерок» — журнал ревизий).
+CREATE TABLE tech_card_revision (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  version VARCHAR(64) NULL,
+  revision_date DATE NULL,
+  author VARCHAR(255) NULL,
+  section VARCHAR(255) NULL COMMENT 'раздел',
+  change_note TEXT NULL COMMENT 'что изменено',
+  display_order INT NOT NULL DEFAULT 0,
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Revision log (журнал ревизий) for a tech card';
+
+-- +migrate Down
+DROP TABLE IF EXISTS tech_card_revision;
+DROP TABLE IF EXISTS tech_card_callout;
+DROP TABLE IF EXISTS tech_card_media;
+DROP TABLE IF EXISTS tech_card_product;
+DROP TABLE IF EXISTS tech_card_size;
+DROP TABLE IF EXISTS tech_card;

--- a/internal/store/sql/0067_add_tech_card_core.sql
+++ b/internal/store/sql/0067_add_tech_card_core.sql
@@ -21,7 +21,12 @@ CREATE TABLE tech_card (
     CHECK (target_gender IS NULL OR target_gender REGEXP '^(male|female|unisex)$'),
   stage VARCHAR(16) NOT NULL DEFAULT 'proto' COMMENT 'proto|fit|sms|pp|prod'
     CHECK (stage REGEXP '^(proto|fit|sms|pp|prod)$'),
-  status VARCHAR(255) NULL COMMENT 'freeform workflow status',
+  status VARCHAR(255) NULL COMMENT 'freeform workflow notes (soft, non-gating)',
+  approval_state VARCHAR(16) NOT NULL DEFAULT 'draft'
+    COMMENT 'gating release state, orthogonal to stage: draft|in_review|approved|released|obsolete'
+    CHECK (approval_state REGEXP '^(draft|in_review|approved|released|obsolete)$'),
+  approved_by VARCHAR(255) NULL COMMENT 'who approved the current revision',
+  released_at TIMESTAMP NULL COMMENT 'when the card was released to manufacture',
   version VARCHAR(64) NULL COMMENT 'revision label (Версия / ревизия)',
   revision_date DATE NULL COMMENT 'date of the current revision (Дата ревизии)',
   base_model_id INT NULL COMMENT 'FK model(id); base fit model (Модель за основу)',
@@ -45,9 +50,14 @@ CREATE TABLE tech_card (
   notes TEXT NULL COMMENT 'additional notes',
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  UNIQUE KEY uniq_tech_card_style_number (style_number),
+  -- style/article numbers are reused across seasons (carryover / re-spec), so the
+  -- article is unique per season, not globally. NOTE: season is NULLable and MySQL
+  -- treats NULLs as distinct, so two cards with the same style_number and NULL season
+  -- are both allowed (uniqueness only bites once a season is set).
+  UNIQUE KEY uniq_tech_card_style_number_season (style_number, season),
   INDEX idx_tech_card_created (created_at),
   INDEX idx_tech_card_stage (stage),
+  INDEX idx_tech_card_approval_state (approval_state),
   FOREIGN KEY (category_id) REFERENCES category(id),
   FOREIGN KEY (base_model_id) REFERENCES model(id) ON DELETE SET NULL,
   FOREIGN KEY (base_sample_size_id) REFERENCES size(id)
@@ -96,8 +106,10 @@ CREATE TABLE tech_card_callout (
   part VARCHAR(255) NULL COMMENT 'деталь / узел',
   description TEXT NULL COMMENT 'описание, уточнение',
   dimensions VARCHAR(255) NULL COMMENT 'размеры / привязка',
+  media_id INT NULL COMMENT 'FK media(id); the sketch this callout is pinned to (0/NULL = unanchored)',
   display_order INT NOT NULL DEFAULT 0,
-  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE,
+  FOREIGN KEY (media_id) REFERENCES media(id) ON DELETE SET NULL
 ) COMMENT 'Sketch callouts (выноски) for a tech card';
 
 -- tech_card_revision: revision log (Sheet «История примерок» — журнал ревизий).

--- a/internal/store/sql/0067_add_tech_card_core.sql
+++ b/internal/store/sql/0067_add_tech_card_core.sql
@@ -34,9 +34,14 @@ CREATE TABLE tech_card (
   designer VARCHAR(255) NULL,
   constructor VARCHAR(255) NULL,
   technologist VARCHAR(255) NULL,
-  target_cost DECIMAL(10, 2) NULL COMMENT 'target cost (Целевая себестоимость)',
-  target_retail_price DECIMAL(10, 2) NULL COMMENT 'target retail price (Целевая розн. цена)',
+  target_cost DECIMAL(10, 2) NULL COMMENT 'target cost (Целевая себестоимость)'
+    CHECK (target_cost IS NULL OR target_cost >= 0),
+  target_retail_price DECIMAL(10, 2) NULL COMMENT 'target retail price (Целевая розн. цена)'
+    CHECK (target_retail_price IS NULL OR target_retail_price >= 0),
   currency VARCHAR(3) NULL COMMENT 'ISO 4217 for target cost/price and costing',
+  measurement_unit VARCHAR(8) NOT NULL DEFAULT 'cm'
+    COMMENT 'cm|in for callout dimensions and the future POM chart'
+    CHECK (measurement_unit REGEXP '^(cm|in)$'),
   -- construction description (lower block of Sheet «Титул»)
   description TEXT NULL COMMENT 'short product description',
   silhouette TEXT NULL COMMENT 'silhouette / length',
@@ -83,6 +88,9 @@ CREATE TABLE tech_card_product (
   UNIQUE KEY uniq_tech_card_product (tech_card_id, product_id),
   INDEX idx_tech_card_product_product (product_id),
   FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE,
+  -- products are soft-deleted (product.deleted_at), so this CASCADE only fires on
+  -- a hard delete and is effectively a safety net; the read path filters out
+  -- soft-deleted products (see productIdsByTechCardIds).
   FOREIGN KEY (product_id) REFERENCES product(id) ON DELETE CASCADE
 ) COMMENT 'Catalog products linked to a tech card';
 
@@ -112,7 +120,9 @@ CREATE TABLE tech_card_callout (
   FOREIGN KEY (media_id) REFERENCES media(id) ON DELETE SET NULL
 ) COMMENT 'Sketch callouts (выноски) for a tech card';
 
--- tech_card_revision: revision log (Sheet «История примерок» — журнал ревизий).
+-- tech_card_revision: changelog of the SPEC DOCUMENT itself (журнал ревизий —
+-- what changed in which section, by whom). This is NOT fit history: fitting
+-- verdicts/measurements live in the separate fitting feature (migration 0064).
 CREATE TABLE tech_card_revision (
   id INT PRIMARY KEY AUTO_INCREMENT,
   tech_card_id INT NOT NULL,

--- a/internal/store/sql/0067_add_tech_card_core.sql
+++ b/internal/store/sql/0067_add_tech_card_core.sql
@@ -40,8 +40,8 @@ CREATE TABLE tech_card (
     CHECK (target_retail_price IS NULL OR target_retail_price >= 0),
   currency VARCHAR(3) NULL COMMENT 'ISO 4217 for target cost/price and costing',
   measurement_unit VARCHAR(8) NOT NULL DEFAULT 'cm'
-    COMMENT 'cm|in for callout dimensions and the future POM chart'
-    CHECK (measurement_unit REGEXP '^(cm|in)$'),
+    COMMENT 'cm|mm for callout dimensions and the POM chart (metric only)'
+    CHECK (measurement_unit REGEXP '^(cm|mm)$'),
   -- construction description (lower block of Sheet «Титул»)
   description TEXT NULL COMMENT 'short product description',
   silhouette TEXT NULL COMMENT 'silhouette / length',

--- a/internal/store/sql/0068_add_tech_card_materials.sql
+++ b/internal/store/sql/0068_add_tech_card_materials.sql
@@ -1,0 +1,131 @@
+-- +migrate Up
+-- Tech card materials (Phase 2): bill of materials (BOM), colorways, and the
+-- graded measurement chart (POM). Builds on 0067 (tech_card core).
+--
+-- Design notes:
+--  * Colorway is a first-class entity (Sheet «Колористика»), not a reuse of
+--    tech_card_product. tech_card_product stays the set of PUBLISHED catalog SKUs;
+--    a colorway is a development colourway with its own lab-dip lifecycle and an
+--    OPTIONAL link to the product that realises it once published.
+--  * Per-material colour per colourway lives in tech_card_bom_colorway (the matrix
+--    cell), so "BOM colour codes hang off the colourway".
+--  * POM grade rows key on size_id (the stable size dictionary id), NOT on
+--    tech_card_size.id: UpdateTechCard full-replaces child rows every save, so the
+--    junction surrogate id is unstable and would orphan the grade.
+--  * Money/cost is per BOM line with its own currency; the header target_cost /
+--    target_retail_price stay TARGET-only (no rollup stored here).
+--  * POM "actual" measurements optionally reference a fitting(id): fit history
+--    itself stays in the fitting feature (migration 0064).
+
+-- tech_card_colorway: a development colourway (Sheet «Колористика» columns).
+CREATE TABLE tech_card_colorway (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  code VARCHAR(64) NULL COMMENT 'short colourway code, e.g. BLK',
+  name VARCHAR(255) NOT NULL COMMENT 'colourway name (название колорвея)',
+  lab_dip_status VARCHAR(16) NOT NULL DEFAULT 'pending'
+    COMMENT 'pending|submitted|approved|rejected'
+    CHECK (lab_dip_status REGEXP '^(pending|submitted|approved|rejected)$'),
+  product_id INT NULL COMMENT 'FK product(id); published SKU realising this colourway',
+  comment TEXT NULL,
+  display_order INT NOT NULL DEFAULT 0,
+  UNIQUE KEY uniq_tech_card_colorway_code (tech_card_id, code),
+  INDEX idx_tech_card_colorway_card (tech_card_id),
+  INDEX idx_tech_card_colorway_product (product_id),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES product(id) ON DELETE SET NULL
+) COMMENT 'Development colourways for a tech card';
+
+-- tech_card_bom_item: one line of the bill of materials (Sheet «Спецификация»).
+CREATE TABLE tech_card_bom_item (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  section VARCHAR(24) NOT NULL
+    COMMENT 'fabric|lining|interlining|insulation|hardware|thread|label|packaging'
+    CHECK (section REGEXP '^(fabric|lining|interlining|insulation|hardware|thread|label|packaging)$'),
+  name VARCHAR(255) NOT NULL COMMENT 'material name (Наименование материала)',
+  placement VARCHAR(255) NULL COMMENT 'Размещение / назначение',
+  supplier VARCHAR(255) NULL,
+  supplier_ref VARCHAR(255) NULL COMMENT 'Артикул поставщика',
+  color VARCHAR(255) NULL COMMENT 'base/default colour (Цвет / колор)',
+  composition VARCHAR(255) NULL COMMENT 'Состав',
+  spec VARCHAR(255) NULL COMMENT 'Ширина / плотность',
+  consumption DECIMAL(10, 3) NULL COMMENT 'Норма расхода'
+    CHECK (consumption IS NULL OR consumption >= 0),
+  unit VARCHAR(32) NULL COMMENT 'Ед.',
+  quantity DECIMAL(10, 3) NULL COMMENT 'Кол-во'
+    CHECK (quantity IS NULL OR quantity >= 0),
+  unit_price DECIMAL(12, 4) NULL COMMENT 'Цена/ед.'
+    CHECK (unit_price IS NULL OR unit_price >= 0),
+  currency VARCHAR(3) NULL COMMENT 'ISO 4217 for unit_price',
+  comment TEXT NULL COMMENT 'Комментарий (лицо/изнанка)',
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_bom_card (tech_card_id),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Bill of materials lines for a tech card';
+
+-- tech_card_bom_colorway: matrix cell — colour of a BOM material in a colourway.
+CREATE TABLE tech_card_bom_colorway (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  bom_item_id INT NOT NULL,
+  colorway_id INT NOT NULL,
+  color VARCHAR(255) NULL COMMENT 'colour name / code for this material in this colourway',
+  pantone VARCHAR(64) NULL COMMENT 'Pantone / code',
+  display_order INT NOT NULL DEFAULT 0,
+  UNIQUE KEY uniq_tech_card_bom_colorway (bom_item_id, colorway_id),
+  INDEX idx_tech_card_bom_colorway_colorway (colorway_id),
+  FOREIGN KEY (bom_item_id) REFERENCES tech_card_bom_item(id) ON DELETE CASCADE,
+  FOREIGN KEY (colorway_id) REFERENCES tech_card_colorway(id) ON DELETE CASCADE
+) COMMENT 'Per-colourway colour of a BOM material (Sheet «Колористика» cells)';
+
+-- tech_card_pom_point: a point of measure (Sheet «Измерения (POM)» rows).
+CREATE TABLE tech_card_pom_point (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  section VARCHAR(255) NULL COMMENT 'group label, e.g. ВЕРХ / КОРПУС',
+  code VARCHAR(32) NULL COMMENT 'POM code (Код)',
+  name VARCHAR(255) NOT NULL COMMENT 'measurement point (Точка измерения)',
+  how_to_measure TEXT NULL COMMENT 'HTM (как измерять)',
+  base_value DECIMAL(8, 2) NULL COMMENT 'base-sample value (Базовый образец)'
+    CHECK (base_value IS NULL OR base_value >= 0),
+  tolerance DECIMAL(8, 2) NULL COMMENT 'tolerance ± (Допуск)'
+    CHECK (tolerance IS NULL OR tolerance >= 0),
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_pom_card (tech_card_id),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Points of measure for a tech card; values in tech_card.measurement_unit';
+
+-- tech_card_pom_grade: graded value of a POM point for a size in the size range.
+-- Keyed on size_id (stable dictionary id), never tech_card_size.id.
+CREATE TABLE tech_card_pom_grade (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  pom_point_id INT NOT NULL,
+  size_id INT NOT NULL COMMENT 'FK size(id)',
+  value DECIMAL(8, 2) NOT NULL CHECK (value >= 0),
+  UNIQUE KEY uniq_tech_card_pom_grade (pom_point_id, size_id),
+  INDEX idx_tech_card_pom_grade_size (size_id),
+  FOREIGN KEY (pom_point_id) REFERENCES tech_card_pom_point(id) ON DELETE CASCADE,
+  FOREIGN KEY (size_id) REFERENCES size(id)
+) COMMENT 'Graded POM values per size';
+
+-- tech_card_pom_actual: an actual measured value (Факт примерка), optionally
+-- linked to the fitting session it was taken in.
+CREATE TABLE tech_card_pom_actual (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  pom_point_id INT NOT NULL,
+  fitting_id INT NULL COMMENT 'FK fitting(id); fit session this measurement came from',
+  label VARCHAR(64) NULL COMMENT 'free label when no fitting linked, e.g. примерка 1',
+  value DECIMAL(8, 2) NOT NULL CHECK (value >= 0),
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_pom_actual_fitting (fitting_id),
+  FOREIGN KEY (pom_point_id) REFERENCES tech_card_pom_point(id) ON DELETE CASCADE,
+  FOREIGN KEY (fitting_id) REFERENCES fitting(id) ON DELETE SET NULL
+) COMMENT 'Actual measured POM values from fittings';
+
+-- +migrate Down
+DROP TABLE IF EXISTS tech_card_pom_actual;
+DROP TABLE IF EXISTS tech_card_pom_grade;
+DROP TABLE IF EXISTS tech_card_pom_point;
+DROP TABLE IF EXISTS tech_card_bom_colorway;
+DROP TABLE IF EXISTS tech_card_bom_item;
+DROP TABLE IF EXISTS tech_card_colorway;

--- a/internal/store/sql/0068_add_tech_card_materials.sql
+++ b/internal/store/sql/0068_add_tech_card_materials.sql
@@ -88,8 +88,10 @@ CREATE TABLE tech_card_pom_point (
   how_to_measure TEXT NULL COMMENT 'HTM (как измерять)',
   base_value DECIMAL(8, 2) NULL COMMENT 'base-sample value (Базовый образец)'
     CHECK (base_value IS NULL OR base_value >= 0),
-  tolerance DECIMAL(8, 2) NULL COMMENT 'tolerance ± (Допуск)'
-    CHECK (tolerance IS NULL OR tolerance >= 0),
+  tolerance_plus DECIMAL(8, 2) NULL COMMENT 'tolerance + (Допуск +)'
+    CHECK (tolerance_plus IS NULL OR tolerance_plus >= 0),
+  tolerance_minus DECIMAL(8, 2) NULL COMMENT 'tolerance - (Допуск -)'
+    CHECK (tolerance_minus IS NULL OR tolerance_minus >= 0),
   display_order INT NOT NULL DEFAULT 0,
   INDEX idx_tech_card_pom_card (tech_card_id),
   FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE

--- a/internal/store/sql/0069_link_fitting_tech_card.sql
+++ b/internal/store/sql/0069_link_fitting_tech_card.sql
@@ -1,0 +1,28 @@
+-- +migrate Up
+-- Link a fitting to a tech card (the style) and make product_id optional.
+--
+-- The fit of a garment is colour-independent (same pattern across colourways), so
+-- a fitting conceptually belongs to the STYLE (tech card); the specific product
+-- (colour/SKU) that was sewn as the fit sample is optional metadata. product_id
+-- therefore becomes nullable so a prototype can be fitted before any colour SKU
+-- exists. One tech card can have many fittings across different products
+-- (colourways): they share tech_card_id and differ by product_id.
+--
+-- The "at least one of (tech_card_id, product_id) must be set" rule is enforced in
+-- the API layer, NOT as a CHECK constraint: tech_card_id uses ON DELETE SET NULL,
+-- and a CHECK could otherwise block deleting a tech card that has style-only
+-- fittings (the SET NULL would violate the CHECK). Existing fittings keep their
+-- product_id, so this migration is safe against existing data.
+
+ALTER TABLE fitting
+  ADD COLUMN tech_card_id INT NULL COMMENT 'FK tech_card(id) — the style being fitted (colour-independent)' AFTER id,
+  MODIFY COLUMN product_id INT NULL COMMENT 'FK product(id) — the specific colour/SKU sample; NULL = style-level / proto',
+  ADD INDEX idx_fitting_tech_card (tech_card_id),
+  ADD CONSTRAINT fk_fitting_tech_card FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE SET NULL;
+
+-- +migrate Down
+ALTER TABLE fitting
+  DROP FOREIGN KEY fk_fitting_tech_card,
+  DROP INDEX idx_fitting_tech_card,
+  DROP COLUMN tech_card_id,
+  MODIFY COLUMN product_id INT NOT NULL COMMENT 'FK product(id) — the garment tried on';

--- a/internal/store/sql/0070_add_tech_card_production.sql
+++ b/internal/store/sql/0070_add_tech_card_production.sql
@@ -1,0 +1,114 @@
+-- +migrate Up
+-- Tech card production (Phase 3): construction/workmanship, labels & packaging, and
+-- costing. Builds on 0067 (core) and 0068 (materials).
+--
+-- Design notes:
+--  * The 1:1 sections (construction, packaging, costing) use tech_card_id as the
+--    PRIMARY KEY so a full-replace on UpdateTechCard is a plain DELETE+INSERT by
+--    tech_card_id, with no surrogate id to leak.
+--  * Costing stores only the manually-entered cost articles + its own currency;
+--    the materials rollup (Σ BOM line_total per currency) and the total are
+--    COMPUTED on read, never stored, and never auto-converted across currencies.
+--    hardware_cost is "hardware if NOT already in the BOM" (per the template), so
+--    it does not double-count the BOM hardware section.
+
+-- tech_card_construction: general workmanship parameters (Sheet «Обработка», top).
+CREATE TABLE tech_card_construction (
+  tech_card_id INT PRIMARY KEY,
+  main_stitch_type VARCHAR(255) NULL COMMENT 'тип основной машинной строчки',
+  stitch_density VARCHAR(64) NULL COMMENT 'плотность строчки по умолчанию (стеж/см)',
+  overlock_threads VARCHAR(32) NULL COMMENT 'краеобмёточная (оверлок), кол-во ниток',
+  seam_allowances VARCHAR(255) NULL COMMENT 'припуски на швы (общие)',
+  hem_finish VARCHAR(255) NULL COMMENT 'обработка низа / подгибка',
+  pressing VARCHAR(255) NULL COMMENT 'ВТО / финишная отделка',
+  machine_class VARCHAR(255) NULL COMMENT 'класс / группа машин',
+  notes TEXT NULL,
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'General workmanship parameters for a tech card (1:1)';
+
+-- tech_card_operation: per-node sewing operations (Sheet «Обработка», operations).
+CREATE TABLE tech_card_operation (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  node VARCHAR(255) NOT NULL COMMENT 'узел / операция',
+  description TEXT NULL COMMENT 'описание обработки',
+  seam_type VARCHAR(255) NULL COMMENT 'тип шва / строчки',
+  stitches_per_cm DECIMAL(5, 2) NULL COMMENT 'стежков/см'
+    CHECK (stitches_per_cm IS NULL OR stitches_per_cm >= 0),
+  topstitch_width VARCHAR(64) NULL COMMENT 'ширина отстрочки',
+  thread VARCHAR(255) NULL COMMENT 'нитки (арт.)',
+  note TEXT NULL COMMENT 'примечание',
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_operation_card (tech_card_id),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Per-node sewing operations for a tech card';
+
+-- tech_card_label: labels & tags (Sheet «Этикетки и упаковка», labels).
+CREATE TABLE tech_card_label (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  label_type VARCHAR(16) NOT NULL
+    COMMENT 'main|size|care|origin|flag|hangtag|barcode|special'
+    CHECK (label_type REGEXP '^(main|size|care|origin|flag|hangtag|barcode|special)$'),
+  content VARCHAR(255) NULL COMMENT 'содержание / артикул',
+  placement VARCHAR(255) NULL COMMENT 'размещение',
+  attachment VARCHAR(255) NULL COMMENT 'крепление',
+  size VARCHAR(64) NULL COMMENT 'размер',
+  note TEXT NULL COMMENT 'примечание',
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_label_card (tech_card_id),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Labels and tags for a tech card';
+
+-- tech_card_packaging: packaging spec (Sheet «Этикетки и упаковка», packaging).
+CREATE TABLE tech_card_packaging (
+  tech_card_id INT PRIMARY KEY,
+  folding_method VARCHAR(255) NULL COMMENT 'способ складывания',
+  polybag VARCHAR(255) NULL COMMENT 'полибэг (тип / размер)',
+  bag_sticker VARCHAR(255) NULL COMMENT 'стикер на пакет',
+  inserts VARCHAR(255) NULL COMMENT 'доп. вложения (картон, булавки, крючок)',
+  units_per_box INT NULL COMMENT 'кол-во в коробе'
+    CHECK (units_per_box IS NULL OR units_per_box >= 0),
+  box_marking VARCHAR(255) NULL COMMENT 'маркировка короба',
+  box_dimensions VARCHAR(128) NULL COMMENT 'размеры короба (Д×Ш×В)',
+  weight_net DECIMAL(8, 3) NULL COMMENT 'вес нетто'
+    CHECK (weight_net IS NULL OR weight_net >= 0),
+  weight_gross DECIMAL(8, 3) NULL COMMENT 'вес брутто'
+    CHECK (weight_gross IS NULL OR weight_gross >= 0),
+  notes TEXT NULL,
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Packaging spec for a tech card (1:1)';
+
+-- tech_card_costing: manually-entered cost articles (Sheet «Калькуляция»).
+-- Materials rollup + total are computed on read from the BOM, not stored.
+CREATE TABLE tech_card_costing (
+  tech_card_id INT PRIMARY KEY,
+  cmt_cost DECIMAL(12, 2) NULL COMMENT 'пошив / работа (CMT)'
+    CHECK (cmt_cost IS NULL OR cmt_cost >= 0),
+  hardware_cost DECIMAL(12, 2) NULL COMMENT 'фурнитура (если вне BOM)'
+    CHECK (hardware_cost IS NULL OR hardware_cost >= 0),
+  packaging_cost DECIMAL(12, 2) NULL COMMENT 'упаковка и маркировка'
+    CHECK (packaging_cost IS NULL OR packaging_cost >= 0),
+  logistics_cost DECIMAL(12, 2) NULL COMMENT 'логистика / доставка'
+    CHECK (logistics_cost IS NULL OR logistics_cost >= 0),
+  overhead_cost DECIMAL(12, 2) NULL COMMENT 'накладные расходы'
+    CHECK (overhead_cost IS NULL OR overhead_cost >= 0),
+  defect_percent DECIMAL(5, 2) NULL COMMENT 'брак / запас (%)'
+    CHECK (defect_percent IS NULL OR (defect_percent >= 0 AND defect_percent <= 100)),
+  markup_multiplier DECIMAL(6, 3) NULL COMMENT 'наценка (×)'
+    CHECK (markup_multiplier IS NULL OR markup_multiplier >= 0),
+  wholesale_price DECIMAL(12, 2) NULL COMMENT 'оптовая цена'
+    CHECK (wholesale_price IS NULL OR wholesale_price >= 0),
+  retail_price DECIMAL(12, 2) NULL COMMENT 'розничная цена'
+    CHECK (retail_price IS NULL OR retail_price >= 0),
+  currency VARCHAR(3) NULL COMMENT 'ISO 4217 for the costing articles',
+  notes TEXT NULL,
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Costing articles for a tech card (1:1); materials/total computed on read';
+
+-- +migrate Down
+DROP TABLE IF EXISTS tech_card_costing;
+DROP TABLE IF EXISTS tech_card_packaging;
+DROP TABLE IF EXISTS tech_card_label;
+DROP TABLE IF EXISTS tech_card_operation;
+DROP TABLE IF EXISTS tech_card_construction;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/store/settings"
 	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
 	"github.com/jekabolt/grbpwr-manager/internal/store/support"
+	"github.com/jekabolt/grbpwr-manager/internal/store/techcard"
 	"github.com/jmoiron/sqlx"
 	migrate "github.com/rubenv/sql-migrate"
 
@@ -103,6 +104,7 @@ type MYSQLStore struct {
 	membershipStore *membership.Store
 	modelStore      *model.Store
 	fittingStore    *fitting.Store
+	techCardStore   *techcard.Store
 }
 
 // resolveCertPath resolves @certs paths to the config/certs directory
@@ -350,6 +352,7 @@ func initSubStores(ms *MYSQLStore) {
 	ms.membershipStore = membership.New(base, ms.Tx)
 	ms.modelStore = model.New(base, ms.Tx)
 	ms.fittingStore = fitting.New(base, ms.Tx)
+	ms.techCardStore = techcard.New(base, ms.Tx)
 }
 
 // initSubStoresForTx initializes sub-stores for a transactional MYSQLStore.
@@ -372,6 +375,7 @@ func initSubStoresForTx(txStore *MYSQLStore, outerTx func(context.Context, func(
 	txStore.membershipStore = membership.New(base, outerTx)
 	txStore.modelStore = model.New(base, outerTx)
 	txStore.fittingStore = fitting.New(base, outerTx)
+	txStore.techCardStore = techcard.New(base, outerTx)
 }
 
 func (ms *MYSQLStore) Close() {
@@ -439,6 +443,7 @@ func (ms *MYSQLStore) Language() dependency.Language          { return ms.langSt
 func (ms *MYSQLStore) Membership() dependency.Membership      { return ms.membershipStore }
 func (ms *MYSQLStore) Models() dependency.Models              { return ms.modelStore }
 func (ms *MYSQLStore) Fittings() dependency.Fittings          { return ms.fittingStore }
+func (ms *MYSQLStore) TechCards() dependency.TechCards        { return ms.techCardStore }
 func (ms *MYSQLStore) StorefrontAccount() dependency.StorefrontAccount {
 	return ms.accountStore
 }

--- a/internal/store/techcard/enrich.go
+++ b/internal/store/techcard/enrich.go
@@ -49,7 +49,10 @@ func (s *Store) enrich(ctx context.Context, cards []entity.TechCard) error {
 		cards[i].Callouts = callouts[id]
 		cards[i].Revisions = revisions[id]
 	}
-	return s.enrichMaterials(ctx, cards)
+	if err := s.enrichMaterials(ctx, cards); err != nil {
+		return err
+	}
+	return s.enrichProduction(ctx, cards)
 }
 
 type techCardIDRow struct {

--- a/internal/store/techcard/enrich.go
+++ b/internal/store/techcard/enrich.go
@@ -1,0 +1,156 @@
+package techcard
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
+)
+
+// enrich loads and attaches the size range, linked products, sketch media
+// (writable items + resolved MediaFull), callouts and revisions for each card.
+func (s *Store) enrich(ctx context.Context, cards []entity.TechCard) error {
+	if len(cards) == 0 {
+		return nil
+	}
+	ids := make([]int, 0, len(cards))
+	for _, c := range cards {
+		ids = append(ids, c.Id)
+	}
+
+	sizes, err := s.idListByTechCardIds(ctx, "tech_card_size", "size_id", ids)
+	if err != nil {
+		return err
+	}
+	products, err := s.idListByTechCardIds(ctx, "tech_card_product", "product_id", ids)
+	if err != nil {
+		return err
+	}
+	mediaItems, mediaFull, err := s.mediaByTechCardIds(ctx, ids)
+	if err != nil {
+		return err
+	}
+	callouts, err := s.calloutsByTechCardIds(ctx, ids)
+	if err != nil {
+		return err
+	}
+	revisions, err := s.revisionsByTechCardIds(ctx, ids)
+	if err != nil {
+		return err
+	}
+
+	for i := range cards {
+		id := cards[i].Id
+		cards[i].SizeIds = sizes[id]
+		cards[i].ProductIds = products[id]
+		cards[i].Media = mediaItems[id]
+		cards[i].ResolvedMedia = mediaFull[id]
+		cards[i].Callouts = callouts[id]
+		cards[i].Revisions = revisions[id]
+	}
+	return nil
+}
+
+type techCardIDRow struct {
+	TechCardID int `db:"tech_card_id"`
+	Value      int `db:"value"`
+}
+
+// idListByTechCardIds loads a single int column (e.g. size_id, product_id) from a
+// child table, grouped by tech_card_id and ordered by display_order.
+func (s *Store) idListByTechCardIds(ctx context.Context, table, column string, ids []int) (map[int][]int, error) {
+	if len(ids) == 0 {
+		return map[int][]int{}, nil
+	}
+	rows, err := storeutil.QueryListNamed[techCardIDRow](ctx, s.DB, fmt.Sprintf(`
+		SELECT tech_card_id, %s AS value
+		FROM %s
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, column, table), map[string]any{"ids": ids})
+	if err != nil {
+		return nil, fmt.Errorf("can't load %s: %w", table, err)
+	}
+	out := make(map[int][]int, len(ids))
+	for _, r := range rows {
+		out[r.TechCardID] = append(out[r.TechCardID], r.Value)
+	}
+	return out, nil
+}
+
+type techCardMediaRow struct {
+	TechCardID int                      `db:"tech_card_id"`
+	Kind       entity.TechCardMediaKind `db:"kind"`
+	entity.MediaFull
+}
+
+func (s *Store) mediaByTechCardIds(ctx context.Context, ids []int) (map[int][]entity.TechCardMediaItem, map[int][]entity.TechCardMediaFull, error) {
+	items := make(map[int][]entity.TechCardMediaItem, len(ids))
+	full := make(map[int][]entity.TechCardMediaFull, len(ids))
+	if len(ids) == 0 {
+		return items, full, nil
+	}
+	rows, err := storeutil.QueryListNamed[techCardMediaRow](ctx, s.DB, `
+		SELECT tcm.tech_card_id, tcm.kind, m.*
+		FROM tech_card_media tcm
+		JOIN media m ON m.id = tcm.media_id
+		WHERE tcm.tech_card_id IN (:ids)
+		ORDER BY tcm.tech_card_id, tcm.display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return nil, nil, fmt.Errorf("can't load tech card media: %w", err)
+	}
+	for i := range rows {
+		tcID := rows[i].TechCardID
+		items[tcID] = append(items[tcID], entity.TechCardMediaItem{MediaId: rows[i].Id, Kind: rows[i].Kind})
+		full[tcID] = append(full[tcID], entity.TechCardMediaFull{Media: rows[i].MediaFull, Kind: rows[i].Kind})
+	}
+	return items, full, nil
+}
+
+type techCardCalloutRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardCallout
+}
+
+func (s *Store) calloutsByTechCardIds(ctx context.Context, ids []int) (map[int][]entity.TechCardCallout, error) {
+	if len(ids) == 0 {
+		return map[int][]entity.TechCardCallout{}, nil
+	}
+	rows, err := storeutil.QueryListNamed[techCardCalloutRow](ctx, s.DB, `
+		SELECT tech_card_id, callout_number, part, description, dimensions
+		FROM tech_card_callout
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return nil, fmt.Errorf("can't load tech card callouts: %w", err)
+	}
+	out := make(map[int][]entity.TechCardCallout, len(ids))
+	for _, r := range rows {
+		out[r.TechCardID] = append(out[r.TechCardID], r.TechCardCallout)
+	}
+	return out, nil
+}
+
+type techCardRevisionRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardRevision
+}
+
+func (s *Store) revisionsByTechCardIds(ctx context.Context, ids []int) (map[int][]entity.TechCardRevision, error) {
+	if len(ids) == 0 {
+		return map[int][]entity.TechCardRevision{}, nil
+	}
+	rows, err := storeutil.QueryListNamed[techCardRevisionRow](ctx, s.DB, `
+		SELECT tech_card_id, version, revision_date, author, section, change_note
+		FROM tech_card_revision
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return nil, fmt.Errorf("can't load tech card revisions: %w", err)
+	}
+	out := make(map[int][]entity.TechCardRevision, len(ids))
+	for _, r := range rows {
+		out[r.TechCardID] = append(out[r.TechCardID], r.TechCardRevision)
+	}
+	return out, nil
+}

--- a/internal/store/techcard/enrich.go
+++ b/internal/store/techcard/enrich.go
@@ -49,7 +49,7 @@ func (s *Store) enrich(ctx context.Context, cards []entity.TechCard) error {
 		cards[i].Callouts = callouts[id]
 		cards[i].Revisions = revisions[id]
 	}
-	return nil
+	return s.enrichMaterials(ctx, cards)
 }
 
 type techCardIDRow struct {

--- a/internal/store/techcard/enrich.go
+++ b/internal/store/techcard/enrich.go
@@ -23,7 +23,7 @@ func (s *Store) enrich(ctx context.Context, cards []entity.TechCard) error {
 	if err != nil {
 		return err
 	}
-	products, err := s.idListByTechCardIds(ctx, "tech_card_product", "product_id", ids)
+	products, err := s.productIdsByTechCardIds(ctx, ids)
 	if err != nil {
 		return err
 	}
@@ -70,6 +70,30 @@ func (s *Store) idListByTechCardIds(ctx context.Context, table, column string, i
 		ORDER BY tech_card_id, display_order`, column, table), map[string]any{"ids": ids})
 	if err != nil {
 		return nil, fmt.Errorf("can't load %s: %w", table, err)
+	}
+	out := make(map[int][]int, len(ids))
+	for _, r := range rows {
+		out[r.TechCardID] = append(out[r.TechCardID], r.Value)
+	}
+	return out, nil
+}
+
+// productIdsByTechCardIds loads linked product ids per tech card, excluding
+// soft-deleted products. Products are soft-deleted (deleted_at), so the ON DELETE
+// CASCADE on tech_card_product never fires and a dead link would otherwise keep
+// surfacing a product that no longer exists for the storefront.
+func (s *Store) productIdsByTechCardIds(ctx context.Context, ids []int) (map[int][]int, error) {
+	if len(ids) == 0 {
+		return map[int][]int{}, nil
+	}
+	rows, err := storeutil.QueryListNamed[techCardIDRow](ctx, s.DB, `
+		SELECT tcp.tech_card_id, tcp.product_id AS value
+		FROM tech_card_product tcp
+		JOIN product p ON p.id = tcp.product_id
+		WHERE tcp.tech_card_id IN (:ids) AND p.deleted_at IS NULL
+		ORDER BY tcp.tech_card_id, tcp.display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return nil, fmt.Errorf("can't load tech card products: %w", err)
 	}
 	out := make(map[int][]int, len(ids))
 	for _, r := range rows {

--- a/internal/store/techcard/enrich.go
+++ b/internal/store/techcard/enrich.go
@@ -117,7 +117,7 @@ func (s *Store) calloutsByTechCardIds(ctx context.Context, ids []int) (map[int][
 		return map[int][]entity.TechCardCallout{}, nil
 	}
 	rows, err := storeutil.QueryListNamed[techCardCalloutRow](ctx, s.DB, `
-		SELECT tech_card_id, callout_number, part, description, dimensions
+		SELECT tech_card_id, callout_number, part, description, dimensions, media_id
 		FROM tech_card_callout
 		WHERE tech_card_id IN (:ids)
 		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})

--- a/internal/store/techcard/materials.go
+++ b/internal/store/techcard/materials.go
@@ -101,17 +101,18 @@ func insertTechCardPom(ctx context.Context, db dependency.DB, tcID int, points [
 		p := &points[i]
 		pomID, err := storeutil.ExecNamedLastId(ctx, db, `
 			INSERT INTO tech_card_pom_point
-				(tech_card_id, section, code, name, how_to_measure, base_value, tolerance, display_order)
-			VALUES (:tech_card_id, :section, :code, :name, :how_to_measure, :base_value, :tolerance, :display_order)`,
+				(tech_card_id, section, code, name, how_to_measure, base_value, tolerance_plus, tolerance_minus, display_order)
+			VALUES (:tech_card_id, :section, :code, :name, :how_to_measure, :base_value, :tolerance_plus, :tolerance_minus, :display_order)`,
 			map[string]any{
-				"tech_card_id":   tcID,
-				"section":        p.Section,
-				"code":           p.Code,
-				"name":           p.Name,
-				"how_to_measure": p.HowToMeasure,
-				"base_value":     p.BaseValue,
-				"tolerance":      p.Tolerance,
-				"display_order":  i,
+				"tech_card_id":    tcID,
+				"section":         p.Section,
+				"code":            p.Code,
+				"name":            p.Name,
+				"how_to_measure":  p.HowToMeasure,
+				"base_value":      p.BaseValue,
+				"tolerance_plus":  p.TolerancePlus,
+				"tolerance_minus": p.ToleranceMinus,
+				"display_order":   i,
 			})
 		if err != nil {
 			return fmt.Errorf("failed to insert tech card pom point: %w", err)
@@ -262,7 +263,7 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 
 	// POM points per card, then grades and actuals per point.
 	pomRows, err := storeutil.QueryListNamed[techCardPomPointRow](ctx, s.DB, `
-		SELECT id, tech_card_id, section, code, name, how_to_measure, base_value, tolerance
+		SELECT id, tech_card_id, section, code, name, how_to_measure, base_value, tolerance_plus, tolerance_minus
 		FROM tech_card_pom_point
 		WHERE tech_card_id IN (:ids)
 		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})

--- a/internal/store/techcard/materials.go
+++ b/internal/store/techcard/materials.go
@@ -1,0 +1,321 @@
+package techcard
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/jekabolt/grbpwr-manager/internal/dependency"
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
+)
+
+// --- inserts (called within the AddTechCard / UpdateTechCard transaction) ---
+
+// insertTechCardColorways inserts the colourways and returns their new ids in the
+// same order, so BOM colorway_index can be resolved to a colourway id.
+func insertTechCardColorways(ctx context.Context, db dependency.DB, tcID int, cws []entity.TechCardColorway) ([]int, error) {
+	ids := make([]int, len(cws))
+	for i := range cws {
+		c := &cws[i]
+		id, err := storeutil.ExecNamedLastId(ctx, db, `
+			INSERT INTO tech_card_colorway
+				(tech_card_id, code, name, lab_dip_status, product_id, comment, display_order)
+			VALUES (:tech_card_id, :code, :name, :lab_dip_status, :product_id, :comment, :display_order)`,
+			map[string]any{
+				"tech_card_id":   tcID,
+				"code":           c.Code,
+				"name":           c.Name,
+				"lab_dip_status": string(c.LabDipStatus),
+				"product_id":     c.ProductId,
+				"comment":        c.Comment,
+				"display_order":  i,
+			})
+		if err != nil {
+			return nil, fmt.Errorf("failed to insert tech card colorway: %w", err)
+		}
+		ids[i] = id
+	}
+	return ids, nil
+}
+
+// insertTechCardBom inserts the BOM lines and, for each, the per-colourway colour
+// cells (resolving ColorwayIndex against colorwayIds).
+func insertTechCardBom(ctx context.Context, db dependency.DB, tcID int, items []entity.TechCardBomItem, colorwayIds []int) error {
+	for i := range items {
+		b := &items[i]
+		bomID, err := storeutil.ExecNamedLastId(ctx, db, `
+			INSERT INTO tech_card_bom_item
+				(tech_card_id, section, name, placement, supplier, supplier_ref, color, composition, spec,
+				 consumption, unit, quantity, unit_price, currency, comment, display_order)
+			VALUES (:tech_card_id, :section, :name, :placement, :supplier, :supplier_ref, :color, :composition, :spec,
+				 :consumption, :unit, :quantity, :unit_price, :currency, :comment, :display_order)`,
+			map[string]any{
+				"tech_card_id":  tcID,
+				"section":       string(b.Section),
+				"name":          b.Name,
+				"placement":     b.Placement,
+				"supplier":      b.Supplier,
+				"supplier_ref":  b.SupplierRef,
+				"color":         b.Color,
+				"composition":   b.Composition,
+				"spec":          b.Spec,
+				"consumption":   b.Consumption,
+				"unit":          b.Unit,
+				"quantity":      b.Quantity,
+				"unit_price":    b.UnitPrice,
+				"currency":      b.Currency,
+				"comment":       b.Comment,
+				"display_order": i,
+			})
+		if err != nil {
+			return fmt.Errorf("failed to insert tech card bom item: %w", err)
+		}
+		if len(b.ColorwayColors) == 0 {
+			continue
+		}
+		rows := make([]map[string]any, 0, len(b.ColorwayColors))
+		for j, cc := range b.ColorwayColors {
+			if cc.ColorwayIndex < 0 || cc.ColorwayIndex >= len(colorwayIds) {
+				return fmt.Errorf("bom colorway_index %d out of range", cc.ColorwayIndex)
+			}
+			rows = append(rows, map[string]any{
+				"bom_item_id":   bomID,
+				"colorway_id":   colorwayIds[cc.ColorwayIndex],
+				"color":         cc.Color,
+				"pantone":       cc.Pantone,
+				"display_order": j,
+			})
+		}
+		if err := storeutil.BulkInsert(ctx, db, "tech_card_bom_colorway", rows); err != nil {
+			return fmt.Errorf("failed to insert tech card bom colorway: %w", err)
+		}
+	}
+	return nil
+}
+
+// insertTechCardPom inserts the POM points and, for each, its graded values and
+// actual measurements.
+func insertTechCardPom(ctx context.Context, db dependency.DB, tcID int, points []entity.TechCardPomPoint) error {
+	for i := range points {
+		p := &points[i]
+		pomID, err := storeutil.ExecNamedLastId(ctx, db, `
+			INSERT INTO tech_card_pom_point
+				(tech_card_id, section, code, name, how_to_measure, base_value, tolerance, display_order)
+			VALUES (:tech_card_id, :section, :code, :name, :how_to_measure, :base_value, :tolerance, :display_order)`,
+			map[string]any{
+				"tech_card_id":   tcID,
+				"section":        p.Section,
+				"code":           p.Code,
+				"name":           p.Name,
+				"how_to_measure": p.HowToMeasure,
+				"base_value":     p.BaseValue,
+				"tolerance":      p.Tolerance,
+				"display_order":  i,
+			})
+		if err != nil {
+			return fmt.Errorf("failed to insert tech card pom point: %w", err)
+		}
+		if len(p.Grades) > 0 {
+			rows := make([]map[string]any, 0, len(p.Grades))
+			for _, g := range p.Grades {
+				rows = append(rows, map[string]any{
+					"pom_point_id": pomID,
+					"size_id":      g.SizeId,
+					"value":        g.Value,
+				})
+			}
+			if err := storeutil.BulkInsert(ctx, db, "tech_card_pom_grade", rows); err != nil {
+				return fmt.Errorf("failed to insert tech card pom grades: %w", err)
+			}
+		}
+		if len(p.Actuals) > 0 {
+			rows := make([]map[string]any, 0, len(p.Actuals))
+			for j, a := range p.Actuals {
+				rows = append(rows, map[string]any{
+					"pom_point_id":  pomID,
+					"fitting_id":    a.FittingId,
+					"label":         a.Label,
+					"value":         a.Value,
+					"display_order": j,
+				})
+			}
+			if err := storeutil.BulkInsert(ctx, db, "tech_card_pom_actual", rows); err != nil {
+				return fmt.Errorf("failed to insert tech card pom actuals: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// --- enrich (load materials for read paths) ---
+
+type techCardColorwayRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardColorway
+}
+
+type techCardBomItemRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardBomItem
+}
+
+type techCardBomColorwayRow struct {
+	BomItemID  int            `db:"bom_item_id"`
+	ColorwayID int            `db:"colorway_id"`
+	Color      sql.NullString `db:"color"`
+	Pantone    sql.NullString `db:"pantone"`
+}
+
+type techCardPomPointRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardPomPoint
+}
+
+type techCardPomGradeRow struct {
+	PomPointID int `db:"pom_point_id"`
+	entity.TechCardPomGrade
+}
+
+type techCardPomActualRow struct {
+	PomPointID int `db:"pom_point_id"`
+	entity.TechCardPomActual
+}
+
+// enrichMaterials loads colourways, BOM lines (+ the per-colourway colour matrix)
+// and POM points (+ grades and actuals) for each card and attaches them.
+func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) error {
+	if len(cards) == 0 {
+		return nil
+	}
+	ids := make([]int, 0, len(cards))
+	for i := range cards {
+		ids = append(ids, cards[i].Id)
+	}
+
+	// Colourways: grouped per card (in display order), plus a colourway id -> index
+	// map so the BOM colour matrix can be emitted by index.
+	cwRows, err := storeutil.QueryListNamed[techCardColorwayRow](ctx, s.DB, `
+		SELECT id, tech_card_id, code, name, lab_dip_status, product_id, comment
+		FROM tech_card_colorway
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("can't load tech card colorways: %w", err)
+	}
+	colorwaysByCard := make(map[int][]entity.TechCardColorway, len(ids))
+	colorwayIndexByID := make(map[int]int, len(cwRows))
+	for _, r := range cwRows {
+		colorwayIndexByID[r.Id] = len(colorwaysByCard[r.TechCardID])
+		colorwaysByCard[r.TechCardID] = append(colorwaysByCard[r.TechCardID], r.TechCardColorway)
+	}
+
+	// BOM lines per card.
+	bomRows, err := storeutil.QueryListNamed[techCardBomItemRow](ctx, s.DB, `
+		SELECT id, tech_card_id, section, name, placement, supplier, supplier_ref, color, composition, spec,
+		       consumption, unit, quantity, unit_price, currency, comment
+		FROM tech_card_bom_item
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("can't load tech card bom items: %w", err)
+	}
+	bomByCard := make(map[int][]entity.TechCardBomItem, len(ids))
+	for _, r := range bomRows {
+		bomByCard[r.TechCardID] = append(bomByCard[r.TechCardID], r.TechCardBomItem)
+	}
+	// Slices are final now; index BOM items by id to attach the colour matrix.
+	bomItemByID := make(map[int]*entity.TechCardBomItem, len(bomRows))
+	bomItemIDs := make([]int, 0, len(bomRows))
+	for card := range bomByCard {
+		items := bomByCard[card]
+		for i := range items {
+			bomItemByID[items[i].Id] = &items[i]
+			bomItemIDs = append(bomItemIDs, items[i].Id)
+		}
+	}
+	if len(bomItemIDs) > 0 {
+		cells, err := storeutil.QueryListNamed[techCardBomColorwayRow](ctx, s.DB, `
+			SELECT bom_item_id, colorway_id, color, pantone
+			FROM tech_card_bom_colorway
+			WHERE bom_item_id IN (:ids)
+			ORDER BY bom_item_id, display_order`, map[string]any{"ids": bomItemIDs})
+		if err != nil {
+			return fmt.Errorf("can't load tech card bom colorways: %w", err)
+		}
+		for _, c := range cells {
+			item, ok := bomItemByID[c.BomItemID]
+			if !ok {
+				continue
+			}
+			idx, ok := colorwayIndexByID[c.ColorwayID]
+			if !ok {
+				continue
+			}
+			item.ColorwayColors = append(item.ColorwayColors, entity.TechCardBomColorwayColor{
+				ColorwayIndex: idx,
+				Color:         c.Color,
+				Pantone:       c.Pantone,
+			})
+		}
+	}
+
+	// POM points per card, then grades and actuals per point.
+	pomRows, err := storeutil.QueryListNamed[techCardPomPointRow](ctx, s.DB, `
+		SELECT id, tech_card_id, section, code, name, how_to_measure, base_value, tolerance
+		FROM tech_card_pom_point
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("can't load tech card pom points: %w", err)
+	}
+	pomByCard := make(map[int][]entity.TechCardPomPoint, len(ids))
+	for _, r := range pomRows {
+		pomByCard[r.TechCardID] = append(pomByCard[r.TechCardID], r.TechCardPomPoint)
+	}
+	pomPointByID := make(map[int]*entity.TechCardPomPoint, len(pomRows))
+	pomPointIDs := make([]int, 0, len(pomRows))
+	for card := range pomByCard {
+		points := pomByCard[card]
+		for i := range points {
+			pomPointByID[points[i].Id] = &points[i]
+			pomPointIDs = append(pomPointIDs, points[i].Id)
+		}
+	}
+	if len(pomPointIDs) > 0 {
+		gradeRows, err := storeutil.QueryListNamed[techCardPomGradeRow](ctx, s.DB, `
+			SELECT pom_point_id, size_id, value
+			FROM tech_card_pom_grade
+			WHERE pom_point_id IN (:ids)
+			ORDER BY pom_point_id, id`, map[string]any{"ids": pomPointIDs})
+		if err != nil {
+			return fmt.Errorf("can't load tech card pom grades: %w", err)
+		}
+		for _, g := range gradeRows {
+			if p, ok := pomPointByID[g.PomPointID]; ok {
+				p.Grades = append(p.Grades, g.TechCardPomGrade)
+			}
+		}
+		actualRows, err := storeutil.QueryListNamed[techCardPomActualRow](ctx, s.DB, `
+			SELECT pom_point_id, fitting_id, label, value
+			FROM tech_card_pom_actual
+			WHERE pom_point_id IN (:ids)
+			ORDER BY pom_point_id, display_order`, map[string]any{"ids": pomPointIDs})
+		if err != nil {
+			return fmt.Errorf("can't load tech card pom actuals: %w", err)
+		}
+		for _, a := range actualRows {
+			if p, ok := pomPointByID[a.PomPointID]; ok {
+				p.Actuals = append(p.Actuals, a.TechCardPomActual)
+			}
+		}
+	}
+
+	for i := range cards {
+		id := cards[i].Id
+		cards[i].Colorways = colorwaysByCard[id]
+		cards[i].BomItems = bomByCard[id]
+		cards[i].PomPoints = pomByCard[id]
+	}
+	return nil
+}

--- a/internal/store/techcard/production.go
+++ b/internal/store/techcard/production.go
@@ -1,0 +1,250 @@
+package techcard
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jekabolt/grbpwr-manager/internal/dependency"
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
+)
+
+// --- inserts (called within the AddTechCard / UpdateTechCard transaction) ---
+
+func insertTechCardConstruction(ctx context.Context, db dependency.DB, tcID int, c *entity.TechCardConstruction) error {
+	if c == nil {
+		return nil
+	}
+	if err := storeutil.ExecNamed(ctx, db, `
+		INSERT INTO tech_card_construction
+			(tech_card_id, main_stitch_type, stitch_density, overlock_threads, seam_allowances,
+			 hem_finish, pressing, machine_class, notes)
+		VALUES (:tech_card_id, :main_stitch_type, :stitch_density, :overlock_threads, :seam_allowances,
+			 :hem_finish, :pressing, :machine_class, :notes)`,
+		map[string]any{
+			"tech_card_id":     tcID,
+			"main_stitch_type": c.MainStitchType,
+			"stitch_density":   c.StitchDensity,
+			"overlock_threads": c.OverlockThreads,
+			"seam_allowances":  c.SeamAllowances,
+			"hem_finish":       c.HemFinish,
+			"pressing":         c.Pressing,
+			"machine_class":    c.MachineClass,
+			"notes":            c.Notes,
+		}); err != nil {
+		return fmt.Errorf("failed to insert tech card construction: %w", err)
+	}
+	return nil
+}
+
+func insertTechCardOperations(ctx context.Context, db dependency.DB, tcID int, ops []entity.TechCardOperation) error {
+	if len(ops) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(ops))
+	for i, o := range ops {
+		rows = append(rows, map[string]any{
+			"tech_card_id":    tcID,
+			"node":            o.Node,
+			"description":     o.Description,
+			"seam_type":       o.SeamType,
+			"stitches_per_cm": o.StitchesPerCm,
+			"topstitch_width": o.TopstitchWidth,
+			"thread":          o.Thread,
+			"note":            o.Note,
+			"display_order":   i,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_operation", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card operations: %w", err)
+	}
+	return nil
+}
+
+func insertTechCardLabels(ctx context.Context, db dependency.DB, tcID int, labels []entity.TechCardLabel) error {
+	if len(labels) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(labels))
+	for i, l := range labels {
+		rows = append(rows, map[string]any{
+			"tech_card_id":  tcID,
+			"label_type":    string(l.LabelType),
+			"content":       l.Content,
+			"placement":     l.Placement,
+			"attachment":    l.Attachment,
+			"size":          l.Size,
+			"note":          l.Note,
+			"display_order": i,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_label", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card labels: %w", err)
+	}
+	return nil
+}
+
+func insertTechCardPackaging(ctx context.Context, db dependency.DB, tcID int, p *entity.TechCardPackaging) error {
+	if p == nil {
+		return nil
+	}
+	if err := storeutil.ExecNamed(ctx, db, `
+		INSERT INTO tech_card_packaging
+			(tech_card_id, folding_method, polybag, bag_sticker, inserts, units_per_box,
+			 box_marking, box_dimensions, weight_net, weight_gross, notes)
+		VALUES (:tech_card_id, :folding_method, :polybag, :bag_sticker, :inserts, :units_per_box,
+			 :box_marking, :box_dimensions, :weight_net, :weight_gross, :notes)`,
+		map[string]any{
+			"tech_card_id":   tcID,
+			"folding_method": p.FoldingMethod,
+			"polybag":        p.Polybag,
+			"bag_sticker":    p.BagSticker,
+			"inserts":        p.Inserts,
+			"units_per_box":  p.UnitsPerBox,
+			"box_marking":    p.BoxMarking,
+			"box_dimensions": p.BoxDimensions,
+			"weight_net":     p.WeightNet,
+			"weight_gross":   p.WeightGross,
+			"notes":          p.Notes,
+		}); err != nil {
+		return fmt.Errorf("failed to insert tech card packaging: %w", err)
+	}
+	return nil
+}
+
+func insertTechCardCosting(ctx context.Context, db dependency.DB, tcID int, c *entity.TechCardCosting) error {
+	if c == nil {
+		return nil
+	}
+	if err := storeutil.ExecNamed(ctx, db, `
+		INSERT INTO tech_card_costing
+			(tech_card_id, cmt_cost, hardware_cost, packaging_cost, logistics_cost, overhead_cost,
+			 defect_percent, markup_multiplier, wholesale_price, retail_price, currency, notes)
+		VALUES (:tech_card_id, :cmt_cost, :hardware_cost, :packaging_cost, :logistics_cost, :overhead_cost,
+			 :defect_percent, :markup_multiplier, :wholesale_price, :retail_price, :currency, :notes)`,
+		map[string]any{
+			"tech_card_id":      tcID,
+			"cmt_cost":          c.CmtCost,
+			"hardware_cost":     c.HardwareCost,
+			"packaging_cost":    c.PackagingCost,
+			"logistics_cost":    c.LogisticsCost,
+			"overhead_cost":     c.OverheadCost,
+			"defect_percent":    c.DefectPercent,
+			"markup_multiplier": c.MarkupMultiplier,
+			"wholesale_price":   c.WholesalePrice,
+			"retail_price":      c.RetailPrice,
+			"currency":          c.Currency,
+			"notes":             c.Notes,
+		}); err != nil {
+		return fmt.Errorf("failed to insert tech card costing: %w", err)
+	}
+	return nil
+}
+
+// --- enrich (load production sections for read paths) ---
+
+type techCardConstructionRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardConstruction
+}
+
+type techCardOperationRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardOperation
+}
+
+type techCardLabelRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardLabel
+}
+
+type techCardPackagingRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardPackaging
+}
+
+type techCardCostingRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardCosting
+}
+
+// enrichProduction loads the construction, operations, labels, packaging and
+// costing sections for each card and attaches them.
+func (s *Store) enrichProduction(ctx context.Context, cards []entity.TechCard) error {
+	if len(cards) == 0 {
+		return nil
+	}
+	ids := make([]int, 0, len(cards))
+	for i := range cards {
+		ids = append(ids, cards[i].Id)
+	}
+
+	consRows, err := storeutil.QueryListNamed[techCardConstructionRow](ctx, s.DB,
+		`SELECT * FROM tech_card_construction WHERE tech_card_id IN (:ids)`, map[string]any{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("can't load tech card construction: %w", err)
+	}
+	consByCard := make(map[int]*entity.TechCardConstruction, len(consRows))
+	for i := range consRows {
+		c := consRows[i].TechCardConstruction
+		consByCard[consRows[i].TechCardID] = &c
+	}
+
+	opRows, err := storeutil.QueryListNamed[techCardOperationRow](ctx, s.DB, `
+		SELECT tech_card_id, node, description, seam_type, stitches_per_cm, topstitch_width, thread, note
+		FROM tech_card_operation
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("can't load tech card operations: %w", err)
+	}
+	opsByCard := make(map[int][]entity.TechCardOperation, len(ids))
+	for _, r := range opRows {
+		opsByCard[r.TechCardID] = append(opsByCard[r.TechCardID], r.TechCardOperation)
+	}
+
+	labelRows, err := storeutil.QueryListNamed[techCardLabelRow](ctx, s.DB, `
+		SELECT tech_card_id, label_type, content, placement, attachment, size, note
+		FROM tech_card_label
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("can't load tech card labels: %w", err)
+	}
+	labelsByCard := make(map[int][]entity.TechCardLabel, len(ids))
+	for _, r := range labelRows {
+		labelsByCard[r.TechCardID] = append(labelsByCard[r.TechCardID], r.TechCardLabel)
+	}
+
+	pkgRows, err := storeutil.QueryListNamed[techCardPackagingRow](ctx, s.DB,
+		`SELECT * FROM tech_card_packaging WHERE tech_card_id IN (:ids)`, map[string]any{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("can't load tech card packaging: %w", err)
+	}
+	pkgByCard := make(map[int]*entity.TechCardPackaging, len(pkgRows))
+	for i := range pkgRows {
+		p := pkgRows[i].TechCardPackaging
+		pkgByCard[pkgRows[i].TechCardID] = &p
+	}
+
+	costRows, err := storeutil.QueryListNamed[techCardCostingRow](ctx, s.DB,
+		`SELECT * FROM tech_card_costing WHERE tech_card_id IN (:ids)`, map[string]any{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("can't load tech card costing: %w", err)
+	}
+	costByCard := make(map[int]*entity.TechCardCosting, len(costRows))
+	for i := range costRows {
+		c := costRows[i].TechCardCosting
+		costByCard[costRows[i].TechCardID] = &c
+	}
+
+	for i := range cards {
+		id := cards[i].Id
+		cards[i].Construction = consByCard[id]
+		cards[i].Operations = opsByCard[id]
+		cards[i].Labels = labelsByCard[id]
+		cards[i].Packaging = pkgByCard[id]
+		cards[i].Costing = costByCard[id]
+	}
+	return nil
+}

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -35,14 +35,16 @@ func New(base storeutil.Base, txFunc TxFunc) *Store {
 
 // header columns shared by INSERT (AddTechCard) and UPDATE (UpdateTechCard).
 const techCardHeaderColumns = `style_number, name, brand, season, collection, category_id,
-	target_gender, stage, status, version, revision_date, base_model_id, base_sample_size_id,
-	designer, constructor, technologist, target_cost, target_retail_price, currency,
+	target_gender, stage, status, approval_state, approved_by, released_at, version, revision_date,
+	base_model_id, base_sample_size_id, designer, constructor, technologist,
+	target_cost, target_retail_price, currency,
 	description, silhouette, collar, fastening, pockets, sleeve_cuff, extra_details,
 	topstitching, aux_materials, notes`
 
 const techCardHeaderValues = `:style_number, :name, :brand, :season, :collection, :category_id,
-	:target_gender, :stage, :status, :version, :revision_date, :base_model_id, :base_sample_size_id,
-	:designer, :constructor, :technologist, :target_cost, :target_retail_price, :currency,
+	:target_gender, :stage, :status, :approval_state, :approved_by, :released_at, :version, :revision_date,
+	:base_model_id, :base_sample_size_id, :designer, :constructor, :technologist,
+	:target_cost, :target_retail_price, :currency,
 	:description, :silhouette, :collar, :fastening, :pockets, :sleeve_cuff, :extra_details,
 	:topstitching, :aux_materials, :notes`
 
@@ -57,6 +59,9 @@ func techCardHeaderParams(tc *entity.TechCardInsert) map[string]any {
 		"target_gender":       tc.TargetGender,
 		"stage":               string(tc.Stage),
 		"status":              tc.Status,
+		"approval_state":      string(tc.ApprovalState),
+		"approved_by":         tc.ApprovedBy,
+		"released_at":         tc.ReleasedAt,
 		"version":             tc.Version,
 		"revision_date":       tc.RevisionDate,
 		"base_model_id":       tc.BaseModelId,
@@ -118,7 +123,9 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 			UPDATE tech_card SET
 				style_number = :style_number, name = :name, brand = :brand, season = :season,
 				collection = :collection, category_id = :category_id, target_gender = :target_gender,
-				stage = :stage, status = :status, version = :version, revision_date = :revision_date,
+				stage = :stage, status = :status, approval_state = :approval_state,
+				approved_by = :approved_by, released_at = :released_at,
+				version = :version, revision_date = :revision_date,
 				base_model_id = :base_model_id, base_sample_size_id = :base_sample_size_id,
 				designer = :designer, constructor = :constructor, technologist = :technologist,
 				target_cost = :target_cost, target_retail_price = :target_retail_price, currency = :currency,
@@ -301,6 +308,7 @@ func insertTechCardCallouts(ctx context.Context, db dependency.DB, id int, callo
 			"part":           c.Part,
 			"description":    c.Description,
 			"dimensions":     c.Dimensions,
+			"media_id":       c.MediaId,
 			"display_order":  i,
 		})
 	}

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -138,9 +138,13 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 			return fmt.Errorf("failed to update tech card: %w", err)
 		}
 
+		// Delete tech_card_bom_item before tech_card_colorway so the bom-colourway
+		// matrix cascades out via the BOM line; pom grades/actuals and bom-colourway
+		// cells cascade from their parents.
 		for _, table := range []string{
 			"tech_card_size", "tech_card_product", "tech_card_media",
 			"tech_card_callout", "tech_card_revision",
+			"tech_card_bom_item", "tech_card_colorway", "tech_card_pom_point",
 		} {
 			if err := storeutil.ExecNamed(ctx, rep.DB(),
 				fmt.Sprintf(`DELETE FROM %s WHERE tech_card_id = :id`, table),
@@ -248,7 +252,19 @@ func insertTechCardChildren(ctx context.Context, db dependency.DB, id int, tc *e
 	if err := insertTechCardCallouts(ctx, db, id, tc.Callouts); err != nil {
 		return err
 	}
-	return insertTechCardRevisions(ctx, db, id, tc.Revisions)
+	if err := insertTechCardRevisions(ctx, db, id, tc.Revisions); err != nil {
+		return err
+	}
+	// Materials (Phase 2): colourways first so the BOM colour matrix can resolve
+	// each colorway_index to a freshly-inserted colourway id.
+	colorwayIds, err := insertTechCardColorways(ctx, db, id, tc.Colorways)
+	if err != nil {
+		return err
+	}
+	if err := insertTechCardBom(ctx, db, id, tc.BomItems, colorwayIds); err != nil {
+		return err
+	}
+	return insertTechCardPom(ctx, db, id, tc.PomPoints)
 }
 
 func insertTechCardSizes(ctx context.Context, db dependency.DB, id int, sizeIDs []int) error {

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -145,6 +145,8 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 			"tech_card_size", "tech_card_product", "tech_card_media",
 			"tech_card_callout", "tech_card_revision",
 			"tech_card_bom_item", "tech_card_colorway", "tech_card_pom_point",
+			"tech_card_construction", "tech_card_operation", "tech_card_label",
+			"tech_card_packaging", "tech_card_costing",
 		} {
 			if err := storeutil.ExecNamed(ctx, rep.DB(),
 				fmt.Sprintf(`DELETE FROM %s WHERE tech_card_id = :id`, table),
@@ -264,7 +266,23 @@ func insertTechCardChildren(ctx context.Context, db dependency.DB, id int, tc *e
 	if err := insertTechCardBom(ctx, db, id, tc.BomItems, colorwayIds); err != nil {
 		return err
 	}
-	return insertTechCardPom(ctx, db, id, tc.PomPoints)
+	if err := insertTechCardPom(ctx, db, id, tc.PomPoints); err != nil {
+		return err
+	}
+	// production (Phase 3)
+	if err := insertTechCardConstruction(ctx, db, id, tc.Construction); err != nil {
+		return err
+	}
+	if err := insertTechCardOperations(ctx, db, id, tc.Operations); err != nil {
+		return err
+	}
+	if err := insertTechCardLabels(ctx, db, id, tc.Labels); err != nil {
+		return err
+	}
+	if err := insertTechCardPackaging(ctx, db, id, tc.Packaging); err != nil {
+		return err
+	}
+	return insertTechCardCosting(ctx, db, id, tc.Costing)
 }
 
 func insertTechCardSizes(ctx context.Context, db dependency.DB, id int, sizeIDs []int) error {

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -1,0 +1,353 @@
+// Package techcard implements garment tech pack (техкарта) management: the header,
+// size range, linked products, sketch media, callouts and revision log.
+package techcard
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/jekabolt/grbpwr-manager/internal/dependency"
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
+)
+
+// Pagination bounds for list endpoints.
+const (
+	defaultPageLimit = 50
+	maxPageLimit     = 100
+)
+
+// TxFunc is a function that executes f within a transaction.
+type TxFunc func(ctx context.Context, f func(context.Context, dependency.Repository) error) error
+
+// Store implements dependency.TechCards.
+type Store struct {
+	storeutil.Base
+	txFunc TxFunc
+}
+
+// New creates a new tech card store.
+func New(base storeutil.Base, txFunc TxFunc) *Store {
+	return &Store{Base: base, txFunc: txFunc}
+}
+
+// header columns shared by INSERT (AddTechCard) and UPDATE (UpdateTechCard).
+const techCardHeaderColumns = `style_number, name, brand, season, collection, category_id,
+	target_gender, stage, status, version, revision_date, base_model_id, base_sample_size_id,
+	designer, constructor, technologist, target_cost, target_retail_price, currency,
+	description, silhouette, collar, fastening, pockets, sleeve_cuff, extra_details,
+	topstitching, aux_materials, notes`
+
+const techCardHeaderValues = `:style_number, :name, :brand, :season, :collection, :category_id,
+	:target_gender, :stage, :status, :version, :revision_date, :base_model_id, :base_sample_size_id,
+	:designer, :constructor, :technologist, :target_cost, :target_retail_price, :currency,
+	:description, :silhouette, :collar, :fastening, :pockets, :sleeve_cuff, :extra_details,
+	:topstitching, :aux_materials, :notes`
+
+func techCardHeaderParams(tc *entity.TechCardInsert) map[string]any {
+	return map[string]any{
+		"style_number":        tc.StyleNumber,
+		"name":                tc.Name,
+		"brand":               tc.Brand,
+		"season":              tc.Season,
+		"collection":          tc.Collection,
+		"category_id":         tc.CategoryId,
+		"target_gender":       tc.TargetGender,
+		"stage":               string(tc.Stage),
+		"status":              tc.Status,
+		"version":             tc.Version,
+		"revision_date":       tc.RevisionDate,
+		"base_model_id":       tc.BaseModelId,
+		"base_sample_size_id": tc.BaseSampleSizeId,
+		"designer":            tc.Designer,
+		"constructor":         tc.Constructor,
+		"technologist":        tc.Technologist,
+		"target_cost":         tc.TargetCost,
+		"target_retail_price": tc.TargetRetailPrice,
+		"currency":            tc.Currency,
+		"description":         tc.Description,
+		"silhouette":          tc.Silhouette,
+		"collar":              tc.Collar,
+		"fastening":           tc.Fastening,
+		"pockets":             tc.Pockets,
+		"sleeve_cuff":         tc.SleeveCuff,
+		"extra_details":       tc.ExtraDetails,
+		"topstitching":        tc.Topstitching,
+		"aux_materials":       tc.AuxMaterials,
+		"notes":               tc.Notes,
+	}
+}
+
+// AddTechCard inserts a tech card and its child sections, returning the new id.
+func (s *Store) AddTechCard(ctx context.Context, tc *entity.TechCardInsert) (int, error) {
+	var id int
+	err := s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
+		var err error
+		id, err = storeutil.ExecNamedLastId(ctx, rep.DB(),
+			fmt.Sprintf(`INSERT INTO tech_card (%s) VALUES (%s)`, techCardHeaderColumns, techCardHeaderValues),
+			techCardHeaderParams(tc))
+		if err != nil {
+			return fmt.Errorf("failed to insert tech card: %w", err)
+		}
+		return insertTechCardChildren(ctx, rep.DB(), id, tc)
+	})
+	if err != nil {
+		return 0, fmt.Errorf("can't add tech card: %w", err)
+	}
+	return id, nil
+}
+
+// UpdateTechCard updates a tech card and replaces its child sections. Returns
+// sql.ErrNoRows when no tech card with the given id exists.
+func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardInsert) error {
+	err := s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
+		exists, err := storeutil.QueryCountNamed(ctx, rep.DB(),
+			`SELECT COUNT(*) FROM tech_card WHERE id = :id`, map[string]any{"id": id})
+		if err != nil {
+			return fmt.Errorf("failed to check tech card existence: %w", err)
+		}
+		if exists == 0 {
+			return sql.ErrNoRows
+		}
+
+		params := techCardHeaderParams(tc)
+		params["id"] = id
+		if err := storeutil.ExecNamed(ctx, rep.DB(), `
+			UPDATE tech_card SET
+				style_number = :style_number, name = :name, brand = :brand, season = :season,
+				collection = :collection, category_id = :category_id, target_gender = :target_gender,
+				stage = :stage, status = :status, version = :version, revision_date = :revision_date,
+				base_model_id = :base_model_id, base_sample_size_id = :base_sample_size_id,
+				designer = :designer, constructor = :constructor, technologist = :technologist,
+				target_cost = :target_cost, target_retail_price = :target_retail_price, currency = :currency,
+				description = :description, silhouette = :silhouette, collar = :collar, fastening = :fastening,
+				pockets = :pockets, sleeve_cuff = :sleeve_cuff, extra_details = :extra_details,
+				topstitching = :topstitching, aux_materials = :aux_materials, notes = :notes
+			WHERE id = :id`, params); err != nil {
+			return fmt.Errorf("failed to update tech card: %w", err)
+		}
+
+		for _, table := range []string{
+			"tech_card_size", "tech_card_product", "tech_card_media",
+			"tech_card_callout", "tech_card_revision",
+		} {
+			if err := storeutil.ExecNamed(ctx, rep.DB(),
+				fmt.Sprintf(`DELETE FROM %s WHERE tech_card_id = :id`, table),
+				map[string]any{"id": id}); err != nil {
+				return fmt.Errorf("failed to clear %s: %w", table, err)
+			}
+		}
+		return insertTechCardChildren(ctx, rep.DB(), id, tc)
+	})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return err
+		}
+		return fmt.Errorf("can't update tech card: %w", err)
+	}
+	return nil
+}
+
+// DeleteTechCard deletes a tech card by id (child sections cascade).
+func (s *Store) DeleteTechCard(ctx context.Context, id int) error {
+	if err := storeutil.ExecNamed(ctx, s.DB,
+		`DELETE FROM tech_card WHERE id = :id`, map[string]any{"id": id}); err != nil {
+		return fmt.Errorf("failed to delete tech card: %w", err)
+	}
+	return nil
+}
+
+// GetTechCardById returns a tech card with its child sections and resolved media.
+func (s *Store) GetTechCardById(ctx context.Context, id int) (*entity.TechCard, error) {
+	tc, err := storeutil.QueryNamedOne[entity.TechCard](ctx, s.DB,
+		`SELECT * FROM tech_card WHERE id = :id`, map[string]any{"id": id})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tech card: %w", err)
+	}
+	cards := []entity.TechCard{tc}
+	if err := s.enrich(ctx, cards); err != nil {
+		return nil, err
+	}
+	return &cards[0], nil
+}
+
+// ListTechCards returns a paged, header-only list of tech cards (no child
+// sections), with the total number of matching cards (ignoring pagination).
+func (s *Store) ListTechCards(ctx context.Context, limit, offset int, orderFactor entity.OrderFactor, filter entity.TechCardListFilter) ([]entity.TechCard, int, error) {
+	limit, offset = clampPagination(limit, offset)
+
+	params := map[string]any{}
+	where := ""
+	if filter.Stage != "" {
+		where += " AND stage = :stage"
+		params["stage"] = filter.Stage
+	}
+	if filter.Gender != "" {
+		where += " AND target_gender = :gender"
+		params["gender"] = filter.Gender
+	}
+	if filter.Brand != "" {
+		where += " AND brand LIKE :brand"
+		params["brand"] = "%" + escapeLike(filter.Brand) + "%"
+	}
+	if filter.Season != "" {
+		where += " AND season LIKE :season"
+		params["season"] = "%" + escapeLike(filter.Season) + "%"
+	}
+	if filter.Name != "" {
+		where += " AND (name LIKE :nameSearch OR style_number LIKE :nameSearch)"
+		params["nameSearch"] = "%" + escapeLike(filter.Name) + "%"
+	}
+	if filter.ProductId > 0 {
+		where += " AND id IN (SELECT tech_card_id FROM tech_card_product WHERE product_id = :productId)"
+		params["productId"] = filter.ProductId
+	}
+
+	total, err := storeutil.QueryCountNamed(ctx, s.DB,
+		fmt.Sprintf(`SELECT COUNT(*) FROM tech_card WHERE 1=1%s`, where), params)
+	if err != nil {
+		return nil, 0, fmt.Errorf("can't count tech cards: %w", err)
+	}
+
+	params["limit"] = limit
+	params["offset"] = offset
+	cards, err := storeutil.QueryListNamed[entity.TechCard](ctx, s.DB, fmt.Sprintf(`
+		SELECT * FROM tech_card
+		WHERE 1=1%s
+		ORDER BY id %s
+		LIMIT :limit OFFSET :offset`, where, orderFactor.String()), params)
+	if err != nil {
+		return nil, 0, fmt.Errorf("can't list tech cards: %w", err)
+	}
+	return cards, total, nil
+}
+
+// insertTechCardChildren inserts the size range, product links, sketch media,
+// callouts and revisions for a tech card (used by both Add and Update).
+func insertTechCardChildren(ctx context.Context, db dependency.DB, id int, tc *entity.TechCardInsert) error {
+	if err := insertTechCardSizes(ctx, db, id, tc.SizeIds); err != nil {
+		return err
+	}
+	if err := insertTechCardProducts(ctx, db, id, tc.ProductIds); err != nil {
+		return err
+	}
+	if err := insertTechCardMedia(ctx, db, id, tc.Media); err != nil {
+		return err
+	}
+	if err := insertTechCardCallouts(ctx, db, id, tc.Callouts); err != nil {
+		return err
+	}
+	return insertTechCardRevisions(ctx, db, id, tc.Revisions)
+}
+
+func insertTechCardSizes(ctx context.Context, db dependency.DB, id int, sizeIDs []int) error {
+	if len(sizeIDs) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(sizeIDs))
+	for i, sid := range sizeIDs {
+		rows = append(rows, map[string]any{"tech_card_id": id, "size_id": sid, "display_order": i})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_size", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card sizes: %w", err)
+	}
+	return nil
+}
+
+func insertTechCardProducts(ctx context.Context, db dependency.DB, id int, productIDs []int) error {
+	if len(productIDs) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(productIDs))
+	for i, pid := range productIDs {
+		rows = append(rows, map[string]any{"tech_card_id": id, "product_id": pid, "display_order": i})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_product", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card products: %w", err)
+	}
+	return nil
+}
+
+func insertTechCardMedia(ctx context.Context, db dependency.DB, id int, media []entity.TechCardMediaItem) error {
+	if len(media) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(media))
+	for i, m := range media {
+		rows = append(rows, map[string]any{
+			"tech_card_id":  id,
+			"media_id":      m.MediaId,
+			"kind":          string(m.Kind),
+			"display_order": i,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_media", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card media: %w", err)
+	}
+	return nil
+}
+
+func insertTechCardCallouts(ctx context.Context, db dependency.DB, id int, callouts []entity.TechCardCallout) error {
+	if len(callouts) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(callouts))
+	for i, c := range callouts {
+		rows = append(rows, map[string]any{
+			"tech_card_id":   id,
+			"callout_number": c.Number,
+			"part":           c.Part,
+			"description":    c.Description,
+			"dimensions":     c.Dimensions,
+			"display_order":  i,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_callout", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card callouts: %w", err)
+	}
+	return nil
+}
+
+func insertTechCardRevisions(ctx context.Context, db dependency.DB, id int, revisions []entity.TechCardRevision) error {
+	if len(revisions) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(revisions))
+	for i, r := range revisions {
+		rows = append(rows, map[string]any{
+			"tech_card_id":  id,
+			"version":       r.Version,
+			"revision_date": r.RevisionDate,
+			"author":        r.Author,
+			"section":       r.Section,
+			"change_note":   r.ChangeNote,
+			"display_order": i,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_revision", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card revisions: %w", err)
+	}
+	return nil
+}
+
+// clampPagination normalizes a client-supplied limit/offset.
+func clampPagination(limit, offset int) (int, int) {
+	if limit <= 0 {
+		limit = defaultPageLimit
+	}
+	if limit > maxPageLimit {
+		limit = maxPageLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
+}
+
+// escapeLike escapes LIKE wildcards in a user-supplied search term.
+func escapeLike(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return r.Replace(s)
+}

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -37,14 +37,14 @@ func New(base storeutil.Base, txFunc TxFunc) *Store {
 const techCardHeaderColumns = `style_number, name, brand, season, collection, category_id,
 	target_gender, stage, status, approval_state, approved_by, released_at, version, revision_date,
 	base_model_id, base_sample_size_id, designer, constructor, technologist,
-	target_cost, target_retail_price, currency,
+	target_cost, target_retail_price, currency, measurement_unit,
 	description, silhouette, collar, fastening, pockets, sleeve_cuff, extra_details,
 	topstitching, aux_materials, notes`
 
 const techCardHeaderValues = `:style_number, :name, :brand, :season, :collection, :category_id,
 	:target_gender, :stage, :status, :approval_state, :approved_by, :released_at, :version, :revision_date,
 	:base_model_id, :base_sample_size_id, :designer, :constructor, :technologist,
-	:target_cost, :target_retail_price, :currency,
+	:target_cost, :target_retail_price, :currency, :measurement_unit,
 	:description, :silhouette, :collar, :fastening, :pockets, :sleeve_cuff, :extra_details,
 	:topstitching, :aux_materials, :notes`
 
@@ -72,6 +72,7 @@ func techCardHeaderParams(tc *entity.TechCardInsert) map[string]any {
 		"target_cost":         tc.TargetCost,
 		"target_retail_price": tc.TargetRetailPrice,
 		"currency":            tc.Currency,
+		"measurement_unit":    string(tc.MeasurementUnit),
 		"description":         tc.Description,
 		"silhouette":          tc.Silhouette,
 		"collar":              tc.Collar,
@@ -129,6 +130,7 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 				base_model_id = :base_model_id, base_sample_size_id = :base_sample_size_id,
 				designer = :designer, constructor = :constructor, technologist = :technologist,
 				target_cost = :target_cost, target_retail_price = :target_retail_price, currency = :currency,
+				measurement_unit = :measurement_unit,
 				description = :description, silhouette = :silhouette, collar = :collar, fastening = :fastening,
 				pockets = :pockets, sleeve_cuff = :sleeve_cuff, extra_details = :extra_details,
 				topstitching = :topstitching, aux_materials = :aux_materials, notes = :notes

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -1298,6 +1298,7 @@ message ListFittingsRequest {
   common.OrderFactor order_factor = 3;
   int32 product_id = 4; // optional filter; 0 = no filter
   int32 model_id = 5; // optional filter; 0 = no filter
+  int32 tech_card_id = 6; // optional filter; 0 = no filter
 }
 
 message ListFittingsResponse {

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -17,6 +17,7 @@ import "common/product.proto";
 import "common/promo.proto";
 import "common/shipment.proto";
 import "common/support.proto";
+import "common/techcard.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 import "google/type/decimal.proto";
@@ -310,6 +311,43 @@ service AdminService {
   // is not shadowed by GET /fitting/{id}.
   rpc ListFittings(ListFittingsRequest) returns (ListFittingsResponse) {
     option (google.api.http) = {get: "/api/admin/fitting/list"};
+  }
+
+  // TECH CARD MANAGER
+  // Same list-after-{id} route ordering as ListModels (see note above): the
+  // literal `…/list` GET route is declared AFTER the `…/{id}` GET route so that
+  // GET /tech-card/list is not shadowed by GET /tech-card/{id}.
+
+  // CreateTechCard creates a new tech card (техкарта) with its nested sections.
+  rpc CreateTechCard(CreateTechCardRequest) returns (CreateTechCardResponse) {
+    option (google.api.http) = {
+      post: "/api/admin/tech-card/add"
+      body: "*"
+    };
+  }
+
+  // GetTechCard returns a tech card by id with its nested sections resolved.
+  rpc GetTechCard(GetTechCardRequest) returns (GetTechCardResponse) {
+    option (google.api.http) = {get: "/api/admin/tech-card/{id}"};
+  }
+
+  // UpdateTechCard updates a tech card, replacing its nested sections.
+  rpc UpdateTechCard(UpdateTechCardRequest) returns (UpdateTechCardResponse) {
+    option (google.api.http) = {
+      post: "/api/admin/tech-card/update"
+      body: "*"
+    };
+  }
+
+  // DeleteTechCard deletes a tech card by id (nested sections cascade).
+  rpc DeleteTechCard(DeleteTechCardRequest) returns (DeleteTechCardResponse) {
+    option (google.api.http) = {delete: "/api/admin/tech-card/{id}"};
+  }
+
+  // ListTechCards lists tech cards (paged, optional filters). Declared last on
+  // purpose so GET /tech-card/list is not shadowed by GET /tech-card/{id}.
+  rpc ListTechCards(ListTechCardsRequest) returns (ListTechCardsResponse) {
+    option (google.api.http) = {get: "/api/admin/tech-card/list"};
   }
 
   // SETTINGS
@@ -2177,4 +2215,52 @@ message RunTierBackfillResponse {
   int64 orders_snapshotted = 1;
   int32 accounts_processed = 2;
   int32 accounts_upgraded = 3;
+}
+
+// TECH CARD MANAGER messages
+
+message CreateTechCardRequest {
+  common.TechCardInsert tech_card = 1;
+}
+
+message CreateTechCardResponse {
+  int32 id = 1;
+}
+
+message GetTechCardRequest {
+  int32 id = 1;
+}
+
+message GetTechCardResponse {
+  common.TechCard tech_card = 1;
+}
+
+message UpdateTechCardRequest {
+  int32 id = 1;
+  common.TechCardInsert tech_card = 2;
+}
+
+message UpdateTechCardResponse {}
+
+message DeleteTechCardRequest {
+  int32 id = 1;
+}
+
+message DeleteTechCardResponse {}
+
+message ListTechCardsRequest {
+  int32 limit = 1;
+  int32 offset = 2;
+  common.OrderFactor order_factor = 3;
+  common.TechCardStage stage = 4; // UNKNOWN = no filter
+  common.GenderEnum gender = 5; // UNKNOWN = no filter
+  string brand = 6; // optional case-insensitive substring
+  string season = 7; // optional case-insensitive substring
+  string name = 8; // optional case-insensitive substring on name or style_number
+  int32 product_id = 9; // optional: only cards linked to this product (0 = no filter)
+}
+
+message ListTechCardsResponse {
+  repeated common.TechCardListItem tech_cards = 1;
+  int32 total = 2;
 }

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -344,8 +344,10 @@ service AdminService {
     option (google.api.http) = {delete: "/api/admin/tech-card/{id}"};
   }
 
-  // ListTechCards lists tech cards (paged, optional filters). Declared last on
-  // purpose so GET /tech-card/list is not shadowed by GET /tech-card/{id}.
+  // ListTechCards lists tech cards (paged, optional filters). Declared AFTER
+  // GetTechCard so the mux (which prepends handlers, first-match wins) checks
+  // /tech-card/list before /tech-card/{id}. Guarded by
+  // TestTechCardListRouteNotShadowed.
   rpc ListTechCards(ListTechCardsRequest) returns (ListTechCardsResponse) {
     option (google.api.http) = {get: "/api/admin/tech-card/list"};
   }

--- a/proto/common/common/fitting.proto
+++ b/proto/common/common/fitting.proto
@@ -30,9 +30,11 @@ message FittingSizeInsert {
   string fit_note = 2;
 }
 
-// FittingInsert is the writable payload for a fitting session.
+// FittingInsert is the writable payload for a fitting session. A fitting anchors
+// to a tech card (the style) and/or a specific product (the colour/SKU sample);
+// at least one of tech_card_id / product_id must be set.
 message FittingInsert {
-  int32 product_id = 1;
+  int32 product_id = 1; // FK product(id); 0 = unset (the specific colour/SKU sample)
   int32 model_id = 2; // FK model(id); 0 = unspecified
   google.protobuf.Timestamp fitting_date = 3;
   string comment = 4;
@@ -41,6 +43,7 @@ message FittingInsert {
   string recorded_by = 7;
   repeated FittingSizeInsert sizes = 8;
   repeated int32 media_ids = 9;
+  int32 tech_card_id = 10; // FK tech_card(id); 0 = unset (the style being fitted)
 }
 
 // Fitting is a stored try-on session with resolved media for display.

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -171,9 +171,96 @@ message TechCardPomPoint {
   repeated TechCardPomActual actuals = 8;
 }
 
+// TechCardLabelType classifies a label / tag (Sheet «Этикетки и упаковка»).
+enum TechCardLabelType {
+  TECH_CARD_LABEL_TYPE_UNKNOWN = 0;
+  TECH_CARD_LABEL_TYPE_MAIN = 1; // основная (бренд)
+  TECH_CARD_LABEL_TYPE_SIZE = 2; // размерная
+  TECH_CARD_LABEL_TYPE_CARE = 3; // состав / уход
+  TECH_CARD_LABEL_TYPE_ORIGIN = 4; // страна производства
+  TECH_CARD_LABEL_TYPE_FLAG = 5; // флаговая
+  TECH_CARD_LABEL_TYPE_HANGTAG = 6; // навесной ярлык (хэнгтег)
+  TECH_CARD_LABEL_TYPE_BARCODE = 7; // штрихкод / RFID
+  TECH_CARD_LABEL_TYPE_SPECIAL = 8; // спецэтикетка
+}
+
+// TechCardConstruction holds general workmanship parameters (Sheet «Обработка»).
+message TechCardConstruction {
+  string main_stitch_type = 1; // тип основной машинной строчки
+  string stitch_density = 2; // плотность строчки по умолчанию (стеж/см)
+  string overlock_threads = 3; // оверлок, кол-во ниток
+  string seam_allowances = 4; // припуски на швы (общие)
+  string hem_finish = 5; // обработка низа / подгибка
+  string pressing = 6; // ВТО / финишная отделка
+  string machine_class = 7; // класс / группа машин
+  string notes = 8;
+}
+
+// TechCardOperation is one per-node sewing operation (Sheet «Обработка»).
+message TechCardOperation {
+  string node = 1; // узел / операция (required)
+  string description = 2; // описание обработки
+  string seam_type = 3; // тип шва / строчки
+  google.type.Decimal stitches_per_cm = 4; // стежков/см
+  string topstitch_width = 5; // ширина отстрочки
+  string thread = 6; // нитки (арт.)
+  string note = 7;
+}
+
+// TechCardLabel is one label / tag spec (Sheet «Этикетки и упаковка»).
+message TechCardLabel {
+  TechCardLabelType label_type = 1; // required
+  string content = 2; // содержание / артикул
+  string placement = 3; // размещение
+  string attachment = 4; // крепление
+  string size = 5; // размер
+  string note = 6;
+}
+
+// TechCardPackaging holds the packaging spec (Sheet «Этикетки и упаковка»).
+message TechCardPackaging {
+  string folding_method = 1; // способ складывания
+  string polybag = 2; // полибэг (тип / размер)
+  string bag_sticker = 3; // стикер на пакет
+  string inserts = 4; // доп. вложения
+  int32 units_per_box = 5; // кол-во в коробе; 0 = unset
+  string box_marking = 6; // маркировка короба
+  string box_dimensions = 7; // размеры короба (Д×Ш×В)
+  google.type.Decimal weight_net = 8; // вес нетто
+  google.type.Decimal weight_gross = 9; // вес брутто
+  string notes = 10;
+}
+
+// TechCardCostLine is one currency bucket of the materials rollup.
+message TechCardCostLine {
+  string currency = 1; // empty = BOM lines without a currency
+  google.type.Decimal amount = 2;
+}
+
+// TechCardCosting holds the manually-entered cost articles (Sheet «Калькуляция»).
+// The materials rollup and total are COMPUTED on read from the BOM; they are
+// output-only (ignored on write) and never converted across currencies.
+message TechCardCosting {
+  google.type.Decimal cmt_cost = 1; // пошив / работа (CMT)
+  google.type.Decimal hardware_cost = 2; // фурнитура (если вне BOM)
+  google.type.Decimal packaging_cost = 3; // упаковка и маркировка
+  google.type.Decimal logistics_cost = 4; // логистика / доставка
+  google.type.Decimal overhead_cost = 5; // накладные расходы
+  google.type.Decimal defect_percent = 6; // брак / запас (%), 0..100
+  google.type.Decimal markup_multiplier = 7; // наценка (×)
+  google.type.Decimal wholesale_price = 8; // оптовая цена
+  google.type.Decimal retail_price = 9; // розничная цена
+  string currency = 10; // ISO 4217 for the articles above
+  string notes = 11;
+
+  // OUTPUT-ONLY computed rollup (ignored on write; no currency conversion).
+  repeated TechCardCostLine materials_total = 12; // Σ BOM line_total grouped by BOM currency
+  google.type.Decimal materials_cost = 13; // Σ BOM line_total in `currency` (and currency-less lines)
+  google.type.Decimal total_cost = 14; // (materials_cost + cmt+hardware+packaging+logistics+overhead) × (1 + defect/100)
+}
+
 // TechCardInsert is the writable payload for a tech card. Nested lists are full
-// replacements on update (like ProductNew). Production sections (operations,
-// labels, packaging, costing) are added later using field numbers >= 43.
+// replacements on update (like ProductNew).
 message TechCardInsert {
   // identification (Sheet «Титул»)
   string style_number = 1; // Артикул (required)
@@ -224,9 +311,15 @@ message TechCardInsert {
   repeated TechCardColorway colorways = 41;
   repeated TechCardPomPoint pom_points = 42;
 
-  // Production sections (operations, labels, packaging, costing) land at >= 43.
+  // production (Phase 3): construction, operations, labels, packaging, costing.
+  TechCardConstruction construction = 43; // 1:1; null = unset
+  repeated TechCardOperation operations = 44;
+  repeated TechCardLabel labels = 45;
+  TechCardPackaging packaging = 46; // 1:1; null = unset
+  TechCardCosting costing = 47; // 1:1; null = unset
+
   // Reserved so a future field can never collide with a removed one.
-  reserved 39, 43 to 99;
+  reserved 39, 48 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -32,6 +32,14 @@ enum TechCardApprovalState {
   TECH_CARD_APPROVAL_STATE_OBSOLETE = 5;
 }
 
+// TechCardMeasurementUnit is the unit for the card's geometry (callout dimensions
+// and the future POM chart).
+enum TechCardMeasurementUnit {
+  TECH_CARD_MEASUREMENT_UNIT_UNKNOWN = 0; // defaults to CM on write
+  TECH_CARD_MEASUREMENT_UNIT_CM = 1;
+  TECH_CARD_MEASUREMENT_UNIT_IN = 2;
+}
+
 // TechCardMediaKind classifies a tech-card sketch image.
 enum TechCardMediaKind {
   TECH_CARD_MEDIA_KIND_UNKNOWN = 0;
@@ -63,7 +71,9 @@ message TechCardCallout {
   int32 media_id = 5; // FK media(id); sketch this callout is pinned to (0 = unanchored)
 }
 
-// TechCardRevision is one entry in the revision log.
+// TechCardRevision is one entry in the spec-document changelog (what changed in
+// which section, by whom). This is NOT fit history — fitting verdicts and
+// measurements live in the separate fitting feature.
 message TechCardRevision {
   string version = 1;
   google.protobuf.Timestamp revision_date = 2;
@@ -89,6 +99,7 @@ message TechCardInsert {
   TechCardApprovalState approval_state = 35; // UNKNOWN defaults to DRAFT
   string approved_by = 36; // who approved the current revision
   google.protobuf.Timestamp released_at = 37; // when released to manufacture
+  TechCardMeasurementUnit measurement_unit = 38; // UNKNOWN defaults to CM
   string version = 10;
   google.protobuf.Timestamp revision_date = 11;
   int32 base_model_id = 12; // FK model(id); 0 = unset
@@ -121,7 +132,7 @@ message TechCardInsert {
 
   // Materials (BOM, colorways, POM) and production sections land here in later
   // phases. Reserved so a future field can never collide with a removed one.
-  reserved 38 to 99;
+  reserved 39 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -1,0 +1,130 @@
+syntax = "proto3";
+
+package common;
+
+import "common/media.proto";
+import "common/product.proto";
+import "google/protobuf/timestamp.proto";
+import "google/type/decimal.proto";
+
+option go_package = "github.com/jekabolt/grbpwr-manager/proto/gen/common;common";
+
+// TechCardStage is the development stage of a tech pack: prototype, fit sample,
+// salesman sample, pre-production, production.
+enum TechCardStage {
+  TECH_CARD_STAGE_UNKNOWN = 0;
+  TECH_CARD_STAGE_PROTO = 1;
+  TECH_CARD_STAGE_FIT = 2;
+  TECH_CARD_STAGE_SMS = 3;
+  TECH_CARD_STAGE_PP = 4;
+  TECH_CARD_STAGE_PROD = 5;
+}
+
+// TechCardMediaKind classifies a tech-card sketch image.
+enum TechCardMediaKind {
+  TECH_CARD_MEDIA_KIND_UNKNOWN = 0;
+  TECH_CARD_MEDIA_KIND_FRONT = 1; // front flat sketch
+  TECH_CARD_MEDIA_KIND_BACK = 2; // back flat sketch
+  TECH_CARD_MEDIA_KIND_DETAIL = 3; // detail / construction node
+  TECH_CARD_MEDIA_KIND_LINING = 4; // internal structure / lining
+  TECH_CARD_MEDIA_KIND_PREVIEW = 5; // cover preview
+}
+
+// TechCardMediaItem is a writable sketch-media reference (id + kind).
+message TechCardMediaItem {
+  int32 media_id = 1; // FK media(id)
+  TechCardMediaKind kind = 2;
+}
+
+// TechCardMediaFull is a resolved sketch-media reference for display.
+message TechCardMediaFull {
+  MediaFull media = 1;
+  TechCardMediaKind kind = 2;
+}
+
+// TechCardCallout is a numbered detail note pointing at the technical sketch.
+message TechCardCallout {
+  int32 number = 1; // callout number on the sketch
+  string part = 2; // деталь / узел
+  string description = 3; // описание, уточнение
+  string dimensions = 4; // размеры / привязка
+}
+
+// TechCardRevision is one entry in the revision log.
+message TechCardRevision {
+  string version = 1;
+  google.protobuf.Timestamp revision_date = 2;
+  string author = 3;
+  string section = 4; // раздел
+  string change_note = 5; // что изменено
+}
+
+// TechCardInsert is the writable payload for a tech card. Nested lists are full
+// replacements on update (like ProductNew). Materials, POM and production sections
+// are added in later iterations using field numbers >= 40.
+message TechCardInsert {
+  // identification (Sheet «Титул»)
+  string style_number = 1; // Артикул (required)
+  string name = 2; // Название изделия (required)
+  string brand = 3;
+  string season = 4;
+  string collection = 5;
+  int32 category_id = 6; // FK category(id); 0 = unset
+  GenderEnum target_gender = 7; // UNKNOWN = unset
+  TechCardStage stage = 8; // UNKNOWN defaults to PROTO
+  string status = 9;
+  string version = 10;
+  google.protobuf.Timestamp revision_date = 11;
+  int32 base_model_id = 12; // FK model(id); 0 = unset
+  int32 base_sample_size_id = 13; // FK size(id); 0 = unset
+  string designer = 14;
+  string constructor = 15;
+  string technologist = 16;
+  google.type.Decimal target_cost = 17;
+  google.type.Decimal target_retail_price = 18;
+  string currency = 19; // ISO 4217 for target cost/price
+
+  // construction description (lower block of Sheet «Титул»)
+  string description = 20;
+  string silhouette = 21;
+  string collar = 22;
+  string fastening = 23;
+  string pockets = 24;
+  string sleeve_cuff = 25;
+  string extra_details = 26;
+  string topstitching = 27;
+  string aux_materials = 28;
+  string notes = 29;
+
+  // children (full-replace on update)
+  repeated int32 size_ids = 30; // size range / grade (FK size(id))
+  repeated int32 product_ids = 31; // linked catalog products (FK product(id))
+  repeated TechCardMediaItem media = 32; // sketch / preview media
+  repeated TechCardCallout callouts = 33; // sketch callouts
+  repeated TechCardRevision revisions = 34; // revision log
+
+  // 40+ reserved for materials (BOM, colorways, POM) and production sections.
+}
+
+// TechCard is a stored tech card with resolved sketch media.
+message TechCard {
+  int32 id = 1;
+  TechCardInsert tech_card = 2;
+  google.protobuf.Timestamp created_at = 3;
+  google.protobuf.Timestamp updated_at = 4;
+  repeated TechCardMediaFull resolved_media = 5; // sketch media with resolved MediaFull
+}
+
+// TechCardListItem is a lightweight tech-card header for list views.
+message TechCardListItem {
+  int32 id = 1;
+  string style_number = 2;
+  string name = 3;
+  string brand = 4;
+  TechCardStage stage = 5;
+  string status = 6;
+  GenderEnum target_gender = 7;
+  string season = 8;
+  google.protobuf.Timestamp created_at = 9;
+  google.protobuf.Timestamp updated_at = 10;
+}

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -20,6 +20,18 @@ enum TechCardStage {
   TECH_CARD_STAGE_PROD = 5;
 }
 
+// TechCardApprovalState is the gating release state of a tech card, orthogonal to
+// TechCardStage (which tracks development progress). A factory must only receive a
+// card in the RELEASED state.
+enum TechCardApprovalState {
+  TECH_CARD_APPROVAL_STATE_UNKNOWN = 0; // defaults to DRAFT on write
+  TECH_CARD_APPROVAL_STATE_DRAFT = 1;
+  TECH_CARD_APPROVAL_STATE_IN_REVIEW = 2;
+  TECH_CARD_APPROVAL_STATE_APPROVED = 3;
+  TECH_CARD_APPROVAL_STATE_RELEASED = 4;
+  TECH_CARD_APPROVAL_STATE_OBSOLETE = 5;
+}
+
 // TechCardMediaKind classifies a tech-card sketch image.
 enum TechCardMediaKind {
   TECH_CARD_MEDIA_KIND_UNKNOWN = 0;
@@ -48,6 +60,7 @@ message TechCardCallout {
   string part = 2; // деталь / узел
   string description = 3; // описание, уточнение
   string dimensions = 4; // размеры / привязка
+  int32 media_id = 5; // FK media(id); sketch this callout is pinned to (0 = unanchored)
 }
 
 // TechCardRevision is one entry in the revision log.
@@ -72,7 +85,10 @@ message TechCardInsert {
   int32 category_id = 6; // FK category(id); 0 = unset
   GenderEnum target_gender = 7; // UNKNOWN = unset
   TechCardStage stage = 8; // UNKNOWN defaults to PROTO
-  string status = 9;
+  string status = 9; // freeform workflow notes (soft, non-gating)
+  TechCardApprovalState approval_state = 35; // UNKNOWN defaults to DRAFT
+  string approved_by = 36; // who approved the current revision
+  google.protobuf.Timestamp released_at = 37; // when released to manufacture
   string version = 10;
   google.protobuf.Timestamp revision_date = 11;
   int32 base_model_id = 12; // FK model(id); 0 = unset
@@ -103,7 +119,9 @@ message TechCardInsert {
   repeated TechCardCallout callouts = 33; // sketch callouts
   repeated TechCardRevision revisions = 34; // revision log
 
-  // 40+ reserved for materials (BOM, colorways, POM) and production sections.
+  // Materials (BOM, colorways, POM) and production sections land here in later
+  // phases. Reserved so a future field can never collide with a removed one.
+  reserved 38 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.
@@ -127,4 +145,5 @@ message TechCardListItem {
   string season = 8;
   google.protobuf.Timestamp created_at = 9;
   google.protobuf.Timestamp updated_at = 10;
+  TechCardApprovalState approval_state = 11;
 }

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -33,11 +33,11 @@ enum TechCardApprovalState {
 }
 
 // TechCardMeasurementUnit is the unit for the card's geometry (callout dimensions
-// and the future POM chart).
+// and the POM chart). Metric only — the brand works in cm and mm, never inches.
 enum TechCardMeasurementUnit {
   TECH_CARD_MEASUREMENT_UNIT_UNKNOWN = 0; // defaults to CM on write
   TECH_CARD_MEASUREMENT_UNIT_CM = 1;
-  TECH_CARD_MEASUREMENT_UNIT_IN = 2;
+  TECH_CARD_MEASUREMENT_UNIT_MM = 2;
 }
 
 // TechCardMediaKind classifies a tech-card sketch image.
@@ -165,7 +165,8 @@ message TechCardPomPoint {
   string name = 3; // required
   string how_to_measure = 4; // HTM
   google.type.Decimal base_value = 5; // базовый образец
-  google.type.Decimal tolerance = 6; // допуск ±
+  google.type.Decimal tolerance_plus = 6; // допуск + (Допуск +); mirrored to minus if minus unset
+  google.type.Decimal tolerance_minus = 9; // допуск - (Допуск -); mirrored to plus if plus unset
   repeated TechCardPomGrade grades = 7;
   repeated TechCardPomActual actuals = 8;
 }

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -82,9 +82,97 @@ message TechCardRevision {
   string change_note = 5; // что изменено
 }
 
+// TechCardBomSection groups a BOM line by material family (Sheet «Спецификация»).
+enum TechCardBomSection {
+  TECH_CARD_BOM_SECTION_UNKNOWN = 0;
+  TECH_CARD_BOM_SECTION_FABRIC = 1; // основные ткани
+  TECH_CARD_BOM_SECTION_LINING = 2; // подклад
+  TECH_CARD_BOM_SECTION_INTERLINING = 3; // приклад / дублерин
+  TECH_CARD_BOM_SECTION_INSULATION = 4; // утеплитель / объём
+  TECH_CARD_BOM_SECTION_HARDWARE = 5; // фурнитура
+  TECH_CARD_BOM_SECTION_THREAD = 6; // нитки
+  TECH_CARD_BOM_SECTION_LABEL = 7; // этикетки и маркировка
+  TECH_CARD_BOM_SECTION_PACKAGING = 8; // упаковка
+}
+
+// TechCardLabDipStatus is the lab-dip approval lifecycle of a colourway.
+enum TechCardLabDipStatus {
+  TECH_CARD_LAB_DIP_STATUS_UNKNOWN = 0; // defaults to PENDING on write
+  TECH_CARD_LAB_DIP_STATUS_PENDING = 1;
+  TECH_CARD_LAB_DIP_STATUS_SUBMITTED = 2;
+  TECH_CARD_LAB_DIP_STATUS_APPROVED = 3;
+  TECH_CARD_LAB_DIP_STATUS_REJECTED = 4;
+}
+
+// TechCardColorway is a development colourway (Sheet «Колористика» columns). It is
+// distinct from tech_card_product (published catalog SKUs); product_id optionally
+// links the published SKU that realises this colourway.
+message TechCardColorway {
+  string code = 1; // short colourway code, e.g. BLK
+  string name = 2; // colourway name (required)
+  TechCardLabDipStatus lab_dip_status = 3; // UNKNOWN defaults to PENDING
+  int32 product_id = 4; // FK product(id); 0 = not yet published
+  string comment = 5;
+}
+
+// TechCardBomColorwayColor is one «Колористика» matrix cell: the colour of a BOM
+// material in a colourway. colorway_index points into TechCardInsert.colorways — a
+// full-replace upsert has no stable colourway ids to reference on write.
+message TechCardBomColorwayColor {
+  int32 colorway_index = 1; // 0-based index into TechCardInsert.colorways
+  string color = 2; // colour name / code
+  string pantone = 3; // Pantone / code
+}
+
+// TechCardBomItem is one bill-of-materials line (Sheet «Спецификация»).
+message TechCardBomItem {
+  TechCardBomSection section = 1; // required
+  string name = 2; // required
+  string placement = 3; // размещение / назначение
+  string supplier = 4;
+  string supplier_ref = 5; // артикул поставщика
+  string color = 6; // base/default colour
+  string composition = 7; // состав
+  string spec = 8; // ширина / плотность
+  google.type.Decimal consumption = 9; // норма расхода
+  string unit = 10; // ед.
+  google.type.Decimal quantity = 11; // кол-во
+  google.type.Decimal unit_price = 12; // цена/ед.
+  string currency = 13; // ISO 4217 for unit_price
+  string comment = 14;
+  repeated TechCardBomColorwayColor colorway_colors = 15; // per-colourway colours
+  google.type.Decimal line_total = 16; // OUTPUT-ONLY: quantity*unit_price (else consumption*unit_price)
+}
+
+// TechCardPomGrade is the graded value of a POM point for one size.
+message TechCardPomGrade {
+  int32 size_id = 1; // FK size(id); must be one of TechCardInsert.size_ids
+  google.type.Decimal value = 2;
+}
+
+// TechCardPomActual is an actual measured value, optionally taken in a fitting.
+message TechCardPomActual {
+  int32 fitting_id = 1; // FK fitting(id); 0 = none
+  string label = 2; // free label when no fitting linked (e.g. примерка 1)
+  google.type.Decimal value = 3;
+}
+
+// TechCardPomPoint is a point of measure with its grade and actuals (Sheet «Измерения»).
+// Values are in TechCardInsert.measurement_unit.
+message TechCardPomPoint {
+  string section = 1; // group label, e.g. ВЕРХ / КОРПУС
+  string code = 2; // код
+  string name = 3; // required
+  string how_to_measure = 4; // HTM
+  google.type.Decimal base_value = 5; // базовый образец
+  google.type.Decimal tolerance = 6; // допуск ±
+  repeated TechCardPomGrade grades = 7;
+  repeated TechCardPomActual actuals = 8;
+}
+
 // TechCardInsert is the writable payload for a tech card. Nested lists are full
-// replacements on update (like ProductNew). Materials, POM and production sections
-// are added in later iterations using field numbers >= 40.
+// replacements on update (like ProductNew). Production sections (operations,
+// labels, packaging, costing) are added later using field numbers >= 43.
 message TechCardInsert {
   // identification (Sheet «Титул»)
   string style_number = 1; // Артикул (required)
@@ -130,9 +218,14 @@ message TechCardInsert {
   repeated TechCardCallout callouts = 33; // sketch callouts
   repeated TechCardRevision revisions = 34; // revision log
 
-  // Materials (BOM, colorways, POM) and production sections land here in later
-  // phases. Reserved so a future field can never collide with a removed one.
-  reserved 39 to 99;
+  // materials (Phase 2): bill of materials, colourways, points of measure.
+  repeated TechCardBomItem bom_items = 40;
+  repeated TechCardColorway colorways = 41;
+  repeated TechCardPomPoint pom_points = 42;
+
+  // Production sections (operations, labels, packaging, costing) land at >= 43.
+  // Reserved so a future field can never collide with a removed one.
+  reserved 39, 43 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.


### PR DESCRIPTION
Garment **tech pack** (техкарта) for the admin panel — modelled on the universal
template (9 sheets). A tech card is a standalone **style** document (stage
proto→fit→sms→pp→prod, gated by an orthogonal approval_state) that links to
0..N catalog products (one style, many colourways). Built backend-only; the admin
frontend (separate Vercel project) consumes the new RPCs.

## API (admin, REST under `/api/admin/tech-card`)
`CreateTechCard` · `GetTechCard{id}` · `UpdateTechCard` · `DeleteTechCard{id}` ·
`ListTechCards` (paged + filters: stage, gender, brand, season, name, product_id).
Full-nested **upsert** like `UpsertProduct` — the whole doc is sent on create/update.

## Scope — all 9 sheets
- **Титул / Тех.эскиз** — identification + construction description, size range, product links, sketch media + callouts, revision log.
- **Спецификация (BOM) / Колористика** — bill of materials (per-line currency + computed `line_total`), first-class colourways with a per-material colour matrix.
- **Измерения (POM)** — graded measurements (keyed on stable `size_id`), how-to-measure, ± tolerance, actuals linkable to fittings.
- **Обработка / Этикетки-упаковка / Калькуляция** — workmanship + operations, typed labels + packaging, costing with a **computed, per-currency** materials rollup + total (no FX conversion).
- **История примерок** — reuses the existing `fitting`/`model` features; fittings now carry `tech_card_id` (product optional) so one card aggregates fittings across colours.

## Migrations
`0067` core · `0068` materials · `0069` fitting↔tech-card link (adds `fitting.tech_card_id`, makes `product_id` nullable) · `0070` production. All additive and safe against existing data.

## Notes for reviewers
- No changes to `product`/`model` tables; `fitting` gains a nullable style link.
- Generated code (`proto/gen`, mocks, swagger) is gitignored — rebuilt by `make build`.
- Validation returns 400 for cross-field rules (base size ∈ size range, colourway product ∈ card products, POM grade size ∈ size range, colorway_index range, per-season unique style_number).
- Computed fields (`line_total`, costing rollup/total) are output-only.
- DTO round-trip + route smoke tests included; `go build`, `go vet ./internal/...`, `golangci-lint` clean.
- **Deferred:** Excel/PDF export (structure is export-ready via `display_order`/sections).

## Verify on beta
`make run-quick` applies `0067–0070`; exercise the nested payload via Swagger UI at `/` (AdminService → `*TechCard*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5VqZ34GMD2xpyYVL1Rm6b