### PR TITLE
feat(admin): tech card (техкарта) — full pack Phase 1–3.5 + multi-agent reviews

### DIFF
--- a/internal/apisrv/admin/techcard.go
+++ b/internal/apisrv/admin/techcard.go
@@ -72,9 +72,15 @@ func (s *Server) UpdateTechCard(ctx context.Context, req *pb_admin.UpdateTechCar
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	if err := s.repo.TechCards().UpdateTechCard(ctx, int(req.Id), tc); err != nil {
+	if err := s.repo.TechCards().UpdateTechCard(ctx, int(req.Id), tc, int(req.ExpectedLockVersion)); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Errorf(codes.NotFound, "tech card not found")
+		}
+		if errors.Is(err, entity.ErrTechCardConflict) {
+			return nil, status.Error(codes.Aborted, "tech card was modified concurrently; reload and retry")
+		}
+		if errors.Is(err, entity.ErrTechCardReleased) {
+			return nil, status.Error(codes.FailedPrecondition, "tech card is released and frozen; re-open to draft to edit")
 		}
 		if s.repo.IsErrUniqueViolation(err) {
 			return nil, status.Error(codes.InvalidArgument, techCardDupMsg)

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -326,7 +326,7 @@ type (
 	// linked products, sketch media, callouts and revision log.
 	TechCards interface {
 		AddTechCard(ctx context.Context, tc *entity.TechCardInsert) (int, error)
-		UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardInsert) error
+		UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardInsert, expectedLockVersion int) error
 		DeleteTechCard(ctx context.Context, id int) error
 		GetTechCardById(ctx context.Context, id int) (*entity.TechCard, error)
 		ListTechCards(ctx context.Context, limit, offset int, orderFactor entity.OrderFactor, filter entity.TechCardListFilter) ([]entity.TechCard, int, error)

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -331,16 +331,6 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		return nil, err
 	}
 
-	// Release gate: a card cannot be RELEASED to a factory while any colourway's
-	// lab dip is still unapproved — bulk colour must be signed off first.
-	if approvalState == entity.TechCardApprovalReleased {
-		for _, c := range colorways {
-			if c.LabDipStatus != entity.LabDipApproved {
-				return nil, fmt.Errorf("cannot release: colorway %q lab dip is %q, must be approved", c.Name, c.LabDipStatus)
-			}
-		}
-	}
-
 	// production (Phase 3)
 	construction, err := parseTechCardConstruction(pb.Construction)
 	if err != nil {
@@ -373,6 +363,22 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 	signoffs, err := parseTechCardSignoffs(pb.Signoffs)
 	if err != nil {
 		return nil, err
+	}
+
+	// Release gate: a card cannot be RELEASED to a factory while any colourway's
+	// lab dip is unapproved (bulk colour unsigned) or any high-severity maker issue
+	// is still open (a known un-buildable operation).
+	if approvalState == entity.TechCardApprovalReleased {
+		for _, c := range colorways {
+			if c.LabDipStatus != entity.LabDipApproved {
+				return nil, fmt.Errorf("cannot release: colorway %q lab dip is %q, must be approved", c.Name, c.LabDipStatus)
+			}
+		}
+		for _, is := range issues {
+			if is.Severity == entity.IssueSeverityHigh && is.Status == entity.IssueStatusOpen {
+				return nil, fmt.Errorf("cannot release: a high-severity issue is still open: %q", is.Description)
+			}
+		}
 	}
 
 	return &entity.TechCardInsert{
@@ -1077,11 +1083,14 @@ func pomActualVerdict(p *entity.TechCardPomPoint, a entity.TechCardPomActual, gr
 	var target decimal.Decimal
 	hasTarget := false
 	if a.SizeId.Valid {
+		// An actual measured at a specific size can only be judged against THAT
+		// size's grade. Do not fall back to base_value (a different size) — that
+		// would emit a confident but cross-size verdict. Ungraded size -> UNKNOWN.
 		if gv, ok := gradeBySize[int(a.SizeId.Int32)]; ok {
 			target, hasTarget = gv, true
 		}
-	}
-	if !hasTarget && p.BaseValue.Valid {
+	} else if p.BaseValue.Valid {
+		// No size given: judge the generic actual against the base-sample value.
 		target, hasTarget = p.BaseValue.Decimal, true
 	}
 	if !hasTarget {

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -326,6 +326,10 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 	if err != nil {
 		return nil, err
 	}
+	issues, err := parseTechCardIssues(pb.Issues)
+	if err != nil {
+		return nil, err
+	}
 
 	return &entity.TechCardInsert{
 		StyleNumber:       pb.StyleNumber,
@@ -376,6 +380,7 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		Labels:            labels,
 		Packaging:         packaging,
 		Costing:           costing,
+		Issues:            issues,
 	}, nil
 }
 
@@ -480,6 +485,7 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Labels:            techCardLabelsToPb(tc.Labels),
 			Packaging:         techCardPackagingToPb(tc.Packaging),
 			Costing:           techCardCostingToPb(tc),
+			Issues:            techCardIssuesToPb(tc.Issues),
 		},
 		ResolvedMedia: resolved,
 	}

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -566,6 +566,7 @@ func ConvertEntityTechCardToListItemPb(tc *entity.TechCard) *pb_common.TechCardL
 		Season:        pbStringFromNull(tc.Season),
 		CreatedAt:     timestamppb.New(tc.CreatedAt),
 		UpdatedAt:     timestamppb.New(tc.UpdatedAt),
+		LockVersion:   int32(tc.LockVersion),
 	}
 }
 
@@ -652,9 +653,16 @@ func parseTechCardColorways(pbs []*pb_common.TechCardColorway, productIds []int)
 			}
 			status = s
 		}
-		if len(c.Pantone) > maxVarchar64 || len(c.PantoneSystem) > maxVarchar32 ||
-			len(c.Hex) > 7 || len(c.LabDipDecidedBy) > maxVarchar255 {
-			return nil, fmt.Errorf("colorway pantone/pantone_system/hex/lab_dip_decided_by too long")
+		if len(c.Pantone) > maxVarchar64 || len(c.Hex) > 7 || len(c.LabDipDecidedBy) > maxVarchar255 {
+			return nil, fmt.Errorf("colorway pantone/hex/lab_dip_decided_by too long")
+		}
+		// Validate format/membership in the DTO (not just lengths) so a bad value
+		// fails as InvalidArgument instead of tripping the DB CHECK as Internal-500.
+		if c.Hex != "" && !isHexColor(c.Hex) {
+			return nil, fmt.Errorf("colorway hex must be #RRGGBB")
+		}
+		if c.PantoneSystem != "" && !validPantoneSystems[c.PantoneSystem] {
+			return nil, fmt.Errorf("colorway pantone_system must be one of TCX, TPX, TPG, C, U")
 		}
 		if c.SwatchMediaId < 0 || c.LabDipRound < 0 {
 			return nil, fmt.Errorf("colorway swatch_media_id/lab_dip_round must not be negative")
@@ -996,6 +1004,22 @@ func pbFabricDirection(s sql.NullString) pb_common.TechCardFabricDirection {
 		return v
 	}
 	return pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_UNKNOWN
+}
+
+// validPantoneSystems mirrors the tech_card_colorway.pantone_system CHECK.
+var validPantoneSystems = map[string]bool{"TCX": true, "TPX": true, "TPG": true, "C": true, "U": true}
+
+// isHexColor reports whether s is a #RRGGBB colour (mirrors the colorway.hex CHECK).
+func isHexColor(s string) bool {
+	if len(s) != 7 || s[0] != '#' {
+		return false
+	}
+	for _, r := range s[1:] {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return false
+		}
+	}
+	return true
 }
 
 // validateUnitInterval rejects a non-null decimal outside [0,1] (callout pos_x/y).

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -295,6 +295,16 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		return nil, err
 	}
 
+	// Release gate: a card cannot be RELEASED to a factory while any colourway's
+	// lab dip is still unapproved — bulk colour must be signed off first.
+	if approvalState == entity.TechCardApprovalReleased {
+		for _, c := range colorways {
+			if c.LabDipStatus != entity.LabDipApproved {
+				return nil, fmt.Errorf("cannot release: colorway %q lab dip is %q, must be approved", c.Name, c.LabDipStatus)
+			}
+		}
+	}
+
 	// production (Phase 3)
 	construction, err := parseTechCardConstruction(pb.Construction)
 	if err != nil {

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -339,6 +339,7 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		Status:            nullStringFromPb(pb.Status),
 		ApprovalState:     approvalState,
 		ApprovedBy:        nullStringFromPb(pb.ApprovedBy),
+		ApprovedAt:        nullTimeFromPbTimestamp(pb.ApprovedAt),
 		ReleasedAt:        nullTimeFromPbTimestamp(pb.ReleasedAt),
 		Version:           nullStringFromPb(pb.Version),
 		RevisionDate:      nullDateFromPbTimestamp(pb.RevisionDate),
@@ -352,6 +353,7 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		Currency:          nullStringFromPb(pb.Currency),
 		MeasurementUnit:   unit,
 		Description:       nullStringFromPb(pb.Description),
+		Concept:           nullStringFromPb(pb.Concept),
 		Silhouette:        nullStringFromPb(pb.Silhouette),
 		Collar:            nullStringFromPb(pb.Collar),
 		Fastening:         nullStringFromPb(pb.Fastening),
@@ -425,9 +427,10 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 	productIds := intsToInt32(tc.ProductIds)
 
 	return &pb_common.TechCard{
-		Id:        int32(tc.Id),
-		CreatedAt: timestamppb.New(tc.CreatedAt),
-		UpdatedAt: timestamppb.New(tc.UpdatedAt),
+		Id:          int32(tc.Id),
+		LockVersion: int32(tc.LockVersion),
+		CreatedAt:   timestamppb.New(tc.CreatedAt),
+		UpdatedAt:   timestamppb.New(tc.UpdatedAt),
 		TechCard: &pb_common.TechCardInsert{
 			StyleNumber:       tc.StyleNumber,
 			Name:              tc.Name,
@@ -440,6 +443,7 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Status:            pbStringFromNull(tc.Status),
 			ApprovalState:     pbTechCardApprovalState(tc.ApprovalState),
 			ApprovedBy:        pbStringFromNull(tc.ApprovedBy),
+			ApprovedAt:        pbTimestampFromNullTime(tc.ApprovedAt),
 			ReleasedAt:        pbTimestampFromNullTime(tc.ReleasedAt),
 			Version:           pbStringFromNull(tc.Version),
 			RevisionDate:      pbTimestampFromNullTime(tc.RevisionDate),
@@ -453,6 +457,7 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Currency:          pbStringFromNull(tc.Currency),
 			MeasurementUnit:   pbTechCardMeasurementUnit(tc.MeasurementUnit),
 			Description:       pbStringFromNull(tc.Description),
+			Concept:           pbStringFromNull(tc.Concept),
 			Silhouette:        pbStringFromNull(tc.Silhouette),
 			Collar:            pbStringFromNull(tc.Collar),
 			Fastening:         pbStringFromNull(tc.Fastening),
@@ -696,6 +701,9 @@ func parseTechCardPomPoints(pbs []*pb_common.TechCardPomPoint, sizeIds []int) ([
 		sizeSet[s] = true
 	}
 	out := make([]entity.TechCardPomPoint, 0, len(pbs))
+	// Non-empty POM codes must be unique within the card (DB enforces
+	// uniq_tech_card_pom_code); dedupe here for a precise InvalidArgument.
+	seenCode := make(map[string]bool, len(pbs))
 	for _, p := range pbs {
 		if p.Name == "" {
 			return nil, fmt.Errorf("pom point name is required")
@@ -705,6 +713,12 @@ func parseTechCardPomPoints(pbs []*pb_common.TechCardPomPoint, sizeIds []int) ([
 		}
 		if len(p.Code) > maxVarchar32 {
 			return nil, fmt.Errorf("pom code must be at most %d characters", maxVarchar32)
+		}
+		if p.Code != "" {
+			if seenCode[p.Code] {
+				return nil, fmt.Errorf("pom points contain a duplicate code: %q", p.Code)
+			}
+			seenCode[p.Code] = true
 		}
 		baseValue, err := nullDecimalFromPb(p.BaseValue)
 		if err != nil {
@@ -757,6 +771,12 @@ func parseTechCardPomPoints(pbs []*pb_common.TechCardPomPoint, sizeIds []int) ([
 			if a.FittingId < 0 {
 				return nil, fmt.Errorf("pom actual fitting_id must not be negative")
 			}
+			if a.SizeId < 0 {
+				return nil, fmt.Errorf("pom actual size_id must not be negative")
+			}
+			if a.SizeId > 0 && !sizeSet[int(a.SizeId)] {
+				return nil, fmt.Errorf("pom actual size_id %d must be one of size_ids", a.SizeId)
+			}
 			if len(a.Label) > maxVarchar64 {
 				return nil, fmt.Errorf("pom actual label must be at most %d characters", maxVarchar64)
 			}
@@ -766,6 +786,7 @@ func parseTechCardPomPoints(pbs []*pb_common.TechCardPomPoint, sizeIds []int) ([
 			}
 			actuals = append(actuals, entity.TechCardPomActual{
 				FittingId: nullInt32FromPb(a.FittingId),
+				SizeId:    nullInt32FromPb(a.SizeId),
 				Label:     nullStringFromPb(a.Label),
 				Value:     val,
 			})
@@ -841,7 +862,9 @@ func techCardPomPointsToPb(points []entity.TechCardPomPoint) []*pb_common.TechCa
 	for i := range points {
 		p := &points[i]
 		grades := make([]*pb_common.TechCardPomGrade, 0, len(p.Grades))
+		gradeBySize := make(map[int]decimal.Decimal, len(p.Grades))
 		for _, g := range p.Grades {
+			gradeBySize[g.SizeId] = g.Value
 			grades = append(grades, &pb_common.TechCardPomGrade{
 				SizeId: int32(g.SizeId),
 				Value:  pbDecimalFromDecimal(g.Value),
@@ -849,11 +872,14 @@ func techCardPomPointsToPb(points []entity.TechCardPomPoint) []*pb_common.TechCa
 		}
 		actuals := make([]*pb_common.TechCardPomActual, 0, len(p.Actuals))
 		for _, a := range p.Actuals {
-			actuals = append(actuals, &pb_common.TechCardPomActual{
+			pa := &pb_common.TechCardPomActual{
 				FittingId: pbInt32FromNull(a.FittingId),
+				SizeId:    pbInt32FromNull(a.SizeId),
 				Label:     pbStringFromNull(a.Label),
 				Value:     pbDecimalFromDecimal(a.Value),
-			})
+			}
+			pa.Deviation, pa.Verdict = pomActualVerdict(p, a, gradeBySize)
+			actuals = append(actuals, pa)
 		}
 		out = append(out, &pb_common.TechCardPomPoint{
 			Section:        pbStringFromNull(p.Section),
@@ -868,6 +894,41 @@ func techCardPomPointsToPb(points []entity.TechCardPomPoint) []*pb_common.TechCa
 		})
 	}
 	return out
+}
+
+// pomActualVerdict computes an actual's deviation from its target (the graded value
+// at the measured size, else the point's base value) and the in/out-of-tolerance
+// verdict. Returns (nil, UNKNOWN) when there is no target to compare against.
+func pomActualVerdict(p *entity.TechCardPomPoint, a entity.TechCardPomActual, gradeBySize map[int]decimal.Decimal) (*pb_decimal.Decimal, pb_common.TechCardPomVerdict) {
+	var target decimal.Decimal
+	hasTarget := false
+	if a.SizeId.Valid {
+		if gv, ok := gradeBySize[int(a.SizeId.Int32)]; ok {
+			target, hasTarget = gv, true
+		}
+	}
+	if !hasTarget && p.BaseValue.Valid {
+		target, hasTarget = p.BaseValue.Decimal, true
+	}
+	if !hasTarget {
+		return nil, pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_UNKNOWN
+	}
+	tolPlus := decimal.Zero
+	if p.TolerancePlus.Valid {
+		tolPlus = p.TolerancePlus.Decimal
+	}
+	tolMinus := decimal.Zero
+	if p.ToleranceMinus.Valid {
+		tolMinus = p.ToleranceMinus.Decimal
+	}
+	verdict := pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_IN_TOLERANCE
+	switch {
+	case a.Value.GreaterThan(target.Add(tolPlus)):
+		verdict = pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_OVER
+	case a.Value.LessThan(target.Sub(tolMinus)):
+		verdict = pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_UNDER
+	}
+	return pbDecimalFromDecimal(a.Value.Sub(target)), verdict
 }
 
 func pbBomSection(s entity.TechCardBomSection) pb_common.TechCardBomSection {

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -76,12 +76,29 @@ var techCardUnitEntityToPb = func() map[entity.TechCardMeasurementUnit]pb_common
 }()
 
 var techCardMediaKindPbToEntity = map[pb_common.TechCardMediaKind]entity.TechCardMediaKind{
-	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_FRONT:   entity.TechCardMediaFront,
-	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_BACK:    entity.TechCardMediaBack,
-	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_DETAIL:  entity.TechCardMediaDetail,
-	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_LINING:  entity.TechCardMediaLining,
-	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_PREVIEW: entity.TechCardMediaPreview,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_FRONT:     entity.TechCardMediaFront,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_BACK:      entity.TechCardMediaBack,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_DETAIL:    entity.TechCardMediaDetail,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_LINING:    entity.TechCardMediaLining,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_PREVIEW:   entity.TechCardMediaPreview,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_MOODBOARD: entity.TechCardMediaMoodboard,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_REFERENCE: entity.TechCardMediaReference,
+	pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_SWATCH:    entity.TechCardMediaSwatch,
 }
+
+var techCardFabricDirectionPbToEntity = map[pb_common.TechCardFabricDirection]entity.TechCardFabricDirection{
+	pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_ANY:     entity.FabricDirectionAny,
+	pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_ONE_WAY: entity.FabricDirectionOneWay,
+	pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_TWO_WAY: entity.FabricDirectionTwoWay,
+}
+
+var techCardFabricDirectionEntityToPb = func() map[entity.TechCardFabricDirection]pb_common.TechCardFabricDirection {
+	m := make(map[entity.TechCardFabricDirection]pb_common.TechCardFabricDirection, len(techCardFabricDirectionPbToEntity))
+	for k, v := range techCardFabricDirectionPbToEntity {
+		m[v] = k
+	}
+	return m
+}()
 
 var techCardMediaKindEntityToPb = func() map[entity.TechCardMediaKind]pb_common.TechCardMediaKind {
 	m := make(map[entity.TechCardMediaKind]pb_common.TechCardMediaKind, len(techCardMediaKindPbToEntity))
@@ -243,7 +260,10 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 			}
 			kind = k
 		}
-		media = append(media, entity.TechCardMediaItem{MediaId: int(m.MediaId), Kind: kind})
+		if len(m.Caption) > maxVarchar255 {
+			return nil, fmt.Errorf("media caption must be at most %d characters", maxVarchar255)
+		}
+		media = append(media, entity.TechCardMediaItem{MediaId: int(m.MediaId), Kind: kind, Caption: nullStringFromPb(m.Caption)})
 	}
 
 	callouts := make([]entity.TechCardCallout, 0, len(pb.Callouts))
@@ -254,12 +274,28 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		if c.MediaId < 0 {
 			return nil, fmt.Errorf("callout media_id must not be negative")
 		}
+		posX, err := nullDecimalFromPb(c.PosX)
+		if err != nil {
+			return nil, fmt.Errorf("callout pos_x: %w", err)
+		}
+		posY, err := nullDecimalFromPb(c.PosY)
+		if err != nil {
+			return nil, fmt.Errorf("callout pos_y: %w", err)
+		}
+		if err := validateUnitInterval(posX, "callout pos_x"); err != nil {
+			return nil, err
+		}
+		if err := validateUnitInterval(posY, "callout pos_y"); err != nil {
+			return nil, err
+		}
 		callouts = append(callouts, entity.TechCardCallout{
 			Number:      int(c.Number),
 			Part:        nullStringFromPb(c.Part),
 			Description: nullStringFromPb(c.Description),
 			Dimensions:  nullStringFromPb(c.Dimensions),
 			MediaId:     nullInt32FromPb(c.MediaId),
+			PosX:        posX,
+			PosY:        posY,
 		})
 	}
 
@@ -330,6 +366,10 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 	if err != nil {
 		return nil, err
 	}
+	sizeQuantities, err := parseTechCardSizeQuantities(pb.SizeQuantities, sizeIds)
+	if err != nil {
+		return nil, err
+	}
 
 	return &entity.TechCardInsert{
 		StyleNumber:       pb.StyleNumber,
@@ -381,6 +421,7 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		Packaging:         packaging,
 		Costing:           costing,
 		Issues:            issues,
+		SizeQuantities:    sizeQuantities,
 	}, nil
 }
 
@@ -395,6 +436,7 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 		media = append(media, &pb_common.TechCardMediaItem{
 			MediaId: int32(m.MediaId),
 			Kind:    pbTechCardMediaKind(m.Kind),
+			Caption: pbStringFromNull(m.Caption),
 		})
 	}
 
@@ -414,6 +456,8 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Description: pbStringFromNull(c.Description),
 			Dimensions:  pbStringFromNull(c.Dimensions),
 			MediaId:     pbInt32FromNull(c.MediaId),
+			PosX:        pbDecimalFromNull(c.PosX),
+			PosY:        pbDecimalFromNull(c.PosY),
 		})
 	}
 
@@ -486,6 +530,7 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Packaging:         techCardPackagingToPb(tc.Packaging),
 			Costing:           techCardCostingToPb(tc),
 			Issues:            techCardIssuesToPb(tc.Issues),
+			SizeQuantities:    techCardSizeQuantitiesToPb(tc.SizeQuantities),
 		},
 		ResolvedMedia: resolved,
 	}
@@ -595,12 +640,28 @@ func parseTechCardColorways(pbs []*pb_common.TechCardColorway, productIds []int)
 			}
 			status = s
 		}
+		if len(c.Pantone) > maxVarchar64 || len(c.PantoneSystem) > maxVarchar32 ||
+			len(c.Hex) > 7 || len(c.LabDipDecidedBy) > maxVarchar255 {
+			return nil, fmt.Errorf("colorway pantone/pantone_system/hex/lab_dip_decided_by too long")
+		}
+		if c.SwatchMediaId < 0 || c.LabDipRound < 0 {
+			return nil, fmt.Errorf("colorway swatch_media_id/lab_dip_round must not be negative")
+		}
 		out = append(out, entity.TechCardColorway{
-			Code:         nullStringFromPb(c.Code),
-			Name:         c.Name,
-			LabDipStatus: status,
-			ProductId:    nullInt32FromPb(c.ProductId),
-			Comment:      nullStringFromPb(c.Comment),
+			Code:               nullStringFromPb(c.Code),
+			Name:               c.Name,
+			LabDipStatus:       status,
+			ProductId:          nullInt32FromPb(c.ProductId),
+			Comment:            nullStringFromPb(c.Comment),
+			Pantone:            nullStringFromPb(c.Pantone),
+			PantoneSystem:      nullStringFromPb(c.PantoneSystem),
+			Hex:                nullStringFromPb(c.Hex),
+			SwatchMediaId:      nullInt32FromPb(c.SwatchMediaId),
+			LabDipRound:        nullInt32FromPb(c.LabDipRound),
+			LabDipSubmittedAt:  nullDateFromPbTimestamp(c.LabDipSubmittedAt),
+			LabDipDecidedAt:    nullDateFromPbTimestamp(c.LabDipDecidedAt),
+			LabDipDecidedBy:    nullStringFromPb(c.LabDipDecidedBy),
+			LabDipRejectReason: nullStringFromPb(c.LabDipRejectReason),
 		})
 	}
 	return out, nil
@@ -680,22 +741,61 @@ func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int) 
 			})
 		}
 
+		fabricWidth, err := nullDecimalFromPb(b.FabricWidth)
+		if err != nil {
+			return nil, fmt.Errorf("bom fabric_width: %w", err)
+		}
+		fabricGsm, err := nullDecimalFromPb(b.FabricWeightGsm)
+		if err != nil {
+			return nil, fmt.Errorf("bom fabric_weight_gsm: %w", err)
+		}
+		wastage, err := nullDecimalFromPb(b.WastagePercent)
+		if err != nil {
+			return nil, fmt.Errorf("bom wastage_percent: %w", err)
+		}
+		for _, v := range []struct {
+			nd    decimal.NullDecimal
+			field string
+		}{{fabricWidth, "bom fabric_width"}, {fabricGsm, "bom fabric_weight_gsm"}} {
+			if err := validateDecimalScale(v.nd, v.field, 2, 100_000); err != nil {
+				return nil, err
+			}
+		}
+		if err := validateDecimalScale(wastage, "bom wastage_percent", 2, 1_000); err != nil {
+			return nil, err
+		}
+		if wastage.Valid && wastage.Decimal.GreaterThan(decimal.NewFromInt(100)) {
+			return nil, fmt.Errorf("bom wastage_percent must be between 0 and 100")
+		}
+		direction := sql.NullString{}
+		if b.FabricDirection != pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_UNKNOWN {
+			d, ok := techCardFabricDirectionPbToEntity[b.FabricDirection]
+			if !ok {
+				return nil, fmt.Errorf("unknown bom fabric_direction: %v", b.FabricDirection)
+			}
+			direction = sql.NullString{String: string(d), Valid: true}
+		}
+
 		out = append(out, entity.TechCardBomItem{
-			Section:        section,
-			Name:           b.Name,
-			Placement:      nullStringFromPb(b.Placement),
-			Supplier:       nullStringFromPb(b.Supplier),
-			SupplierRef:    nullStringFromPb(b.SupplierRef),
-			Color:          nullStringFromPb(b.Color),
-			Composition:    nullStringFromPb(b.Composition),
-			Spec:           nullStringFromPb(b.Spec),
-			Consumption:    consumption,
-			Unit:           nullStringFromPb(b.Unit),
-			Quantity:       quantity,
-			UnitPrice:      unitPrice,
-			Currency:       nullStringFromPb(b.Currency),
-			Comment:        nullStringFromPb(b.Comment),
-			ColorwayColors: colors,
+			Section:         section,
+			Name:            b.Name,
+			Placement:       nullStringFromPb(b.Placement),
+			Supplier:        nullStringFromPb(b.Supplier),
+			SupplierRef:     nullStringFromPb(b.SupplierRef),
+			Color:           nullStringFromPb(b.Color),
+			Composition:     nullStringFromPb(b.Composition),
+			Spec:            nullStringFromPb(b.Spec),
+			Consumption:     consumption,
+			Unit:            nullStringFromPb(b.Unit),
+			Quantity:        quantity,
+			UnitPrice:       unitPrice,
+			Currency:        nullStringFromPb(b.Currency),
+			Comment:         nullStringFromPb(b.Comment),
+			FabricWidth:     fabricWidth,
+			FabricWeightGsm: fabricGsm,
+			FabricDirection: direction,
+			WastagePercent:  wastage,
+			ColorwayColors:  colors,
 		})
 	}
 	return out, nil
@@ -819,11 +919,20 @@ func techCardColorwaysToPb(cws []entity.TechCardColorway) []*pb_common.TechCardC
 	out := make([]*pb_common.TechCardColorway, 0, len(cws))
 	for _, c := range cws {
 		out = append(out, &pb_common.TechCardColorway{
-			Code:         pbStringFromNull(c.Code),
-			Name:         c.Name,
-			LabDipStatus: pbLabDipStatus(c.LabDipStatus),
-			ProductId:    pbInt32FromNull(c.ProductId),
-			Comment:      pbStringFromNull(c.Comment),
+			Code:               pbStringFromNull(c.Code),
+			Name:               c.Name,
+			LabDipStatus:       pbLabDipStatus(c.LabDipStatus),
+			ProductId:          pbInt32FromNull(c.ProductId),
+			Comment:            pbStringFromNull(c.Comment),
+			Pantone:            pbStringFromNull(c.Pantone),
+			PantoneSystem:      pbStringFromNull(c.PantoneSystem),
+			Hex:                pbStringFromNull(c.Hex),
+			SwatchMediaId:      pbInt32FromNull(c.SwatchMediaId),
+			LabDipRound:        pbInt32FromNull(c.LabDipRound),
+			LabDipSubmittedAt:  pbTimestampFromNullTime(c.LabDipSubmittedAt),
+			LabDipDecidedAt:    pbTimestampFromNullTime(c.LabDipDecidedAt),
+			LabDipDecidedBy:    pbStringFromNull(c.LabDipDecidedBy),
+			LabDipRejectReason: pbStringFromNull(c.LabDipRejectReason),
 		})
 	}
 	return out
@@ -842,23 +951,76 @@ func techCardBomItemsToPb(items []entity.TechCardBomItem) []*pb_common.TechCardB
 			})
 		}
 		out = append(out, &pb_common.TechCardBomItem{
-			Section:        pbBomSection(b.Section),
-			Name:           b.Name,
-			Placement:      pbStringFromNull(b.Placement),
-			Supplier:       pbStringFromNull(b.Supplier),
-			SupplierRef:    pbStringFromNull(b.SupplierRef),
-			Color:          pbStringFromNull(b.Color),
-			Composition:    pbStringFromNull(b.Composition),
-			Spec:           pbStringFromNull(b.Spec),
-			Consumption:    pbDecimalFromNull(b.Consumption),
-			Unit:           pbStringFromNull(b.Unit),
-			Quantity:       pbDecimalFromNull(b.Quantity),
-			UnitPrice:      pbDecimalFromNull(b.UnitPrice),
-			Currency:       pbStringFromNull(b.Currency),
-			Comment:        pbStringFromNull(b.Comment),
-			ColorwayColors: colors,
-			LineTotal:      pbDecimalFromNull(b.LineTotal()),
+			Section:         pbBomSection(b.Section),
+			Name:            b.Name,
+			Placement:       pbStringFromNull(b.Placement),
+			Supplier:        pbStringFromNull(b.Supplier),
+			SupplierRef:     pbStringFromNull(b.SupplierRef),
+			Color:           pbStringFromNull(b.Color),
+			Composition:     pbStringFromNull(b.Composition),
+			Spec:            pbStringFromNull(b.Spec),
+			Consumption:     pbDecimalFromNull(b.Consumption),
+			Unit:            pbStringFromNull(b.Unit),
+			Quantity:        pbDecimalFromNull(b.Quantity),
+			UnitPrice:       pbDecimalFromNull(b.UnitPrice),
+			Currency:        pbStringFromNull(b.Currency),
+			Comment:         pbStringFromNull(b.Comment),
+			ColorwayColors:  colors,
+			LineTotal:       pbDecimalFromNull(b.LineTotal()),
+			FabricWidth:     pbDecimalFromNull(b.FabricWidth),
+			FabricWeightGsm: pbDecimalFromNull(b.FabricWeightGsm),
+			FabricDirection: pbFabricDirection(b.FabricDirection),
+			WastagePercent:  pbDecimalFromNull(b.WastagePercent),
 		})
+	}
+	return out
+}
+
+func pbFabricDirection(s sql.NullString) pb_common.TechCardFabricDirection {
+	if !s.Valid {
+		return pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_UNKNOWN
+	}
+	if v, ok := techCardFabricDirectionEntityToPb[entity.TechCardFabricDirection(s.String)]; ok {
+		return v
+	}
+	return pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_UNKNOWN
+}
+
+// validateUnitInterval rejects a non-null decimal outside [0,1] (callout pos_x/y).
+func validateUnitInterval(nd decimal.NullDecimal, field string) error {
+	if !nd.Valid {
+		return nil
+	}
+	if nd.Decimal.IsNegative() || nd.Decimal.GreaterThan(decimal.NewFromInt(1)) {
+		return fmt.Errorf("%s must be between 0 and 1", field)
+	}
+	return nil
+}
+
+func parseTechCardSizeQuantities(pbs []*pb_common.TechCardSizeQuantity, sizeIds []int) ([]entity.TechCardSizeQuantity, error) {
+	out := make([]entity.TechCardSizeQuantity, 0, len(pbs))
+	seen := make(map[int]bool, len(pbs))
+	for _, q := range pbs {
+		sid := int(q.SizeId)
+		if sid <= 0 || !slices.Contains(sizeIds, sid) {
+			return nil, fmt.Errorf("size_quantity size_id %d must be one of size_ids", q.SizeId)
+		}
+		if seen[sid] {
+			return nil, fmt.Errorf("duplicate size_quantity for size_id %d", q.SizeId)
+		}
+		seen[sid] = true
+		if q.OrderQty < 0 {
+			return nil, fmt.Errorf("size_quantity order_qty must not be negative")
+		}
+		out = append(out, entity.TechCardSizeQuantity{SizeId: sid, OrderQty: int(q.OrderQty)})
+	}
+	return out, nil
+}
+
+func techCardSizeQuantitiesToPb(qs []entity.TechCardSizeQuantity) []*pb_common.TechCardSizeQuantity {
+	out := make([]*pb_common.TechCardSizeQuantity, 0, len(qs))
+	for _, q := range qs {
+		out = append(out, &pb_common.TechCardSizeQuantity{SizeId: int32(q.SizeId), OrderQty: int32(q.OrderQty)})
 	}
 	return out
 }

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -370,6 +370,10 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 	if err != nil {
 		return nil, err
 	}
+	signoffs, err := parseTechCardSignoffs(pb.Signoffs)
+	if err != nil {
+		return nil, err
+	}
 
 	return &entity.TechCardInsert{
 		StyleNumber:       pb.StyleNumber,
@@ -422,6 +426,7 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		Costing:           costing,
 		Issues:            issues,
 		SizeQuantities:    sizeQuantities,
+		Signoffs:          signoffs,
 	}, nil
 }
 
@@ -531,6 +536,7 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Costing:           techCardCostingToPb(tc),
 			Issues:            techCardIssuesToPb(tc.Issues),
 			SizeQuantities:    techCardSizeQuantitiesToPb(tc.SizeQuantities),
+			Signoffs:          techCardSignoffsToPb(tc.Signoffs),
 		},
 		ResolvedMedia: resolved,
 	}

--- a/internal/dto/techcard_production.go
+++ b/internal/dto/techcard_production.go
@@ -73,7 +73,8 @@ func parseTechCardConstruction(pb *pb_common.TechCardConstruction) (*entity.Tech
 	if err != nil {
 		return nil, fmt.Errorf("construction labour_rate: %w", err)
 	}
-	if err := validateDecimalScale(labourRate, "construction labour_rate", bomPriceMaxFrac, bomPriceLimit); err != nil {
+	// DECIMAL(10,4): 6 integer digits, so the magnitude limit is 1e6, not bomPriceLimit.
+	if err := validateDecimalScale(labourRate, "construction labour_rate", 4, 1_000_000); err != nil {
 		return nil, err
 	}
 	return &entity.TechCardConstruction{
@@ -100,8 +101,8 @@ func parseTechCardOperations(pbs []*pb_common.TechCardOperation) ([]entity.TechC
 			return nil, fmt.Errorf("operation node/seam_type/thread must be at most %d characters", maxVarchar255)
 		}
 		if len(o.TopstitchWidth) > maxVarchar64 || len(o.Machine) > maxVarchar64 ||
-			len(o.SeamAllowance) > maxVarchar64 || len(o.Needle) > maxVarchar64 {
-			return nil, fmt.Errorf("operation topstitch_width/machine/seam_allowance/needle must be at most %d characters", maxVarchar64)
+			len(o.SeamAllowance) > maxVarchar64 || len(o.Needle) > maxVarchar64 || len(o.Attachment) > maxVarchar64 {
+			return nil, fmt.Errorf("operation topstitch_width/machine/seam_allowance/needle/attachment must be at most %d characters", maxVarchar64)
 		}
 		if o.OperationNumber < 0 {
 			return nil, fmt.Errorf("operation operation_number must not be negative")
@@ -131,6 +132,7 @@ func parseTechCardOperations(pbs []*pb_common.TechCardOperation) ([]entity.TechC
 			SeamAllowance:   nullStringFromPb(o.SeamAllowance),
 			Thread:          nullStringFromPb(o.Thread),
 			Needle:          nullStringFromPb(o.Needle),
+			Attachment:      nullStringFromPb(o.Attachment),
 			TimeNorm:        timeNorm,
 			Note:            nullStringFromPb(o.Note),
 		})
@@ -322,6 +324,7 @@ func techCardOperationsToPb(ops []entity.TechCardOperation) []*pb_common.TechCar
 			SeamAllowance:   pbStringFromNull(o.SeamAllowance),
 			Thread:          pbStringFromNull(o.Thread),
 			Needle:          pbStringFromNull(o.Needle),
+			Attachment:      pbStringFromNull(o.Attachment),
 			TimeNorm:        pbDecimalFromNull(o.TimeNorm),
 			Note:            pbStringFromNull(o.Note),
 		})

--- a/internal/dto/techcard_production.go
+++ b/internal/dto/techcard_production.go
@@ -552,11 +552,41 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 		MaterialsCost:    pbDecimalFromDecimal(materialsCost.Round(costMaxFrac)),
 	}
 
-	// total_cost = (materials in costing currency + cmt+hardware+packaging+
+	costingCcy := ""
+	if c.Currency.Valid {
+		costingCcy = c.Currency.String
+	}
+
+	// Computed labour: total_sam = Σ(operation time_norm); labour_cost = SAM × rate
+	// (denominated in construction.labour_rate_currency).
+	totalSam := decimal.Zero
+	for i := range tc.Operations {
+		if tc.Operations[i].TimeNorm.Valid {
+			totalSam = totalSam.Add(tc.Operations[i].TimeNorm.Decimal)
+		}
+	}
+	labourCcy := ""
+	var labourCost decimal.NullDecimal
+	if tc.Construction != nil {
+		labourCcy = tc.Construction.LabourRateCurrency.String
+		if totalSam.IsPositive() && tc.Construction.LabourRate.Valid {
+			labourCost = decimal.NullDecimal{Decimal: totalSam.Mul(tc.Construction.LabourRate.Decimal), Valid: true}
+		}
+	}
+
+	// Make (sewing) cost folded into total_cost: a manual cmt_cost is authoritative;
+	// otherwise the computed labour stands in as the make cost — but only when its
+	// currency matches the costing currency, so labour is never silently FX-folded.
+	makeCost := c.CmtCost
+	if !c.CmtCost.Valid && labourCost.Valid && labourCcy == costingCcy {
+		makeCost = labourCost
+	}
+
+	// total_cost = (materials in costing currency + make + hardware+packaging+
 	// logistics+overhead) grossed up by the defect/reserve %. Single-currency,
 	// best-effort: cross-currency materials are surfaced in materials_total.
 	total := materialsCost
-	for _, d := range []decimal.NullDecimal{c.CmtCost, c.HardwareCost, c.PackagingCost, c.LogisticsCost, c.OverheadCost} {
+	for _, d := range []decimal.NullDecimal{makeCost, c.HardwareCost, c.PackagingCost, c.LogisticsCost, c.OverheadCost} {
 		if d.Valid {
 			total = total.Add(d.Decimal)
 		}
@@ -566,13 +596,16 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 	}
 	out.TotalCost = pbDecimalFromDecimal(total.Round(costMaxFrac))
 
-	// Flag when a BOM line is priced in a currency other than the costing currency:
-	// such lines are surfaced in materials_total but excluded from total_cost (no
-	// auto-conversion), so the total is not the full landed cost.
-	costingCcy := ""
-	if c.Currency.Valid {
-		costingCcy = c.Currency.String
+	if totalSam.IsPositive() {
+		out.TotalSam = pbDecimalFromDecimal(totalSam.Round(3))
 	}
+	if labourCost.Valid {
+		out.LabourCost = pbDecimalFromDecimal(labourCost.Decimal.Round(costMaxFrac))
+	}
+
+	// Flag when part of the cost is excluded from total_cost for want of an FX
+	// conversion: a BOM line in another currency, or computed labour that would be
+	// the make cost but is in a different currency than the costing one.
 	for i := range tc.BomItems {
 		b := &tc.BomItems[i]
 		if b.Currency.Valid && b.Currency.String != "" && b.Currency.String != costingCcy && b.LineTotal().Valid {
@@ -580,19 +613,8 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 			break
 		}
 	}
-
-	// total_sam = Σ(operation time_norm); labour_cost = total_sam × labour_rate.
-	totalSam := decimal.Zero
-	for i := range tc.Operations {
-		if tc.Operations[i].TimeNorm.Valid {
-			totalSam = totalSam.Add(tc.Operations[i].TimeNorm.Decimal)
-		}
-	}
-	if totalSam.IsPositive() {
-		out.TotalSam = pbDecimalFromDecimal(totalSam.Round(3))
-		if tc.Construction != nil && tc.Construction.LabourRate.Valid {
-			out.LabourCost = pbDecimalFromDecimal(totalSam.Mul(tc.Construction.LabourRate.Decimal).Round(costMaxFrac))
-		}
+	if labourCost.Valid && !c.CmtCost.Valid && labourCcy != costingCcy {
+		out.HasUnconvertedCurrencies = true
 	}
 	return out
 }

--- a/internal/dto/techcard_production.go
+++ b/internal/dto/techcard_production.go
@@ -364,6 +364,21 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 		total = total.Mul(decimal.NewFromInt(1).Add(c.DefectPercent.Decimal.Div(decimal.NewFromInt(100))))
 	}
 	out.TotalCost = pbDecimalFromDecimal(total.Round(costMaxFrac))
+
+	// Flag when a BOM line is priced in a currency other than the costing currency:
+	// such lines are surfaced in materials_total but excluded from total_cost (no
+	// auto-conversion), so the total is not the full landed cost.
+	costingCcy := ""
+	if c.Currency.Valid {
+		costingCcy = c.Currency.String
+	}
+	for i := range tc.BomItems {
+		b := &tc.BomItems[i]
+		if b.Currency.Valid && b.Currency.String != "" && b.Currency.String != costingCcy && b.LineTotal().Valid {
+			out.HasUnconvertedCurrencies = true
+			break
+		}
+	}
 	return out
 }
 

--- a/internal/dto/techcard_production.go
+++ b/internal/dto/techcard_production.go
@@ -66,15 +66,27 @@ func parseTechCardConstruction(pb *pb_common.TechCardConstruction) (*entity.Tech
 			return nil, fmt.Errorf("%s must be at most %d characters", c.field, c.max)
 		}
 	}
+	if pb.LabourRateCurrency != "" && len(pb.LabourRateCurrency) != maxCurrency {
+		return nil, fmt.Errorf("construction labour_rate_currency must be a 3-letter ISO 4217 code")
+	}
+	labourRate, err := nullDecimalFromPb(pb.LabourRate)
+	if err != nil {
+		return nil, fmt.Errorf("construction labour_rate: %w", err)
+	}
+	if err := validateDecimalScale(labourRate, "construction labour_rate", bomPriceMaxFrac, bomPriceLimit); err != nil {
+		return nil, err
+	}
 	return &entity.TechCardConstruction{
-		MainStitchType:  nullStringFromPb(pb.MainStitchType),
-		StitchDensity:   nullStringFromPb(pb.StitchDensity),
-		OverlockThreads: nullStringFromPb(pb.OverlockThreads),
-		SeamAllowances:  nullStringFromPb(pb.SeamAllowances),
-		HemFinish:       nullStringFromPb(pb.HemFinish),
-		Pressing:        nullStringFromPb(pb.Pressing),
-		MachineClass:    nullStringFromPb(pb.MachineClass),
-		Notes:           nullStringFromPb(pb.Notes),
+		MainStitchType:     nullStringFromPb(pb.MainStitchType),
+		StitchDensity:      nullStringFromPb(pb.StitchDensity),
+		OverlockThreads:    nullStringFromPb(pb.OverlockThreads),
+		SeamAllowances:     nullStringFromPb(pb.SeamAllowances),
+		HemFinish:          nullStringFromPb(pb.HemFinish),
+		Pressing:           nullStringFromPb(pb.Pressing),
+		MachineClass:       nullStringFromPb(pb.MachineClass),
+		Notes:              nullStringFromPb(pb.Notes),
+		LabourRate:         labourRate,
+		LabourRateCurrency: nullStringFromPb(pb.LabourRateCurrency),
 	}, nil
 }
 
@@ -87,8 +99,12 @@ func parseTechCardOperations(pbs []*pb_common.TechCardOperation) ([]entity.TechC
 		if len(o.Node) > maxVarchar255 || len(o.SeamType) > maxVarchar255 || len(o.Thread) > maxVarchar255 {
 			return nil, fmt.Errorf("operation node/seam_type/thread must be at most %d characters", maxVarchar255)
 		}
-		if len(o.TopstitchWidth) > maxVarchar64 {
-			return nil, fmt.Errorf("operation topstitch_width must be at most %d characters", maxVarchar64)
+		if len(o.TopstitchWidth) > maxVarchar64 || len(o.Machine) > maxVarchar64 ||
+			len(o.SeamAllowance) > maxVarchar64 || len(o.Needle) > maxVarchar64 {
+			return nil, fmt.Errorf("operation topstitch_width/machine/seam_allowance/needle must be at most %d characters", maxVarchar64)
+		}
+		if o.OperationNumber < 0 {
+			return nil, fmt.Errorf("operation operation_number must not be negative")
 		}
 		stitches, err := nullDecimalFromPb(o.StitchesPerCm)
 		if err != nil {
@@ -97,14 +113,26 @@ func parseTechCardOperations(pbs []*pb_common.TechCardOperation) ([]entity.TechC
 		if err := validateDecimalScale(stitches, "operation stitches_per_cm", stitchFrac, stitchLimit); err != nil {
 			return nil, err
 		}
+		timeNorm, err := nullDecimalFromPb(o.TimeNorm)
+		if err != nil {
+			return nil, fmt.Errorf("operation time_norm: %w", err)
+		}
+		if err := validateDecimalScale(timeNorm, "operation time_norm", 3, 10_000); err != nil {
+			return nil, err
+		}
 		out = append(out, entity.TechCardOperation{
-			Node:           o.Node,
-			Description:    nullStringFromPb(o.Description),
-			SeamType:       nullStringFromPb(o.SeamType),
-			StitchesPerCm:  stitches,
-			TopstitchWidth: nullStringFromPb(o.TopstitchWidth),
-			Thread:         nullStringFromPb(o.Thread),
-			Note:           nullStringFromPb(o.Note),
+			OperationNumber: nullInt32FromPb(o.OperationNumber),
+			Node:            o.Node,
+			Description:     nullStringFromPb(o.Description),
+			SeamType:        nullStringFromPb(o.SeamType),
+			Machine:         nullStringFromPb(o.Machine),
+			StitchesPerCm:   stitches,
+			TopstitchWidth:  nullStringFromPb(o.TopstitchWidth),
+			SeamAllowance:   nullStringFromPb(o.SeamAllowance),
+			Thread:          nullStringFromPb(o.Thread),
+			Needle:          nullStringFromPb(o.Needle),
+			TimeNorm:        timeNorm,
+			Note:            nullStringFromPb(o.Note),
 		})
 	}
 	return out, nil
@@ -267,14 +295,16 @@ func techCardConstructionToPb(c *entity.TechCardConstruction) *pb_common.TechCar
 		return nil
 	}
 	return &pb_common.TechCardConstruction{
-		MainStitchType:  pbStringFromNull(c.MainStitchType),
-		StitchDensity:   pbStringFromNull(c.StitchDensity),
-		OverlockThreads: pbStringFromNull(c.OverlockThreads),
-		SeamAllowances:  pbStringFromNull(c.SeamAllowances),
-		HemFinish:       pbStringFromNull(c.HemFinish),
-		Pressing:        pbStringFromNull(c.Pressing),
-		MachineClass:    pbStringFromNull(c.MachineClass),
-		Notes:           pbStringFromNull(c.Notes),
+		MainStitchType:     pbStringFromNull(c.MainStitchType),
+		StitchDensity:      pbStringFromNull(c.StitchDensity),
+		OverlockThreads:    pbStringFromNull(c.OverlockThreads),
+		SeamAllowances:     pbStringFromNull(c.SeamAllowances),
+		HemFinish:          pbStringFromNull(c.HemFinish),
+		Pressing:           pbStringFromNull(c.Pressing),
+		MachineClass:       pbStringFromNull(c.MachineClass),
+		Notes:              pbStringFromNull(c.Notes),
+		LabourRate:         pbDecimalFromNull(c.LabourRate),
+		LabourRateCurrency: pbStringFromNull(c.LabourRateCurrency),
 	}
 }
 
@@ -282,13 +312,103 @@ func techCardOperationsToPb(ops []entity.TechCardOperation) []*pb_common.TechCar
 	out := make([]*pb_common.TechCardOperation, 0, len(ops))
 	for _, o := range ops {
 		out = append(out, &pb_common.TechCardOperation{
-			Node:           o.Node,
-			Description:    pbStringFromNull(o.Description),
-			SeamType:       pbStringFromNull(o.SeamType),
-			StitchesPerCm:  pbDecimalFromNull(o.StitchesPerCm),
-			TopstitchWidth: pbStringFromNull(o.TopstitchWidth),
-			Thread:         pbStringFromNull(o.Thread),
-			Note:           pbStringFromNull(o.Note),
+			OperationNumber: pbInt32FromNull(o.OperationNumber),
+			Node:            o.Node,
+			Description:     pbStringFromNull(o.Description),
+			SeamType:        pbStringFromNull(o.SeamType),
+			Machine:         pbStringFromNull(o.Machine),
+			StitchesPerCm:   pbDecimalFromNull(o.StitchesPerCm),
+			TopstitchWidth:  pbStringFromNull(o.TopstitchWidth),
+			SeamAllowance:   pbStringFromNull(o.SeamAllowance),
+			Thread:          pbStringFromNull(o.Thread),
+			Needle:          pbStringFromNull(o.Needle),
+			TimeNorm:        pbDecimalFromNull(o.TimeNorm),
+			Note:            pbStringFromNull(o.Note),
+		})
+	}
+	return out
+}
+
+// --- issues (Phase 3.5b) ---
+
+var techCardIssueSeverityPbToEntity = map[pb_common.TechCardIssueSeverity]entity.TechCardIssueSeverity{
+	pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_LOW:    entity.IssueSeverityLow,
+	pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_MEDIUM: entity.IssueSeverityMedium,
+	pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_HIGH:   entity.IssueSeverityHigh,
+}
+var techCardIssueSeverityEntityToPb = func() map[entity.TechCardIssueSeverity]pb_common.TechCardIssueSeverity {
+	m := make(map[entity.TechCardIssueSeverity]pb_common.TechCardIssueSeverity, len(techCardIssueSeverityPbToEntity))
+	for k, v := range techCardIssueSeverityPbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
+var techCardIssueStatusPbToEntity = map[pb_common.TechCardIssueStatus]entity.TechCardIssueStatus{
+	pb_common.TechCardIssueStatus_TECH_CARD_ISSUE_STATUS_OPEN:     entity.IssueStatusOpen,
+	pb_common.TechCardIssueStatus_TECH_CARD_ISSUE_STATUS_RESOLVED: entity.IssueStatusResolved,
+	pb_common.TechCardIssueStatus_TECH_CARD_ISSUE_STATUS_WONTFIX:  entity.IssueStatusWontfix,
+}
+var techCardIssueStatusEntityToPb = func() map[entity.TechCardIssueStatus]pb_common.TechCardIssueStatus {
+	m := make(map[entity.TechCardIssueStatus]pb_common.TechCardIssueStatus, len(techCardIssueStatusPbToEntity))
+	for k, v := range techCardIssueStatusPbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
+func parseTechCardIssues(pbs []*pb_common.TechCardIssue) ([]entity.TechCardIssue, error) {
+	out := make([]entity.TechCardIssue, 0, len(pbs))
+	for _, i := range pbs {
+		if i.Description == "" {
+			return nil, fmt.Errorf("issue description is required")
+		}
+		if i.OperationNumber < 0 || i.CalloutNumber < 0 {
+			return nil, fmt.Errorf("issue operation_number/callout_number must not be negative")
+		}
+		if len(i.RaisedBy) > maxVarchar255 {
+			return nil, fmt.Errorf("issue raised_by must be at most %d characters", maxVarchar255)
+		}
+		severity := entity.IssueSeverityMedium
+		if i.Severity != pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_UNKNOWN {
+			s, ok := techCardIssueSeverityPbToEntity[i.Severity]
+			if !ok {
+				return nil, fmt.Errorf("unknown issue severity: %v", i.Severity)
+			}
+			severity = s
+		}
+		st := entity.IssueStatusOpen
+		if i.Status != pb_common.TechCardIssueStatus_TECH_CARD_ISSUE_STATUS_UNKNOWN {
+			v, ok := techCardIssueStatusPbToEntity[i.Status]
+			if !ok {
+				return nil, fmt.Errorf("unknown issue status: %v", i.Status)
+			}
+			st = v
+		}
+		out = append(out, entity.TechCardIssue{
+			OperationNumber: nullInt32FromPb(i.OperationNumber),
+			CalloutNumber:   nullInt32FromPb(i.CalloutNumber),
+			RaisedBy:        nullStringFromPb(i.RaisedBy),
+			Severity:        severity,
+			Status:          st,
+			Description:     i.Description,
+			ResolutionNote:  nullStringFromPb(i.ResolutionNote),
+		})
+	}
+	return out, nil
+}
+
+func techCardIssuesToPb(issues []entity.TechCardIssue) []*pb_common.TechCardIssue {
+	out := make([]*pb_common.TechCardIssue, 0, len(issues))
+	for _, i := range issues {
+		out = append(out, &pb_common.TechCardIssue{
+			OperationNumber: pbInt32FromNull(i.OperationNumber),
+			CalloutNumber:   pbInt32FromNull(i.CalloutNumber),
+			RaisedBy:        pbStringFromNull(i.RaisedBy),
+			Severity:        techCardIssueSeverityEntityToPb[i.Severity],
+			Status:          techCardIssueStatusEntityToPb[i.Status],
+			Description:     i.Description,
+			ResolutionNote:  pbStringFromNull(i.ResolutionNote),
 		})
 	}
 	return out
@@ -377,6 +497,20 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 		if b.Currency.Valid && b.Currency.String != "" && b.Currency.String != costingCcy && b.LineTotal().Valid {
 			out.HasUnconvertedCurrencies = true
 			break
+		}
+	}
+
+	// total_sam = Σ(operation time_norm); labour_cost = total_sam × labour_rate.
+	totalSam := decimal.Zero
+	for i := range tc.Operations {
+		if tc.Operations[i].TimeNorm.Valid {
+			totalSam = totalSam.Add(tc.Operations[i].TimeNorm.Decimal)
+		}
+	}
+	if totalSam.IsPositive() {
+		out.TotalSam = pbDecimalFromDecimal(totalSam.Round(3))
+		if tc.Construction != nil && tc.Construction.LabourRate.Valid {
+			out.LabourCost = pbDecimalFromDecimal(totalSam.Mul(tc.Construction.LabourRate.Decimal).Round(costMaxFrac))
 		}
 	}
 	return out

--- a/internal/dto/techcard_production.go
+++ b/internal/dto/techcard_production.go
@@ -414,6 +414,87 @@ func techCardIssuesToPb(issues []entity.TechCardIssue) []*pb_common.TechCardIssu
 	return out
 }
 
+// --- sign-off (Phase 3.5a-2) ---
+
+var techCardSignoffSectionPbToEntity = map[pb_common.TechCardSignoffSection]entity.TechCardSignoffSection{
+	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_DESIGN:       entity.SignoffDesign,
+	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_CONSTRUCTION: entity.SignoffConstruction,
+	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_POM:          entity.SignoffPom,
+	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_MATERIALS:    entity.SignoffMaterials,
+	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COLOUR:       entity.SignoffColour,
+	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_LABELS:       entity.SignoffLabels,
+	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_PACKAGING:    entity.SignoffPackaging,
+	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COSTING:      entity.SignoffCosting,
+}
+var techCardSignoffSectionEntityToPb = func() map[entity.TechCardSignoffSection]pb_common.TechCardSignoffSection {
+	m := make(map[entity.TechCardSignoffSection]pb_common.TechCardSignoffSection, len(techCardSignoffSectionPbToEntity))
+	for k, v := range techCardSignoffSectionPbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
+var techCardSignoffStatePbToEntity = map[pb_common.TechCardSignoffState]entity.TechCardSignoffState{
+	pb_common.TechCardSignoffState_TECH_CARD_SIGNOFF_STATE_PENDING:  entity.SignoffStatePending,
+	pb_common.TechCardSignoffState_TECH_CARD_SIGNOFF_STATE_APPROVED: entity.SignoffStateApproved,
+	pb_common.TechCardSignoffState_TECH_CARD_SIGNOFF_STATE_REJECTED: entity.SignoffStateRejected,
+}
+var techCardSignoffStateEntityToPb = func() map[entity.TechCardSignoffState]pb_common.TechCardSignoffState {
+	m := make(map[entity.TechCardSignoffState]pb_common.TechCardSignoffState, len(techCardSignoffStatePbToEntity))
+	for k, v := range techCardSignoffStatePbToEntity {
+		m[v] = k
+	}
+	return m
+}()
+
+func parseTechCardSignoffs(pbs []*pb_common.TechCardSignoff) ([]entity.TechCardSignoff, error) {
+	out := make([]entity.TechCardSignoff, 0, len(pbs))
+	seen := make(map[entity.TechCardSignoffSection]bool, len(pbs))
+	for _, s := range pbs {
+		section, ok := techCardSignoffSectionPbToEntity[s.Section]
+		if !ok {
+			return nil, fmt.Errorf("signoff section is required and must be valid")
+		}
+		if seen[section] {
+			return nil, fmt.Errorf("duplicate signoff for section %q", section)
+		}
+		seen[section] = true
+		if len(s.SignedBy) > maxVarchar255 {
+			return nil, fmt.Errorf("signoff signed_by must be at most %d characters", maxVarchar255)
+		}
+		state := entity.SignoffStatePending
+		if s.State != pb_common.TechCardSignoffState_TECH_CARD_SIGNOFF_STATE_UNKNOWN {
+			v, ok := techCardSignoffStatePbToEntity[s.State]
+			if !ok {
+				return nil, fmt.Errorf("unknown signoff state: %v", s.State)
+			}
+			state = v
+		}
+		out = append(out, entity.TechCardSignoff{
+			Section:  section,
+			State:    state,
+			SignedBy: nullStringFromPb(s.SignedBy),
+			SignedAt: nullTimeFromPbTimestamp(s.SignedAt),
+			Note:     nullStringFromPb(s.Note),
+		})
+	}
+	return out, nil
+}
+
+func techCardSignoffsToPb(signoffs []entity.TechCardSignoff) []*pb_common.TechCardSignoff {
+	out := make([]*pb_common.TechCardSignoff, 0, len(signoffs))
+	for _, s := range signoffs {
+		out = append(out, &pb_common.TechCardSignoff{
+			Section:  techCardSignoffSectionEntityToPb[s.Section],
+			State:    techCardSignoffStateEntityToPb[s.State],
+			SignedBy: pbStringFromNull(s.SignedBy),
+			SignedAt: pbTimestampFromNullTime(s.SignedAt),
+			Note:     pbStringFromNull(s.Note),
+		})
+	}
+	return out
+}
+
 func techCardLabelsToPb(labels []entity.TechCardLabel) []*pb_common.TechCardLabel {
 	out := make([]*pb_common.TechCardLabel, 0, len(labels))
 	for _, l := range labels {

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -131,6 +131,10 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 		"neg cost":          {StyleNumber: "x", Name: "y", TargetCost: &pb_decimal.Decimal{Value: "-1"}},
 		"cost overflow":     {StyleNumber: "x", Name: "y", TargetCost: &pb_decimal.Decimal{Value: "100000000"}},
 		"cost decimals":     {StyleNumber: "x", Name: "y", TargetRetailPrice: &pb_decimal.Decimal{Value: "1.999"}},
+		"dup colorway code": {StyleNumber: "x", Name: "y", Colorways: []*pb_common.TechCardColorway{{Name: "a", Code: "BLK"}, {Name: "b", Code: "BLK"}}},
+		"release unapproved": {StyleNumber: "x", Name: "y",
+			ApprovalState: pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_RELEASED,
+			Colorways:     []*pb_common.TechCardColorway{{Name: "Black"}}}, // lab dip defaults to pending
 	}
 	for name, in := range bad {
 		if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -132,6 +132,8 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 		"cost overflow":     {StyleNumber: "x", Name: "y", TargetCost: &pb_decimal.Decimal{Value: "100000000"}},
 		"cost decimals":     {StyleNumber: "x", Name: "y", TargetRetailPrice: &pb_decimal.Decimal{Value: "1.999"}},
 		"dup colorway code": {StyleNumber: "x", Name: "y", Colorways: []*pb_common.TechCardColorway{{Name: "a", Code: "BLK"}, {Name: "b", Code: "BLK"}}},
+		"bad hex":           {StyleNumber: "x", Name: "y", Colorways: []*pb_common.TechCardColorway{{Name: "a", Hex: "red"}}},
+		"bad pantone sys":   {StyleNumber: "x", Name: "y", Colorways: []*pb_common.TechCardColorway{{Name: "a", PantoneSystem: "XXX"}}},
 		"release unapproved": {StyleNumber: "x", Name: "y",
 			ApprovalState: pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_RELEASED,
 			Colorways:     []*pb_common.TechCardColorway{{Name: "Black"}}}, // lab dip defaults to pending
@@ -460,7 +462,7 @@ func TestConvertTechCardOperationsAndIssues(t *testing.T) {
 		Name:         "Jacket",
 		Construction: &pb_common.TechCardConstruction{LabourRate: dec("0.5"), LabourRateCurrency: "EUR"},
 		Operations: []*pb_common.TechCardOperation{
-			{Node: "collar", OperationNumber: 10, Machine: "lockstitch", SeamAllowance: "1.0", Needle: "90/14", TimeNorm: dec("2")},
+			{Node: "collar", OperationNumber: 10, Machine: "lockstitch", SeamAllowance: "1.0", Needle: "90/14", Attachment: "binder", TimeNorm: dec("2")},
 			{Node: "side", OperationNumber: 20, TimeNorm: dec("3")},
 		},
 		Costing: &pb_common.TechCardCosting{Currency: "EUR"},
@@ -473,7 +475,7 @@ func TestConvertTechCardOperationsAndIssues(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(got.Operations) != 2 || !got.Operations[0].OperationNumber.Valid || got.Operations[0].OperationNumber.Int32 != 10 ||
-		got.Operations[0].Machine.String != "lockstitch" || !got.Operations[0].TimeNorm.Valid {
+		got.Operations[0].Machine.String != "lockstitch" || got.Operations[0].Attachment.String != "binder" || !got.Operations[0].TimeNorm.Valid {
 		t.Errorf("operations mismatch: %+v", got.Operations)
 	}
 	if len(got.Issues) != 1 || got.Issues[0].Severity != entity.IssueSeverityHigh || got.Issues[0].Status != entity.IssueStatusOpen {

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -570,6 +570,42 @@ func TestConvertTechCardMaterialsDepth(t *testing.T) {
 	}
 }
 
+func TestConvertTechCardSignoffs(t *testing.T) {
+	in := &pb_common.TechCardInsert{
+		StyleNumber: "ST-050", Name: "Tee",
+		Signoffs: []*pb_common.TechCardSignoff{
+			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COSTING, State: pb_common.TechCardSignoffState_TECH_CARD_SIGNOFF_STATE_APPROVED, SignedBy: "finance"},
+			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COLOUR},
+		},
+	}
+	got, err := ConvertPbTechCardInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Signoffs) != 2 || got.Signoffs[0].Section != entity.SignoffCosting || got.Signoffs[0].State != entity.SignoffStateApproved {
+		t.Errorf("signoffs mismatch: %+v", got.Signoffs)
+	}
+	if got.Signoffs[1].State != entity.SignoffStatePending {
+		t.Errorf("signoff default state mismatch: %+v", got.Signoffs[1])
+	}
+	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
+	if len(pb.TechCard.Signoffs) != 2 || pb.TechCard.Signoffs[0].Section != pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COSTING {
+		t.Errorf("pb signoffs mismatch: %+v", pb.TechCard.Signoffs)
+	}
+
+	bad := map[string]*pb_common.TechCardInsert{
+		"signoff no section": {StyleNumber: "x", Name: "y", Signoffs: []*pb_common.TechCardSignoff{{SignedBy: "x"}}},
+		"signoff dup section": {StyleNumber: "x", Name: "y", Signoffs: []*pb_common.TechCardSignoff{
+			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_POM},
+			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_POM}}},
+	}
+	for name, bi := range bad {
+		if _, err := ConvertPbTechCardInsertToEntity(bi); err == nil {
+			t.Errorf("case %q: expected error, got nil", name)
+		}
+	}
+}
+
 // ListItem conversion produces a lightweight header.
 func TestConvertEntityTechCardToListItemPb(t *testing.T) {
 	tc := &entity.TechCard{

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -502,6 +502,74 @@ func TestConvertTechCardOperationsAndIssues(t *testing.T) {
 	}
 }
 
+func TestConvertTechCardMaterialsDepth(t *testing.T) {
+	dec := func(s string) *pb_decimal.Decimal { return &pb_decimal.Decimal{Value: s} }
+	ts := timestamppb.New(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	in := &pb_common.TechCardInsert{
+		StyleNumber: "ST-040",
+		Name:        "Parka",
+		SizeIds:     []int32{4, 5},
+		SizeQuantities: []*pb_common.TechCardSizeQuantity{
+			{SizeId: 4, OrderQty: 120}, {SizeId: 5, OrderQty: 80},
+		},
+		Media: []*pb_common.TechCardMediaItem{
+			{MediaId: 11, Kind: pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_MOODBOARD, Caption: "AW vibe"},
+		},
+		Callouts: []*pb_common.TechCardCallout{{Number: 1, PosX: dec("0.5"), PosY: dec("0.25")}},
+		Colorways: []*pb_common.TechCardColorway{
+			{Name: "Black", Pantone: "19-4005", PantoneSystem: "TCX", Hex: "#101010", LabDipRound: 2, SwatchMediaId: 11, LabDipDecidedBy: "colorist", LabDipDecidedAt: ts},
+		},
+		BomItems: []*pb_common.TechCardBomItem{
+			{
+				Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "shell",
+				Quantity: dec("2"), UnitPrice: dec("10"), Currency: "EUR", WastagePercent: dec("10"),
+				FabricWidth: dec("150"), FabricDirection: pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_ONE_WAY,
+			},
+		},
+	}
+	got, err := ConvertPbTechCardInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.SizeQuantities) != 2 || got.SizeQuantities[0].OrderQty != 120 {
+		t.Errorf("size_quantities mismatch: %+v", got.SizeQuantities)
+	}
+	if got.Media[0].Caption.String != "AW vibe" || got.Media[0].Kind != entity.TechCardMediaMoodboard {
+		t.Errorf("media caption/kind mismatch: %+v", got.Media[0])
+	}
+	if !got.Callouts[0].PosX.Valid || got.BomItems[0].FabricDirection.String != string(entity.FabricDirectionOneWay) {
+		t.Errorf("callout/fabric mismatch: %+v %+v", got.Callouts[0], got.BomItems[0])
+	}
+	if got.Colorways[0].Pantone.String != "19-4005" || got.Colorways[0].LabDipRound.Int32 != 2 {
+		t.Errorf("colorway lab-dip mismatch: %+v", got.Colorways[0])
+	}
+	// line_total grossed up by 10% wastage: 2 * 10 * 1.1 = 22.
+	if lt := got.BomItems[0].LineTotal(); !lt.Valid || !lt.Decimal.Equal(decimal.RequireFromString("22")) {
+		t.Errorf("line_total with wastage mismatch: %+v", lt)
+	}
+
+	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
+	if pb.TechCard.BomItems[0].LineTotal.Value != "22" ||
+		pb.TechCard.BomItems[0].FabricDirection != pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_ONE_WAY {
+		t.Errorf("pb bom mismatch: %+v", pb.TechCard.BomItems[0])
+	}
+	if len(pb.TechCard.SizeQuantities) != 2 || pb.TechCard.Colorways[0].Pantone != "19-4005" || pb.TechCard.Media[0].Caption != "AW vibe" {
+		t.Errorf("pb depth fields mismatch")
+	}
+
+	bad := map[string]*pb_common.TechCardInsert{
+		"wastage over 100": {StyleNumber: "x", Name: "y", BomItems: []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "m", WastagePercent: dec("150")}}},
+		"size qty not in range": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
+			SizeQuantities: []*pb_common.TechCardSizeQuantity{{SizeId: 9, OrderQty: 1}}},
+		"callout pos out of range": {StyleNumber: "x", Name: "y", Callouts: []*pb_common.TechCardCallout{{Number: 1, PosX: dec("2")}}},
+	}
+	for name, bi := range bad {
+		if _, err := ConvertPbTechCardInsertToEntity(bi); err == nil {
+			t.Errorf("case %q: expected error, got nil", name)
+		}
+	}
+}
+
 // ListItem conversion produces a lightweight header.
 func TestConvertEntityTechCardToListItemPb(t *testing.T) {
 	tc := &entity.TechCard{

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -453,6 +453,55 @@ func TestConvertTechCardPomActualVerdict(t *testing.T) {
 	}
 }
 
+func TestConvertTechCardOperationsAndIssues(t *testing.T) {
+	dec := func(s string) *pb_decimal.Decimal { return &pb_decimal.Decimal{Value: s} }
+	in := &pb_common.TechCardInsert{
+		StyleNumber:  "ST-030",
+		Name:         "Jacket",
+		Construction: &pb_common.TechCardConstruction{LabourRate: dec("0.5"), LabourRateCurrency: "EUR"},
+		Operations: []*pb_common.TechCardOperation{
+			{Node: "collar", OperationNumber: 10, Machine: "lockstitch", SeamAllowance: "1.0", Needle: "90/14", TimeNorm: dec("2")},
+			{Node: "side", OperationNumber: 20, TimeNorm: dec("3")},
+		},
+		Costing: &pb_common.TechCardCosting{Currency: "EUR"},
+		Issues: []*pb_common.TechCardIssue{
+			{OperationNumber: 10, Severity: pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_HIGH, Description: "collar too tight to turn"},
+		},
+	}
+	got, err := ConvertPbTechCardInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Operations) != 2 || !got.Operations[0].OperationNumber.Valid || got.Operations[0].OperationNumber.Int32 != 10 ||
+		got.Operations[0].Machine.String != "lockstitch" || !got.Operations[0].TimeNorm.Valid {
+		t.Errorf("operations mismatch: %+v", got.Operations)
+	}
+	if len(got.Issues) != 1 || got.Issues[0].Severity != entity.IssueSeverityHigh || got.Issues[0].Status != entity.IssueStatusOpen {
+		t.Errorf("issues mismatch: %+v", got.Issues)
+	}
+
+	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
+	cost := pb.TechCard.Costing
+	if cost == nil || cost.TotalSam == nil || cost.TotalSam.Value != "5" {
+		t.Errorf("total_sam mismatch: %+v", cost.GetTotalSam())
+	}
+	if cost.LabourCost == nil || cost.LabourCost.Value != "2.5" {
+		t.Errorf("labour_cost mismatch: %+v", cost.GetLabourCost())
+	}
+	if len(pb.TechCard.Operations) != 2 || pb.TechCard.Operations[0].OperationNumber != 10 {
+		t.Errorf("pb operations mismatch: %+v", pb.TechCard.Operations)
+	}
+	if len(pb.TechCard.Issues) != 1 || pb.TechCard.Issues[0].Severity != pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_HIGH {
+		t.Errorf("pb issues mismatch: %+v", pb.TechCard.Issues)
+	}
+
+	// issue without a description is rejected.
+	if _, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{StyleNumber: "x", Name: "y",
+		Issues: []*pb_common.TechCardIssue{{Severity: pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_LOW}}}); err == nil {
+		t.Errorf("expected error for issue without description")
+	}
+}
+
 // ListItem conversion produces a lightweight header.
 func TestConvertEntityTechCardToListItemPb(t *testing.T) {
 	tc := &entity.TechCard{

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -388,6 +388,10 @@ func TestConvertTechCardProductionAndCosting(t *testing.T) {
 	if byCcy["EUR"] != "25" || byCcy["USD"] != "3" {
 		t.Errorf("materials_total mismatch: %+v", byCcy)
 	}
+	// USD line against EUR costing → excluded from total_cost, flag must be set.
+	if !cost.HasUnconvertedCurrencies {
+		t.Errorf("expected has_unconverted_currencies (USD BOM line vs EUR costing)")
+	}
 
 	// invalid cases.
 	bad := map[string]*pb_common.TechCardInsert{
@@ -402,6 +406,50 @@ func TestConvertTechCardProductionAndCosting(t *testing.T) {
 		if _, err := ConvertPbTechCardInsertToEntity(bi); err == nil {
 			t.Errorf("case %q: expected error, got nil", name)
 		}
+	}
+}
+
+func TestConvertTechCardPomActualVerdict(t *testing.T) {
+	dec := func(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+	nd := func(s string) decimal.NullDecimal { return decimal.NullDecimal{Decimal: dec(s), Valid: true} }
+	pt := entity.TechCardPomPoint{
+		Name:           "Chest",
+		BaseValue:      nd("50"),
+		TolerancePlus:  nd("1"),
+		ToleranceMinus: nd("1"),
+		Grades: []entity.TechCardPomGrade{
+			{SizeId: 4, Value: dec("54")},
+			{SizeId: 5, Value: dec("56")},
+		},
+		Actuals: []entity.TechCardPomActual{
+			{SizeId: nullInt32FromPb(4), Value: dec("54.5")}, // in tolerance (54 ± 1)
+			{SizeId: nullInt32FromPb(4), Value: dec("55.5")}, // over (> 55)
+			{SizeId: nullInt32FromPb(4), Value: dec("52.5")}, // under (< 53)
+			{Value: dec("50")}, // no size → base 50, in tolerance
+			{SizeId: nullInt32FromPb(99), Value: dec("70")}, // size w/o grade → base 50 → over
+		},
+	}
+	tc := &entity.TechCard{
+		Id:             1,
+		TechCardInsert: entity.TechCardInsert{StyleNumber: "x", Name: "y", PomPoints: []entity.TechCardPomPoint{pt}},
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	acts := ConvertEntityTechCardToPb(tc).TechCard.PomPoints[0].Actuals
+	want := []pb_common.TechCardPomVerdict{
+		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_IN_TOLERANCE,
+		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_OVER,
+		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_UNDER,
+		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_IN_TOLERANCE,
+		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_OVER,
+	}
+	for i, w := range want {
+		if acts[i].Verdict != w {
+			t.Errorf("actual %d verdict = %v, want %v", i, acts[i].Verdict, w)
+		}
+	}
+	if acts[0].Deviation == nil || acts[0].Deviation.Value != "0.5" {
+		t.Errorf("actual 0 deviation = %+v, want 0.5", acts[0].Deviation)
 	}
 }
 

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -426,7 +426,7 @@ func TestConvertTechCardPomActualVerdict(t *testing.T) {
 			{SizeId: nullInt32FromPb(4), Value: dec("55.5")}, // over (> 55)
 			{SizeId: nullInt32FromPb(4), Value: dec("52.5")}, // under (< 53)
 			{Value: dec("50")}, // no size → base 50, in tolerance
-			{SizeId: nullInt32FromPb(99), Value: dec("70")}, // size w/o grade → base 50 → over
+			{SizeId: nullInt32FromPb(99), Value: dec("70")}, // size set but ungraded → UNKNOWN (no cross-size fallback)
 		},
 	}
 	tc := &entity.TechCard{
@@ -441,7 +441,7 @@ func TestConvertTechCardPomActualVerdict(t *testing.T) {
 		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_OVER,
 		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_UNDER,
 		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_IN_TOLERANCE,
-		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_OVER,
+		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_UNKNOWN,
 	}
 	for i, w := range want {
 		if acts[i].Verdict != w {
@@ -488,6 +488,10 @@ func TestConvertTechCardOperationsAndIssues(t *testing.T) {
 	if cost.LabourCost == nil || cost.LabourCost.Value != "2.5" {
 		t.Errorf("labour_cost mismatch: %+v", cost.GetLabourCost())
 	}
+	// no cmt_cost + same currency → computed labour folds into total_cost as the make cost.
+	if cost.TotalCost == nil || cost.TotalCost.Value != "2.5" {
+		t.Errorf("total_cost should include folded labour: %+v", cost.GetTotalCost())
+	}
 	if len(pb.TechCard.Operations) != 2 || pb.TechCard.Operations[0].OperationNumber != 10 {
 		t.Errorf("pb operations mismatch: %+v", pb.TechCard.Operations)
 	}
@@ -499,6 +503,12 @@ func TestConvertTechCardOperationsAndIssues(t *testing.T) {
 	if _, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{StyleNumber: "x", Name: "y",
 		Issues: []*pb_common.TechCardIssue{{Severity: pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_LOW}}}); err == nil {
 		t.Errorf("expected error for issue without description")
+	}
+
+	// releasing while a high-severity issue is still open is blocked.
+	in.ApprovalState = pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_RELEASED
+	if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {
+		t.Errorf("expected release to be blocked by an open high-severity issue")
 	}
 }
 

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -2,10 +2,19 @@ package entity
 
 import (
 	"database/sql"
+	"errors"
 	"time"
 
 	"github.com/shopspring/decimal"
 )
+
+// ErrTechCardConflict is returned by UpdateTechCard when the caller's
+// expected_lock_version no longer matches the stored one (a concurrent edit).
+var ErrTechCardConflict = errors.New("tech card was modified concurrently")
+
+// ErrTechCardReleased is returned when content of a RELEASED tech card is edited
+// without first re-opening it to DRAFT (a released card is frozen for the factory).
+var ErrTechCardReleased = errors.New("tech card is released and frozen; re-open to draft to edit")
 
 // TechCardStage is the development stage of a tech card. It mirrors the
 // common.TechCardStage proto enum and is stored as a string in tech_card.stage.
@@ -257,9 +266,11 @@ type TechCardPomGrade struct {
 	Value  decimal.Decimal `db:"value"`
 }
 
-// TechCardPomActual is an actual measured value, optionally from a fitting.
+// TechCardPomActual is an actual measured value, optionally from a fitting and at
+// a specific size (so it can be compared to that size's grade ± tolerance).
 type TechCardPomActual struct {
 	FittingId sql.NullInt32   `db:"fitting_id"`
+	SizeId    sql.NullInt32   `db:"size_id"`
 	Label     sql.NullString  `db:"label"`
 	Value     decimal.Decimal `db:"value"`
 }
@@ -387,6 +398,7 @@ type TechCardInsert struct {
 	Status            sql.NullString          `db:"status"`
 	ApprovalState     TechCardApprovalState   `db:"approval_state"`
 	ApprovedBy        sql.NullString          `db:"approved_by"`
+	ApprovedAt        sql.NullTime            `db:"approved_at"`
 	ReleasedAt        sql.NullTime            `db:"released_at"`
 	Version           sql.NullString          `db:"version"`
 	RevisionDate      sql.NullTime            `db:"revision_date"`
@@ -401,6 +413,7 @@ type TechCardInsert struct {
 	MeasurementUnit   TechCardMeasurementUnit `db:"measurement_unit"`
 	// construction description
 	Description  sql.NullString `db:"description"`
+	Concept      sql.NullString `db:"concept"`
 	Silhouette   sql.NullString `db:"silhouette"`
 	Collar       sql.NullString `db:"collar"`
 	Fastening    sql.NullString `db:"fastening"`
@@ -441,7 +454,8 @@ type TechCardListFilter struct {
 
 // TechCard is a stored tech card (tech_card row + child sections + resolved media).
 type TechCard struct {
-	Id int `db:"id"`
+	Id          int `db:"id"`
+	LockVersion int `db:"lock_version"`
 	TechCardInsert
 	CreatedAt time.Time `db:"created_at"`
 	UpdatedAt time.Time `db:"updated_at"`

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -331,17 +331,61 @@ type TechCardConstruction struct {
 	Pressing        sql.NullString `db:"pressing"`
 	MachineClass    sql.NullString `db:"machine_class"`
 	Notes           sql.NullString `db:"notes"`
+	// labour rate (Phase 3.5b): per-minute cost; × Σ(operation SAM) = labour cost.
+	LabourRate         decimal.NullDecimal `db:"labour_rate"`
+	LabourRateCurrency sql.NullString      `db:"labour_rate_currency"`
 }
 
 // TechCardOperation is one per-node sewing operation (Sheet «Обработка»).
 type TechCardOperation struct {
-	Node           string              `db:"node"`
-	Description    sql.NullString      `db:"description"`
-	SeamType       sql.NullString      `db:"seam_type"`
-	StitchesPerCm  decimal.NullDecimal `db:"stitches_per_cm"`
-	TopstitchWidth sql.NullString      `db:"topstitch_width"`
-	Thread         sql.NullString      `db:"thread"`
-	Note           sql.NullString      `db:"note"`
+	OperationNumber sql.NullInt32       `db:"operation_number"`
+	Node            string              `db:"node"`
+	Description     sql.NullString      `db:"description"`
+	SeamType        sql.NullString      `db:"seam_type"`
+	Machine         sql.NullString      `db:"machine"`
+	StitchesPerCm   decimal.NullDecimal `db:"stitches_per_cm"`
+	TopstitchWidth  sql.NullString      `db:"topstitch_width"`
+	SeamAllowance   sql.NullString      `db:"seam_allowance"`
+	Thread          sql.NullString      `db:"thread"`
+	Needle          sql.NullString      `db:"needle"`
+	TimeNorm        decimal.NullDecimal `db:"time_norm"`
+	Note            sql.NullString      `db:"note"`
+}
+
+// TechCardIssueSeverity / TechCardIssueStatus classify a maker-flagged issue.
+type TechCardIssueSeverity string
+
+const (
+	IssueSeverityLow    TechCardIssueSeverity = "low"
+	IssueSeverityMedium TechCardIssueSeverity = "medium"
+	IssueSeverityHigh   TechCardIssueSeverity = "high"
+)
+
+var ValidTechCardIssueSeverities = map[TechCardIssueSeverity]bool{
+	IssueSeverityLow: true, IssueSeverityMedium: true, IssueSeverityHigh: true,
+}
+
+type TechCardIssueStatus string
+
+const (
+	IssueStatusOpen     TechCardIssueStatus = "open"
+	IssueStatusResolved TechCardIssueStatus = "resolved"
+	IssueStatusWontfix  TechCardIssueStatus = "wontfix"
+)
+
+var ValidTechCardIssueStatuses = map[TechCardIssueStatus]bool{
+	IssueStatusOpen: true, IssueStatusResolved: true, IssueStatusWontfix: true,
+}
+
+// TechCardIssue is a maker-flagged construction problem (Sheet «Обработка»).
+type TechCardIssue struct {
+	OperationNumber sql.NullInt32         `db:"operation_number"`
+	CalloutNumber   sql.NullInt32         `db:"callout_number"`
+	RaisedBy        sql.NullString        `db:"raised_by"`
+	Severity        TechCardIssueSeverity `db:"severity"`
+	Status          TechCardIssueStatus   `db:"status"`
+	Description     string                `db:"description"`
+	ResolutionNote  sql.NullString        `db:"resolution_note"`
 }
 
 // TechCardLabel is one label/tag spec (Sheet «Этикетки и упаковка»).
@@ -439,6 +483,7 @@ type TechCardInsert struct {
 	Labels       []TechCardLabel       `db:"-"`
 	Packaging    *TechCardPackaging    `db:"-"`
 	Costing      *TechCardCosting      `db:"-"`
+	Issues       []TechCardIssue       `db:"-"`
 }
 
 // TechCardListFilter holds optional filters for listing tech cards. Empty/zero

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -395,6 +395,7 @@ type TechCardOperation struct {
 	SeamAllowance   sql.NullString      `db:"seam_allowance"`
 	Thread          sql.NullString      `db:"thread"`
 	Needle          sql.NullString      `db:"needle"`
+	Attachment      sql.NullString      `db:"attachment"`
 	TimeNorm        decimal.NullDecimal `db:"time_norm"`
 	Note            sql.NullString      `db:"note"`
 }

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -435,6 +435,46 @@ type TechCardIssue struct {
 	ResolutionNote  sql.NullString        `db:"resolution_note"`
 }
 
+// TechCardSignoffSection / TechCardSignoffState classify a per-section sign-off.
+type TechCardSignoffSection string
+
+const (
+	SignoffDesign       TechCardSignoffSection = "design"
+	SignoffConstruction TechCardSignoffSection = "construction"
+	SignoffPom          TechCardSignoffSection = "pom"
+	SignoffMaterials    TechCardSignoffSection = "materials"
+	SignoffColour       TechCardSignoffSection = "colour"
+	SignoffLabels       TechCardSignoffSection = "labels"
+	SignoffPackaging    TechCardSignoffSection = "packaging"
+	SignoffCosting      TechCardSignoffSection = "costing"
+)
+
+var ValidTechCardSignoffSections = map[TechCardSignoffSection]bool{
+	SignoffDesign: true, SignoffConstruction: true, SignoffPom: true, SignoffMaterials: true,
+	SignoffColour: true, SignoffLabels: true, SignoffPackaging: true, SignoffCosting: true,
+}
+
+type TechCardSignoffState string
+
+const (
+	SignoffStatePending  TechCardSignoffState = "pending"
+	SignoffStateApproved TechCardSignoffState = "approved"
+	SignoffStateRejected TechCardSignoffState = "rejected"
+)
+
+var ValidTechCardSignoffStates = map[TechCardSignoffState]bool{
+	SignoffStatePending: true, SignoffStateApproved: true, SignoffStateRejected: true,
+}
+
+// TechCardSignoff records one responsible role's sign-off of a sheet.
+type TechCardSignoff struct {
+	Section  TechCardSignoffSection `db:"section"`
+	State    TechCardSignoffState   `db:"state"`
+	SignedBy sql.NullString         `db:"signed_by"`
+	SignedAt sql.NullTime           `db:"signed_at"`
+	Note     sql.NullString         `db:"note"`
+}
+
 // TechCardLabel is one label/tag spec (Sheet «Этикетки и упаковка»).
 type TechCardLabel struct {
 	LabelType  TechCardLabelType `db:"label_type"`
@@ -532,6 +572,7 @@ type TechCardInsert struct {
 	Costing        *TechCardCosting       `db:"-"`
 	Issues         []TechCardIssue        `db:"-"`
 	SizeQuantities []TechCardSizeQuantity `db:"-"`
+	Signoffs       []TechCardSignoff      `db:"-"`
 }
 
 // TechCardListFilter holds optional filters for listing tech cards. Empty/zero

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -96,20 +96,26 @@ func IsValidTechCardMeasurementUnit(u TechCardMeasurementUnit) bool {
 type TechCardMediaKind string
 
 const (
-	TechCardMediaFront   TechCardMediaKind = "front"
-	TechCardMediaBack    TechCardMediaKind = "back"
-	TechCardMediaDetail  TechCardMediaKind = "detail"
-	TechCardMediaLining  TechCardMediaKind = "lining"
-	TechCardMediaPreview TechCardMediaKind = "preview"
+	TechCardMediaFront     TechCardMediaKind = "front"
+	TechCardMediaBack      TechCardMediaKind = "back"
+	TechCardMediaDetail    TechCardMediaKind = "detail"
+	TechCardMediaLining    TechCardMediaKind = "lining"
+	TechCardMediaPreview   TechCardMediaKind = "preview"
+	TechCardMediaMoodboard TechCardMediaKind = "moodboard"
+	TechCardMediaReference TechCardMediaKind = "reference"
+	TechCardMediaSwatch    TechCardMediaKind = "swatch"
 )
 
 // ValidTechCardMediaKinds is the set of accepted sketch-media kinds.
 var ValidTechCardMediaKinds = map[TechCardMediaKind]bool{
-	TechCardMediaFront:   true,
-	TechCardMediaBack:    true,
-	TechCardMediaDetail:  true,
-	TechCardMediaLining:  true,
-	TechCardMediaPreview: true,
+	TechCardMediaFront:     true,
+	TechCardMediaBack:      true,
+	TechCardMediaDetail:    true,
+	TechCardMediaLining:    true,
+	TechCardMediaPreview:   true,
+	TechCardMediaMoodboard: true,
+	TechCardMediaReference: true,
+	TechCardMediaSwatch:    true,
 }
 
 // IsValidTechCardMediaKind reports whether k is an accepted media kind.
@@ -121,6 +127,7 @@ func IsValidTechCardMediaKind(k TechCardMediaKind) bool {
 type TechCardMediaItem struct {
 	MediaId int               `db:"media_id"`
 	Kind    TechCardMediaKind `db:"kind"`
+	Caption sql.NullString    `db:"caption"`
 }
 
 // TechCardMediaFull is a resolved sketch-media reference for display.
@@ -131,11 +138,13 @@ type TechCardMediaFull struct {
 
 // TechCardCallout is a numbered detail note pointing at the technical sketch.
 type TechCardCallout struct {
-	Number      int            `db:"callout_number"`
-	Part        sql.NullString `db:"part"`
-	Description sql.NullString `db:"description"`
-	Dimensions  sql.NullString `db:"dimensions"`
-	MediaId     sql.NullInt32  `db:"media_id"` // sketch this callout is pinned to
+	Number      int                 `db:"callout_number"`
+	Part        sql.NullString      `db:"part"`
+	Description sql.NullString      `db:"description"`
+	Dimensions  sql.NullString      `db:"dimensions"`
+	MediaId     sql.NullInt32       `db:"media_id"` // sketch this callout is pinned to
+	PosX        decimal.NullDecimal `db:"pos_x"`    // normalised 0..1 marker position
+	PosY        decimal.NullDecimal `db:"pos_y"`
 }
 
 // TechCardRevision is one entry in the revision log.
@@ -205,12 +214,21 @@ func IsValidTechCardLabDipStatus(s TechCardLabDipStatus) bool {
 
 // TechCardColorway is a development colourway (Sheet «Колористика»).
 type TechCardColorway struct {
-	Id           int                  `db:"id"`
-	Code         sql.NullString       `db:"code"`
-	Name         string               `db:"name"`
-	LabDipStatus TechCardLabDipStatus `db:"lab_dip_status"`
-	ProductId    sql.NullInt32        `db:"product_id"`
-	Comment      sql.NullString       `db:"comment"`
+	Id                 int                  `db:"id"`
+	Code               sql.NullString       `db:"code"`
+	Name               string               `db:"name"`
+	LabDipStatus       TechCardLabDipStatus `db:"lab_dip_status"`
+	ProductId          sql.NullInt32        `db:"product_id"`
+	Comment            sql.NullString       `db:"comment"`
+	Pantone            sql.NullString       `db:"pantone"`
+	PantoneSystem      sql.NullString       `db:"pantone_system"`
+	Hex                sql.NullString       `db:"hex"`
+	SwatchMediaId      sql.NullInt32        `db:"swatch_media_id"`
+	LabDipRound        sql.NullInt32        `db:"lab_dip_round"`
+	LabDipSubmittedAt  sql.NullTime         `db:"lab_dip_submitted_at"`
+	LabDipDecidedAt    sql.NullTime         `db:"lab_dip_decided_at"`
+	LabDipDecidedBy    sql.NullString       `db:"lab_dip_decided_by"`
+	LabDipRejectReason sql.NullString       `db:"lab_dip_reject_reason"`
 }
 
 // TechCardBomColorwayColor is the colour of a BOM material in a colourway. On
@@ -239,13 +257,32 @@ type TechCardBomItem struct {
 	UnitPrice   decimal.NullDecimal `db:"unit_price"`
 	Currency    sql.NullString      `db:"currency"`
 	Comment     sql.NullString      `db:"comment"`
+	// fabric data for the cutter / marker (Phase 3.5c)
+	FabricWidth     decimal.NullDecimal `db:"fabric_width"`
+	FabricWeightGsm decimal.NullDecimal `db:"fabric_weight_gsm"`
+	FabricDirection sql.NullString      `db:"fabric_direction"`
+	WastagePercent  decimal.NullDecimal `db:"wastage_percent"`
 	// ColorwayColors are the per-colourway colours (in-memory; persisted to
 	// tech_card_bom_colorway).
 	ColorwayColors []TechCardBomColorwayColor `db:"-"`
 }
 
-// LineTotal returns quantity*unit_price, falling back to consumption*unit_price
-// when quantity is unset. Invalid (no price) yields an invalid NullDecimal.
+// TechCardFabricDirection enumerates the cutting layout a fabric requires.
+type TechCardFabricDirection string
+
+const (
+	FabricDirectionAny    TechCardFabricDirection = "any"
+	FabricDirectionOneWay TechCardFabricDirection = "one_way"
+	FabricDirectionTwoWay TechCardFabricDirection = "two_way"
+)
+
+var ValidTechCardFabricDirections = map[TechCardFabricDirection]bool{
+	FabricDirectionAny: true, FabricDirectionOneWay: true, FabricDirectionTwoWay: true,
+}
+
+// LineTotal returns quantity*unit_price (falling back to consumption*unit_price
+// when quantity is unset), grossed up by wastage_percent when set. Invalid (no
+// price) yields an invalid NullDecimal.
 func (b *TechCardBomItem) LineTotal() decimal.NullDecimal {
 	if !b.UnitPrice.Valid {
 		return decimal.NullDecimal{}
@@ -257,7 +294,17 @@ func (b *TechCardBomItem) LineTotal() decimal.NullDecimal {
 	if !qty.Valid {
 		return decimal.NullDecimal{}
 	}
-	return decimal.NullDecimal{Decimal: qty.Decimal.Mul(b.UnitPrice.Decimal), Valid: true}
+	total := qty.Decimal.Mul(b.UnitPrice.Decimal)
+	if b.WastagePercent.Valid {
+		total = total.Mul(decimal.NewFromInt(1).Add(b.WastagePercent.Decimal.Div(decimal.NewFromInt(100))))
+	}
+	return decimal.NullDecimal{Decimal: total, Valid: true}
+}
+
+// TechCardSizeQuantity is the production order quantity for a size (size run).
+type TechCardSizeQuantity struct {
+	SizeId   int `db:"size_id"`
+	OrderQty int `db:"order_qty"`
 }
 
 // TechCardPomGrade is the graded value of a POM point for a size.
@@ -478,12 +525,13 @@ type TechCardInsert struct {
 	Colorways []TechCardColorway `db:"-"`
 	PomPoints []TechCardPomPoint `db:"-"`
 	// production (Phase 3); 1:1 sections are nil when unset
-	Construction *TechCardConstruction `db:"-"`
-	Operations   []TechCardOperation   `db:"-"`
-	Labels       []TechCardLabel       `db:"-"`
-	Packaging    *TechCardPackaging    `db:"-"`
-	Costing      *TechCardCosting      `db:"-"`
-	Issues       []TechCardIssue       `db:"-"`
+	Construction   *TechCardConstruction  `db:"-"`
+	Operations     []TechCardOperation    `db:"-"`
+	Labels         []TechCardLabel        `db:"-"`
+	Packaging      *TechCardPackaging     `db:"-"`
+	Costing        *TechCardCosting       `db:"-"`
+	Issues         []TechCardIssue        `db:"-"`
+	SizeQuantities []TechCardSizeQuantity `db:"-"`
 }
 
 // TechCardListFilter holds optional filters for listing tech cards. Empty/zero

--- a/internal/store/sql/0071_tech_card_hardening.sql
+++ b/internal/store/sql/0071_tech_card_hardening.sql
@@ -1,0 +1,36 @@
+-- +migrate Up
+-- Tech card hardening (Phase 3.5a): optimistic locking so concurrent role edits
+-- don't silently clobber each other; a stable unique POM code so a measurement
+-- point is addressable across revisions; POM actuals tied to the size they were
+-- measured at (so QC can compare to that size's grade ± tolerance); plus an
+-- approved_at timestamp and a design-concept field.
+
+ALTER TABLE tech_card
+  ADD COLUMN lock_version INT NOT NULL DEFAULT 0
+    COMMENT 'optimistic-lock counter; bumped on every update, echoed to the client' AFTER id,
+  ADD COLUMN approved_at TIMESTAMP NULL
+    COMMENT 'when the current revision was approved (auto-set on approve/release)' AFTER approved_by,
+  ADD COLUMN concept TEXT NULL COMMENT 'design concept / intent (designer)' AFTER description;
+
+-- A non-empty POM code is the stable cross-revision handle for a point. NULLs are
+-- distinct in MySQL, so the unique key only bites once a code is set.
+ALTER TABLE tech_card_pom_point
+  ADD UNIQUE KEY uniq_tech_card_pom_code (tech_card_id, code);
+
+-- An actual measured against a specific size can be compared to that size's grade
+-- (falling back to base_value when no size is given).
+ALTER TABLE tech_card_pom_actual
+  ADD COLUMN size_id INT NULL COMMENT 'FK size(id); the size this piece was measured at' AFTER pom_point_id,
+  ADD INDEX idx_tech_card_pom_actual_size (size_id),
+  ADD CONSTRAINT fk_tech_card_pom_actual_size FOREIGN KEY (size_id) REFERENCES size(id);
+
+-- +migrate Down
+ALTER TABLE tech_card_pom_actual
+  DROP FOREIGN KEY fk_tech_card_pom_actual_size,
+  DROP INDEX idx_tech_card_pom_actual_size,
+  DROP COLUMN size_id;
+ALTER TABLE tech_card_pom_point DROP INDEX uniq_tech_card_pom_code;
+ALTER TABLE tech_card
+  DROP COLUMN concept,
+  DROP COLUMN approved_at,
+  DROP COLUMN lock_version;

--- a/internal/store/sql/0072_tech_card_operations_issues.sql
+++ b/internal/store/sql/0072_tech_card_operations_issues.sql
@@ -1,0 +1,52 @@
+-- +migrate Up
+-- Tech card operations depth + a sewer issue-flag channel (Phase 3.5b).
+--  * Per-operation: an explicit operation number (addressable «оп. 10»), the
+--    machine/equipment, per-seam allowance, needle spec, and the time norm (SAM /
+--    норма времени) the technologist owns. A labour rate on the construction sheet
+--    lets the costing roll Σ(SAM) × rate into a computed labour cost.
+--  * tech_card_issue: a first-class channel for the seamstress (or anyone) to flag
+--    that an operation/detail is hard or impossible to execute, tracked to
+--    resolution and pinned to the operation number / callout it concerns.
+
+ALTER TABLE tech_card_operation
+  ADD COLUMN operation_number INT NULL COMMENT 'human operation number (оп. 10, 20, …)' AFTER tech_card_id,
+  ADD COLUMN machine VARCHAR(64) NULL COMMENT 'machine / equipment for this operation' AFTER seam_type,
+  ADD COLUMN seam_allowance VARCHAR(64) NULL COMMENT 'seam allowance for this узел' AFTER topstitch_width,
+  ADD COLUMN needle VARCHAR(64) NULL COMMENT 'needle size / type' AFTER thread,
+  ADD COLUMN time_norm DECIMAL(7, 3) NULL COMMENT 'SAM / норма времени, minutes'
+    CHECK (time_norm IS NULL OR time_norm >= 0);
+
+ALTER TABLE tech_card_construction
+  ADD COLUMN labour_rate DECIMAL(10, 4) NULL COMMENT 'labour cost per minute (× Σ SAM = labour cost)'
+    CHECK (labour_rate IS NULL OR labour_rate >= 0),
+  ADD COLUMN labour_rate_currency VARCHAR(3) NULL COMMENT 'ISO 4217 for labour_rate';
+
+-- tech_card_issue: sewer/maker flags against an operation or callout.
+CREATE TABLE tech_card_issue (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  operation_number INT NULL COMMENT 'the operation this issue is about (matches tech_card_operation.operation_number)',
+  callout_number INT NULL COMMENT 'the sketch callout this issue is about',
+  raised_by VARCHAR(255) NULL COMMENT 'who flagged it (e.g. seamstress)',
+  severity VARCHAR(8) NOT NULL DEFAULT 'medium' COMMENT 'low|medium|high'
+    CHECK (severity REGEXP '^(low|medium|high)$'),
+  status VARCHAR(12) NOT NULL DEFAULT 'open' COMMENT 'open|resolved|wontfix'
+    CHECK (status REGEXP '^(open|resolved|wontfix)$'),
+  description TEXT NOT NULL COMMENT 'what is hard / impossible',
+  resolution_note TEXT NULL,
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_issue_card (tech_card_id),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Maker-flagged issues against a tech card operation / callout';
+
+-- +migrate Down
+DROP TABLE IF EXISTS tech_card_issue;
+ALTER TABLE tech_card_construction
+  DROP COLUMN labour_rate_currency,
+  DROP COLUMN labour_rate;
+ALTER TABLE tech_card_operation
+  DROP COLUMN time_norm,
+  DROP COLUMN needle,
+  DROP COLUMN seam_allowance,
+  DROP COLUMN machine,
+  DROP COLUMN operation_number;

--- a/internal/store/sql/0073_tech_card_materials_depth.sql
+++ b/internal/store/sql/0073_tech_card_materials_depth.sql
@@ -1,0 +1,68 @@
+-- +migrate Up
+-- Tech card materials/colour/sizes depth (Phase 3.5c):
+--  * Colourway lab-dip lifecycle (round, dates, who decided, reject reason) plus a
+--    swatch image and a precise colour standard (pantone + system + hex) — the
+--    colourist's audit trail and the factory's match target.
+--  * BOM fabric data the cutter needs for a marker: usable width, weight (GSM),
+--    direction/nap, and a cutting wastage % (folds into line_total).
+--  * Per-size order quantity (size run), not just the grade list.
+--  * Sketch media gain captions and the new moodboard/reference/swatch kinds;
+--    callouts gain normalised x/y so a number can be placed on the drawing.
+
+ALTER TABLE tech_card_colorway
+  ADD COLUMN pantone VARCHAR(64) NULL COMMENT 'headline Pantone code',
+  ADD COLUMN pantone_system VARCHAR(8) NULL COMMENT 'TCX|TPX|TPG|C|U (Pantone book)'
+    CHECK (pantone_system IS NULL OR pantone_system REGEXP '^(TCX|TPX|TPG|C|U)$'),
+  ADD COLUMN hex VARCHAR(7) NULL COMMENT 'screen approximation, #RRGGBB'
+    CHECK (hex IS NULL OR hex REGEXP '^#[0-9A-Fa-f]{6}$'),
+  ADD COLUMN swatch_media_id INT NULL COMMENT 'FK media(id); approved physical swatch',
+  ADD COLUMN lab_dip_round INT NULL COMMENT 'lab-dip submission round (1, 2, …)',
+  ADD COLUMN lab_dip_submitted_at DATE NULL,
+  ADD COLUMN lab_dip_decided_at DATE NULL,
+  ADD COLUMN lab_dip_decided_by VARCHAR(255) NULL,
+  ADD COLUMN lab_dip_reject_reason TEXT NULL,
+  ADD INDEX idx_tech_card_colorway_swatch (swatch_media_id),
+  ADD CONSTRAINT fk_tech_card_colorway_swatch FOREIGN KEY (swatch_media_id) REFERENCES media(id) ON DELETE SET NULL;
+
+ALTER TABLE tech_card_bom_item
+  ADD COLUMN fabric_width DECIMAL(7, 2) NULL COMMENT 'usable fabric width, cm'
+    CHECK (fabric_width IS NULL OR fabric_width >= 0),
+  ADD COLUMN fabric_weight_gsm DECIMAL(7, 2) NULL COMMENT 'fabric weight, g/m²'
+    CHECK (fabric_weight_gsm IS NULL OR fabric_weight_gsm >= 0),
+  ADD COLUMN fabric_direction VARCHAR(8) NULL COMMENT 'any|one_way|two_way (nap / layout)'
+    CHECK (fabric_direction IS NULL OR fabric_direction REGEXP '^(any|one_way|two_way)$'),
+  ADD COLUMN wastage_percent DECIMAL(5, 2) NULL COMMENT 'cutting wastage %, folded into line_total'
+    CHECK (wastage_percent IS NULL OR (wastage_percent >= 0 AND wastage_percent <= 100));
+
+ALTER TABLE tech_card_size
+  ADD COLUMN order_qty INT NULL COMMENT 'production order quantity for this size (size run)'
+    CHECK (order_qty IS NULL OR order_qty >= 0);
+
+ALTER TABLE tech_card_media
+  ADD COLUMN caption VARCHAR(255) NULL COMMENT 'image caption / view name',
+  DROP CHECK tech_card_media_chk_1,
+  ADD CONSTRAINT chk_tech_card_media_kind
+    CHECK (kind REGEXP '^(front|back|detail|lining|preview|moodboard|reference|swatch)$');
+
+ALTER TABLE tech_card_callout
+  ADD COLUMN pos_x DECIMAL(5, 4) NULL COMMENT 'normalised x (0..1) of the marker on its sketch'
+    CHECK (pos_x IS NULL OR (pos_x >= 0 AND pos_x <= 1)),
+  ADD COLUMN pos_y DECIMAL(5, 4) NULL COMMENT 'normalised y (0..1) of the marker on its sketch'
+    CHECK (pos_y IS NULL OR (pos_y >= 0 AND pos_y <= 1));
+
+-- +migrate Down
+ALTER TABLE tech_card_callout DROP COLUMN pos_y, DROP COLUMN pos_x;
+ALTER TABLE tech_card_media
+  DROP CHECK chk_tech_card_media_kind,
+  ADD CONSTRAINT tech_card_media_chk_1 CHECK (kind REGEXP '^(front|back|detail|lining|preview)$'),
+  DROP COLUMN caption;
+ALTER TABLE tech_card_size DROP COLUMN order_qty;
+ALTER TABLE tech_card_bom_item
+  DROP COLUMN wastage_percent, DROP COLUMN fabric_direction,
+  DROP COLUMN fabric_weight_gsm, DROP COLUMN fabric_width;
+ALTER TABLE tech_card_colorway
+  DROP FOREIGN KEY fk_tech_card_colorway_swatch,
+  DROP INDEX idx_tech_card_colorway_swatch,
+  DROP COLUMN lab_dip_reject_reason, DROP COLUMN lab_dip_decided_by,
+  DROP COLUMN lab_dip_decided_at, DROP COLUMN lab_dip_submitted_at, DROP COLUMN lab_dip_round,
+  DROP COLUMN swatch_media_id, DROP COLUMN hex, DROP COLUMN pantone_system, DROP COLUMN pantone;

--- a/internal/store/sql/0074_tech_card_signoff.sql
+++ b/internal/store/sql/0074_tech_card_signoff.sql
@@ -1,0 +1,25 @@
+-- +migrate Up
+-- Per-section sign-off (Phase 3.5a-2). The single header approval_state can't say
+-- "costing approved by finance, labels still pending compliance". tech_card_signoff
+-- records a sign-off per responsible section, so the merchandiser/manager can see
+-- who signed which sheet. signed_by is free text (matching the codebase's actor
+-- convention: fitting.recorded_by, tech_card_revision.author).
+
+CREATE TABLE tech_card_signoff (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  section VARCHAR(16) NOT NULL
+    COMMENT 'design|construction|pom|materials|colour|labels|packaging|costing'
+    CHECK (section REGEXP '^(design|construction|pom|materials|colour|labels|packaging|costing)$'),
+  state VARCHAR(8) NOT NULL DEFAULT 'pending' COMMENT 'pending|approved|rejected'
+    CHECK (state REGEXP '^(pending|approved|rejected)$'),
+  signed_by VARCHAR(255) NULL COMMENT 'who signed off (free text / role name)',
+  signed_at TIMESTAMP NULL,
+  note TEXT NULL,
+  display_order INT NOT NULL DEFAULT 0,
+  UNIQUE KEY uniq_tech_card_signoff (tech_card_id, section),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Per-section sign-off for a tech card';
+
+-- +migrate Down
+DROP TABLE IF EXISTS tech_card_signoff;

--- a/internal/store/sql/0075_tech_card_operation_attachment.sql
+++ b/internal/store/sql/0075_tech_card_operation_attachment.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+-- A sewing operation's workaid (folder/binder/guide/hemmer/presser-foot). For
+-- binding/hemming/elastic operations the attachment IS the operation and the SAM
+-- is undefined without it, so capture it as a first-class field.
+ALTER TABLE tech_card_operation
+  ADD COLUMN attachment VARCHAR(64) NULL COMMENT 'folder/binder/guide/hemmer/presser-foot (приспособление)' AFTER needle;
+
+-- +migrate Down
+ALTER TABLE tech_card_operation DROP COLUMN attachment;

--- a/internal/store/storeutil/query.go
+++ b/internal/store/storeutil/query.go
@@ -117,6 +117,25 @@ func ExecNamed(
 	return nil
 }
 
+// ExecNamedRows executes a named-parameter UPDATE/DELETE and returns the number of
+// affected rows (for optimistic-lock / existence checks).
+func ExecNamedRows(
+	ctx context.Context,
+	conn dependency.DB,
+	query string,
+	params map[string]any,
+) (int64, error) {
+	query, args, err := makeQuery(query, params)
+	if err != nil {
+		return 0, err
+	}
+	res, err := conn.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("ExecContext: %w", err)
+	}
+	return res.RowsAffected()
+}
+
 // ExecNamedLastId executes a named-parameter INSERT and returns the last insert ID.
 func ExecNamedLastId(
 	ctx context.Context,

--- a/internal/store/techcard/enrich.go
+++ b/internal/store/techcard/enrich.go
@@ -2,11 +2,38 @@ package techcard
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
 	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
 )
+
+type techCardSizeQtyRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardSizeQuantity
+}
+
+// sizeQuantitiesByTechCardIds loads per-size order quantities (only sizes that
+// have one) grouped by tech card.
+func (s *Store) sizeQuantitiesByTechCardIds(ctx context.Context, ids []int) (map[int][]entity.TechCardSizeQuantity, error) {
+	if len(ids) == 0 {
+		return map[int][]entity.TechCardSizeQuantity{}, nil
+	}
+	rows, err := storeutil.QueryListNamed[techCardSizeQtyRow](ctx, s.DB, `
+		SELECT tech_card_id, size_id, order_qty
+		FROM tech_card_size
+		WHERE tech_card_id IN (:ids) AND order_qty IS NOT NULL
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return nil, fmt.Errorf("can't load tech card size quantities: %w", err)
+	}
+	out := make(map[int][]entity.TechCardSizeQuantity, len(ids))
+	for _, r := range rows {
+		out[r.TechCardID] = append(out[r.TechCardID], r.TechCardSizeQuantity)
+	}
+	return out, nil
+}
 
 // enrich loads and attaches the size range, linked products, sketch media
 // (writable items + resolved MediaFull), callouts and revisions for each card.
@@ -20,6 +47,10 @@ func (s *Store) enrich(ctx context.Context, cards []entity.TechCard) error {
 	}
 
 	sizes, err := s.idListByTechCardIds(ctx, "tech_card_size", "size_id", ids)
+	if err != nil {
+		return err
+	}
+	sizeQty, err := s.sizeQuantitiesByTechCardIds(ctx, ids)
 	if err != nil {
 		return err
 	}
@@ -43,6 +74,7 @@ func (s *Store) enrich(ctx context.Context, cards []entity.TechCard) error {
 	for i := range cards {
 		id := cards[i].Id
 		cards[i].SizeIds = sizes[id]
+		cards[i].SizeQuantities = sizeQty[id]
 		cards[i].ProductIds = products[id]
 		cards[i].Media = mediaItems[id]
 		cards[i].ResolvedMedia = mediaFull[id]
@@ -108,6 +140,7 @@ func (s *Store) productIdsByTechCardIds(ctx context.Context, ids []int) (map[int
 type techCardMediaRow struct {
 	TechCardID int                      `db:"tech_card_id"`
 	Kind       entity.TechCardMediaKind `db:"kind"`
+	Caption    sql.NullString           `db:"caption"`
 	entity.MediaFull
 }
 
@@ -118,7 +151,7 @@ func (s *Store) mediaByTechCardIds(ctx context.Context, ids []int) (map[int][]en
 		return items, full, nil
 	}
 	rows, err := storeutil.QueryListNamed[techCardMediaRow](ctx, s.DB, `
-		SELECT tcm.tech_card_id, tcm.kind, m.*
+		SELECT tcm.tech_card_id, tcm.kind, tcm.caption, m.*
 		FROM tech_card_media tcm
 		JOIN media m ON m.id = tcm.media_id
 		WHERE tcm.tech_card_id IN (:ids)
@@ -128,7 +161,7 @@ func (s *Store) mediaByTechCardIds(ctx context.Context, ids []int) (map[int][]en
 	}
 	for i := range rows {
 		tcID := rows[i].TechCardID
-		items[tcID] = append(items[tcID], entity.TechCardMediaItem{MediaId: rows[i].Id, Kind: rows[i].Kind})
+		items[tcID] = append(items[tcID], entity.TechCardMediaItem{MediaId: rows[i].Id, Kind: rows[i].Kind, Caption: rows[i].Caption})
 		full[tcID] = append(full[tcID], entity.TechCardMediaFull{Media: rows[i].MediaFull, Kind: rows[i].Kind})
 	}
 	return items, full, nil
@@ -144,7 +177,7 @@ func (s *Store) calloutsByTechCardIds(ctx context.Context, ids []int) (map[int][
 		return map[int][]entity.TechCardCallout{}, nil
 	}
 	rows, err := storeutil.QueryListNamed[techCardCalloutRow](ctx, s.DB, `
-		SELECT tech_card_id, callout_number, part, description, dimensions, media_id
+		SELECT tech_card_id, callout_number, part, description, dimensions, media_id, pos_x, pos_y
 		FROM tech_card_callout
 		WHERE tech_card_id IN (:ids)
 		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})

--- a/internal/store/techcard/materials.go
+++ b/internal/store/techcard/materials.go
@@ -137,6 +137,7 @@ func insertTechCardPom(ctx context.Context, db dependency.DB, tcID int, points [
 				rows = append(rows, map[string]any{
 					"pom_point_id":  pomID,
 					"fitting_id":    a.FittingId,
+					"size_id":       a.SizeId,
 					"label":         a.Label,
 					"value":         a.Value,
 					"display_order": j,
@@ -303,7 +304,7 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 			}
 		}
 		actualRows, err := storeutil.QueryListNamed[techCardPomActualRow](ctx, s.DB, `
-			SELECT pom_point_id, fitting_id, label, value
+			SELECT pom_point_id, fitting_id, size_id, label, value
 			FROM tech_card_pom_actual
 			WHERE pom_point_id IN (:ids)
 			ORDER BY pom_point_id, display_order`, map[string]any{"ids": pomPointIDs})

--- a/internal/store/techcard/materials.go
+++ b/internal/store/techcard/materials.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
@@ -196,11 +197,15 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 
 	// Colourways: grouped per card (in display order), plus a colourway id -> index
 	// map so the BOM colour matrix can be emitted by index.
+	// product_id resolves through a LEFT JOIN that excludes soft-deleted products
+	// (products are soft-deleted, so the ON DELETE SET NULL never fires) — a dead
+	// SKU surfaces as NULL instead of a dangling id, mirroring productIdsByTechCardIds.
 	cwRows, err := storeutil.QueryListNamed[techCardColorwayRow](ctx, s.DB, `
-		SELECT id, tech_card_id, code, name, lab_dip_status, product_id, comment
-		FROM tech_card_colorway
-		WHERE tech_card_id IN (:ids)
-		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+		SELECT c.id, c.tech_card_id, c.code, c.name, c.lab_dip_status, p.id AS product_id, c.comment
+		FROM tech_card_colorway c
+		LEFT JOIN product p ON p.id = c.product_id AND p.deleted_at IS NULL
+		WHERE c.tech_card_id IN (:ids)
+		ORDER BY c.tech_card_id, c.display_order`, map[string]any{"ids": ids})
 	if err != nil {
 		return fmt.Errorf("can't load tech card colorways: %w", err)
 	}
@@ -316,7 +321,33 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 		id := cards[i].Id
 		cards[i].Colorways = colorwaysByCard[id]
 		cards[i].BomItems = bomByCard[id]
-		cards[i].PomPoints = pomByCard[id]
+		points := pomByCard[id]
+		sortPomGradesBySizeOrder(points, cards[i].SizeIds)
+		cards[i].PomPoints = points
 	}
 	return nil
+}
+
+// sortPomGradesBySizeOrder orders each point's grades by the card's declared size
+// range (tech_card_size order), so the graded chart renders its size columns in a
+// stable, meaningful order instead of insertion order. cards[i].SizeIds is already
+// populated by enrich before enrichMaterials runs.
+func sortPomGradesBySizeOrder(points []entity.TechCardPomPoint, sizeIds []int) {
+	if len(sizeIds) == 0 {
+		return
+	}
+	rank := make(map[int]int, len(sizeIds))
+	for i, sid := range sizeIds {
+		rank[sid] = i
+	}
+	order := func(sid int) int {
+		if r, ok := rank[sid]; ok {
+			return r
+		}
+		return len(sizeIds) // sizes outside the range (shouldn't happen) sort last
+	}
+	for i := range points {
+		g := points[i].Grades
+		sort.SliceStable(g, func(a, b int) bool { return order(g[a].SizeId) < order(g[b].SizeId) })
+	}
 }

--- a/internal/store/techcard/materials.go
+++ b/internal/store/techcard/materials.go
@@ -21,16 +21,29 @@ func insertTechCardColorways(ctx context.Context, db dependency.DB, tcID int, cw
 		c := &cws[i]
 		id, err := storeutil.ExecNamedLastId(ctx, db, `
 			INSERT INTO tech_card_colorway
-				(tech_card_id, code, name, lab_dip_status, product_id, comment, display_order)
-			VALUES (:tech_card_id, :code, :name, :lab_dip_status, :product_id, :comment, :display_order)`,
+				(tech_card_id, code, name, lab_dip_status, product_id, comment, display_order,
+				 pantone, pantone_system, hex, swatch_media_id, lab_dip_round,
+				 lab_dip_submitted_at, lab_dip_decided_at, lab_dip_decided_by, lab_dip_reject_reason)
+			VALUES (:tech_card_id, :code, :name, :lab_dip_status, :product_id, :comment, :display_order,
+				 :pantone, :pantone_system, :hex, :swatch_media_id, :lab_dip_round,
+				 :lab_dip_submitted_at, :lab_dip_decided_at, :lab_dip_decided_by, :lab_dip_reject_reason)`,
 			map[string]any{
-				"tech_card_id":   tcID,
-				"code":           c.Code,
-				"name":           c.Name,
-				"lab_dip_status": string(c.LabDipStatus),
-				"product_id":     c.ProductId,
-				"comment":        c.Comment,
-				"display_order":  i,
+				"tech_card_id":          tcID,
+				"code":                  c.Code,
+				"name":                  c.Name,
+				"lab_dip_status":        string(c.LabDipStatus),
+				"product_id":            c.ProductId,
+				"comment":               c.Comment,
+				"display_order":         i,
+				"pantone":               c.Pantone,
+				"pantone_system":        c.PantoneSystem,
+				"hex":                   c.Hex,
+				"swatch_media_id":       c.SwatchMediaId,
+				"lab_dip_round":         c.LabDipRound,
+				"lab_dip_submitted_at":  c.LabDipSubmittedAt,
+				"lab_dip_decided_at":    c.LabDipDecidedAt,
+				"lab_dip_decided_by":    c.LabDipDecidedBy,
+				"lab_dip_reject_reason": c.LabDipRejectReason,
 			})
 		if err != nil {
 			return nil, fmt.Errorf("failed to insert tech card colorway: %w", err)
@@ -48,26 +61,32 @@ func insertTechCardBom(ctx context.Context, db dependency.DB, tcID int, items []
 		bomID, err := storeutil.ExecNamedLastId(ctx, db, `
 			INSERT INTO tech_card_bom_item
 				(tech_card_id, section, name, placement, supplier, supplier_ref, color, composition, spec,
-				 consumption, unit, quantity, unit_price, currency, comment, display_order)
+				 consumption, unit, quantity, unit_price, currency, comment, display_order,
+				 fabric_width, fabric_weight_gsm, fabric_direction, wastage_percent)
 			VALUES (:tech_card_id, :section, :name, :placement, :supplier, :supplier_ref, :color, :composition, :spec,
-				 :consumption, :unit, :quantity, :unit_price, :currency, :comment, :display_order)`,
+				 :consumption, :unit, :quantity, :unit_price, :currency, :comment, :display_order,
+				 :fabric_width, :fabric_weight_gsm, :fabric_direction, :wastage_percent)`,
 			map[string]any{
-				"tech_card_id":  tcID,
-				"section":       string(b.Section),
-				"name":          b.Name,
-				"placement":     b.Placement,
-				"supplier":      b.Supplier,
-				"supplier_ref":  b.SupplierRef,
-				"color":         b.Color,
-				"composition":   b.Composition,
-				"spec":          b.Spec,
-				"consumption":   b.Consumption,
-				"unit":          b.Unit,
-				"quantity":      b.Quantity,
-				"unit_price":    b.UnitPrice,
-				"currency":      b.Currency,
-				"comment":       b.Comment,
-				"display_order": i,
+				"tech_card_id":      tcID,
+				"section":           string(b.Section),
+				"name":              b.Name,
+				"placement":         b.Placement,
+				"supplier":          b.Supplier,
+				"supplier_ref":      b.SupplierRef,
+				"color":             b.Color,
+				"composition":       b.Composition,
+				"spec":              b.Spec,
+				"consumption":       b.Consumption,
+				"unit":              b.Unit,
+				"quantity":          b.Quantity,
+				"unit_price":        b.UnitPrice,
+				"currency":          b.Currency,
+				"comment":           b.Comment,
+				"display_order":     i,
+				"fabric_width":      b.FabricWidth,
+				"fabric_weight_gsm": b.FabricWeightGsm,
+				"fabric_direction":  b.FabricDirection,
+				"wastage_percent":   b.WastagePercent,
 			})
 		if err != nil {
 			return fmt.Errorf("failed to insert tech card bom item: %w", err)
@@ -202,7 +221,9 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 	// (products are soft-deleted, so the ON DELETE SET NULL never fires) — a dead
 	// SKU surfaces as NULL instead of a dangling id, mirroring productIdsByTechCardIds.
 	cwRows, err := storeutil.QueryListNamed[techCardColorwayRow](ctx, s.DB, `
-		SELECT c.id, c.tech_card_id, c.code, c.name, c.lab_dip_status, p.id AS product_id, c.comment
+		SELECT c.id, c.tech_card_id, c.code, c.name, c.lab_dip_status, p.id AS product_id, c.comment,
+		       c.pantone, c.pantone_system, c.hex, c.swatch_media_id, c.lab_dip_round,
+		       c.lab_dip_submitted_at, c.lab_dip_decided_at, c.lab_dip_decided_by, c.lab_dip_reject_reason
 		FROM tech_card_colorway c
 		LEFT JOIN product p ON p.id = c.product_id AND p.deleted_at IS NULL
 		WHERE c.tech_card_id IN (:ids)
@@ -220,7 +241,8 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 	// BOM lines per card.
 	bomRows, err := storeutil.QueryListNamed[techCardBomItemRow](ctx, s.DB, `
 		SELECT id, tech_card_id, section, name, placement, supplier, supplier_ref, color, composition, spec,
-		       consumption, unit, quantity, unit_price, currency, comment
+		       consumption, unit, quantity, unit_price, currency, comment,
+		       fabric_width, fabric_weight_gsm, fabric_direction, wastage_percent
 		FROM tech_card_bom_item
 		WHERE tech_card_id IN (:ids)
 		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})

--- a/internal/store/techcard/production.go
+++ b/internal/store/techcard/production.go
@@ -172,6 +172,28 @@ func insertTechCardIssues(ctx context.Context, db dependency.DB, tcID int, issue
 	return nil
 }
 
+func insertTechCardSignoffs(ctx context.Context, db dependency.DB, tcID int, signoffs []entity.TechCardSignoff) error {
+	if len(signoffs) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(signoffs))
+	for i, s := range signoffs {
+		rows = append(rows, map[string]any{
+			"tech_card_id":  tcID,
+			"section":       string(s.Section),
+			"state":         string(s.State),
+			"signed_by":     s.SignedBy,
+			"signed_at":     s.SignedAt,
+			"note":          s.Note,
+			"display_order": i,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_signoff", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card signoffs: %w", err)
+	}
+	return nil
+}
+
 // --- enrich (load production sections for read paths) ---
 
 type techCardConstructionRow struct {
@@ -182,6 +204,11 @@ type techCardConstructionRow struct {
 type techCardIssueRow struct {
 	TechCardID int `db:"tech_card_id"`
 	entity.TechCardIssue
+}
+
+type techCardSignoffRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardSignoff
 }
 
 type techCardOperationRow struct {
@@ -288,6 +315,19 @@ func (s *Store) enrichProduction(ctx context.Context, cards []entity.TechCard) e
 		issuesByCard[r.TechCardID] = append(issuesByCard[r.TechCardID], r.TechCardIssue)
 	}
 
+	signoffRows, err := storeutil.QueryListNamed[techCardSignoffRow](ctx, s.DB, `
+		SELECT tech_card_id, section, state, signed_by, signed_at, note
+		FROM tech_card_signoff
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("can't load tech card signoffs: %w", err)
+	}
+	signoffsByCard := make(map[int][]entity.TechCardSignoff, len(ids))
+	for _, r := range signoffRows {
+		signoffsByCard[r.TechCardID] = append(signoffsByCard[r.TechCardID], r.TechCardSignoff)
+	}
+
 	for i := range cards {
 		id := cards[i].Id
 		cards[i].Construction = consByCard[id]
@@ -296,6 +336,7 @@ func (s *Store) enrichProduction(ctx context.Context, cards []entity.TechCard) e
 		cards[i].Packaging = pkgByCard[id]
 		cards[i].Costing = costByCard[id]
 		cards[i].Issues = issuesByCard[id]
+		cards[i].Signoffs = signoffsByCard[id]
 	}
 	return nil
 }

--- a/internal/store/techcard/production.go
+++ b/internal/store/techcard/production.go
@@ -18,19 +18,21 @@ func insertTechCardConstruction(ctx context.Context, db dependency.DB, tcID int,
 	if err := storeutil.ExecNamed(ctx, db, `
 		INSERT INTO tech_card_construction
 			(tech_card_id, main_stitch_type, stitch_density, overlock_threads, seam_allowances,
-			 hem_finish, pressing, machine_class, notes)
+			 hem_finish, pressing, machine_class, notes, labour_rate, labour_rate_currency)
 		VALUES (:tech_card_id, :main_stitch_type, :stitch_density, :overlock_threads, :seam_allowances,
-			 :hem_finish, :pressing, :machine_class, :notes)`,
+			 :hem_finish, :pressing, :machine_class, :notes, :labour_rate, :labour_rate_currency)`,
 		map[string]any{
-			"tech_card_id":     tcID,
-			"main_stitch_type": c.MainStitchType,
-			"stitch_density":   c.StitchDensity,
-			"overlock_threads": c.OverlockThreads,
-			"seam_allowances":  c.SeamAllowances,
-			"hem_finish":       c.HemFinish,
-			"pressing":         c.Pressing,
-			"machine_class":    c.MachineClass,
-			"notes":            c.Notes,
+			"tech_card_id":         tcID,
+			"main_stitch_type":     c.MainStitchType,
+			"stitch_density":       c.StitchDensity,
+			"overlock_threads":     c.OverlockThreads,
+			"seam_allowances":      c.SeamAllowances,
+			"hem_finish":           c.HemFinish,
+			"pressing":             c.Pressing,
+			"machine_class":        c.MachineClass,
+			"notes":                c.Notes,
+			"labour_rate":          c.LabourRate,
+			"labour_rate_currency": c.LabourRateCurrency,
 		}); err != nil {
 		return fmt.Errorf("failed to insert tech card construction: %w", err)
 	}
@@ -44,15 +46,20 @@ func insertTechCardOperations(ctx context.Context, db dependency.DB, tcID int, o
 	rows := make([]map[string]any, 0, len(ops))
 	for i, o := range ops {
 		rows = append(rows, map[string]any{
-			"tech_card_id":    tcID,
-			"node":            o.Node,
-			"description":     o.Description,
-			"seam_type":       o.SeamType,
-			"stitches_per_cm": o.StitchesPerCm,
-			"topstitch_width": o.TopstitchWidth,
-			"thread":          o.Thread,
-			"note":            o.Note,
-			"display_order":   i,
+			"tech_card_id":     tcID,
+			"operation_number": o.OperationNumber,
+			"node":             o.Node,
+			"description":      o.Description,
+			"seam_type":        o.SeamType,
+			"machine":          o.Machine,
+			"stitches_per_cm":  o.StitchesPerCm,
+			"topstitch_width":  o.TopstitchWidth,
+			"seam_allowance":   o.SeamAllowance,
+			"thread":           o.Thread,
+			"needle":           o.Needle,
+			"time_norm":        o.TimeNorm,
+			"note":             o.Note,
+			"display_order":    i,
 		})
 	}
 	if err := storeutil.BulkInsert(ctx, db, "tech_card_operation", rows); err != nil {
@@ -141,11 +148,40 @@ func insertTechCardCosting(ctx context.Context, db dependency.DB, tcID int, c *e
 	return nil
 }
 
+func insertTechCardIssues(ctx context.Context, db dependency.DB, tcID int, issues []entity.TechCardIssue) error {
+	if len(issues) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(issues))
+	for i, is := range issues {
+		rows = append(rows, map[string]any{
+			"tech_card_id":     tcID,
+			"operation_number": is.OperationNumber,
+			"callout_number":   is.CalloutNumber,
+			"raised_by":        is.RaisedBy,
+			"severity":         string(is.Severity),
+			"status":           string(is.Status),
+			"description":      is.Description,
+			"resolution_note":  is.ResolutionNote,
+			"display_order":    i,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_issue", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card issues: %w", err)
+	}
+	return nil
+}
+
 // --- enrich (load production sections for read paths) ---
 
 type techCardConstructionRow struct {
 	TechCardID int `db:"tech_card_id"`
 	entity.TechCardConstruction
+}
+
+type techCardIssueRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardIssue
 }
 
 type techCardOperationRow struct {
@@ -191,7 +227,8 @@ func (s *Store) enrichProduction(ctx context.Context, cards []entity.TechCard) e
 	}
 
 	opRows, err := storeutil.QueryListNamed[techCardOperationRow](ctx, s.DB, `
-		SELECT tech_card_id, node, description, seam_type, stitches_per_cm, topstitch_width, thread, note
+		SELECT tech_card_id, operation_number, node, description, seam_type, machine, stitches_per_cm,
+		       topstitch_width, seam_allowance, thread, needle, time_norm, note
 		FROM tech_card_operation
 		WHERE tech_card_id IN (:ids)
 		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
@@ -238,6 +275,19 @@ func (s *Store) enrichProduction(ctx context.Context, cards []entity.TechCard) e
 		costByCard[costRows[i].TechCardID] = &c
 	}
 
+	issueRows, err := storeutil.QueryListNamed[techCardIssueRow](ctx, s.DB, `
+		SELECT tech_card_id, operation_number, callout_number, raised_by, severity, status, description, resolution_note
+		FROM tech_card_issue
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("can't load tech card issues: %w", err)
+	}
+	issuesByCard := make(map[int][]entity.TechCardIssue, len(ids))
+	for _, r := range issueRows {
+		issuesByCard[r.TechCardID] = append(issuesByCard[r.TechCardID], r.TechCardIssue)
+	}
+
 	for i := range cards {
 		id := cards[i].Id
 		cards[i].Construction = consByCard[id]
@@ -245,6 +295,7 @@ func (s *Store) enrichProduction(ctx context.Context, cards []entity.TechCard) e
 		cards[i].Labels = labelsByCard[id]
 		cards[i].Packaging = pkgByCard[id]
 		cards[i].Costing = costByCard[id]
+		cards[i].Issues = issuesByCard[id]
 	}
 	return nil
 }

--- a/internal/store/techcard/production.go
+++ b/internal/store/techcard/production.go
@@ -57,6 +57,7 @@ func insertTechCardOperations(ctx context.Context, db dependency.DB, tcID int, o
 			"seam_allowance":   o.SeamAllowance,
 			"thread":           o.Thread,
 			"needle":           o.Needle,
+			"attachment":       o.Attachment,
 			"time_norm":        o.TimeNorm,
 			"note":             o.Note,
 			"display_order":    i,
@@ -255,7 +256,7 @@ func (s *Store) enrichProduction(ctx context.Context, cards []entity.TechCard) e
 
 	opRows, err := storeutil.QueryListNamed[techCardOperationRow](ctx, s.DB, `
 		SELECT tech_card_id, operation_number, node, description, seam_type, machine, stitches_per_cm,
-		       topstitch_width, seam_allowance, thread, needle, time_norm, note
+		       topstitch_width, seam_allowance, thread, needle, attachment, time_norm, note
 		FROM tech_card_operation
 		WHERE tech_card_id IN (:ids)
 		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -88,22 +88,38 @@ func techCardHeaderParams(tc *entity.TechCardInsert) map[string]any {
 	}
 }
 
-// stampApprovalTimes auto-sets approved_at/released_at when the card enters the
-// corresponding state without the timestamp already provided.
-func (s *Store) stampApprovalTimes(tc *entity.TechCardInsert) {
-	approvedOrReleased := tc.ApprovalState == entity.TechCardApprovalApproved ||
-		tc.ApprovalState == entity.TechCardApprovalReleased
-	if approvedOrReleased && !tc.ApprovedAt.Valid {
-		tc.ApprovedAt = sql.NullTime{Time: s.Now(), Valid: true}
-	}
-	if tc.ApprovalState == entity.TechCardApprovalReleased && !tc.ReleasedAt.Valid {
-		tc.ReleasedAt = sql.NullTime{Time: s.Now(), Valid: true}
+// stampApprovalTimes makes the server authoritative for approved_at/released_at,
+// ignoring any client-sent value: the stamp is set on the transition INTO
+// approved/released, preserved across edits and re-release, and CLEARED when the
+// card leaves those states (e.g. re-opened to draft) so a stale stamp can never lie.
+func (s *Store) stampApprovalTimes(tc *entity.TechCardInsert, prevState entity.TechCardApprovalState, prevApprovedAt, prevReleasedAt sql.NullTime) {
+	now := sql.NullTime{Time: s.Now(), Valid: true}
+	prevApprovedish := prevState == entity.TechCardApprovalApproved || prevState == entity.TechCardApprovalReleased
+	switch tc.ApprovalState {
+	case entity.TechCardApprovalApproved, entity.TechCardApprovalReleased:
+		if prevApprovedish && prevApprovedAt.Valid {
+			tc.ApprovedAt = prevApprovedAt // keep the original approval time across edits
+		} else {
+			tc.ApprovedAt = now
+		}
+		if tc.ApprovalState == entity.TechCardApprovalReleased {
+			if prevState == entity.TechCardApprovalReleased && prevReleasedAt.Valid {
+				tc.ReleasedAt = prevReleasedAt
+			} else {
+				tc.ReleasedAt = now
+			}
+		} else {
+			tc.ReleasedAt = sql.NullTime{} // approved but not (yet) released
+		}
+	default: // draft, in_review, obsolete — clear both so re-open can't carry a stale stamp
+		tc.ApprovedAt = sql.NullTime{}
+		tc.ReleasedAt = sql.NullTime{}
 	}
 }
 
 // AddTechCard inserts a tech card and its child sections, returning the new id.
 func (s *Store) AddTechCard(ctx context.Context, tc *entity.TechCardInsert) (int, error) {
-	s.stampApprovalTimes(tc)
+	s.stampApprovalTimes(tc, "", sql.NullTime{}, sql.NullTime{})
 	var id int
 	err := s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
 		var err error
@@ -126,13 +142,14 @@ func (s *Store) AddTechCard(ctx context.Context, tc *entity.TechCardInsert) (int
 // mismatch), refuses to mutate a RELEASED card unless it is re-opened to DRAFT
 // (entity.ErrTechCardReleased), and returns sql.ErrNoRows when no card exists.
 func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardInsert, expectedLockVersion int) error {
-	s.stampApprovalTimes(tc)
 	err := s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
 		cur, err := storeutil.QueryNamedOne[struct {
-			LockVersion   int    `db:"lock_version"`
-			ApprovalState string `db:"approval_state"`
+			LockVersion   int          `db:"lock_version"`
+			ApprovalState string       `db:"approval_state"`
+			ApprovedAt    sql.NullTime `db:"approved_at"`
+			ReleasedAt    sql.NullTime `db:"released_at"`
 		}](ctx, rep.DB(),
-			`SELECT lock_version, approval_state FROM tech_card WHERE id = :id`, map[string]any{"id": id})
+			`SELECT lock_version, approval_state, approved_at, released_at FROM tech_card WHERE id = :id`, map[string]any{"id": id})
 		if err != nil {
 			if err == sql.ErrNoRows {
 				return sql.ErrNoRows
@@ -148,6 +165,8 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 			tc.ApprovalState != entity.TechCardApprovalDraft {
 			return entity.ErrTechCardReleased
 		}
+		// Server owns the lifecycle stamps (set on enter, cleared on re-open).
+		s.stampApprovalTimes(tc, entity.TechCardApprovalState(cur.ApprovalState), cur.ApprovedAt, cur.ReleasedAt)
 
 		params := techCardHeaderParams(tc)
 		params["id"] = id

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -179,7 +179,7 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 			"tech_card_callout", "tech_card_revision",
 			"tech_card_bom_item", "tech_card_colorway", "tech_card_pom_point",
 			"tech_card_construction", "tech_card_operation", "tech_card_label",
-			"tech_card_packaging", "tech_card_costing",
+			"tech_card_packaging", "tech_card_costing", "tech_card_issue",
 		} {
 			if err := storeutil.ExecNamed(ctx, rep.DB(),
 				fmt.Sprintf(`DELETE FROM %s WHERE tech_card_id = :id`, table),
@@ -316,7 +316,10 @@ func insertTechCardChildren(ctx context.Context, db dependency.DB, id int, tc *e
 	if err := insertTechCardPackaging(ctx, db, id, tc.Packaging); err != nil {
 		return err
 	}
-	return insertTechCardCosting(ctx, db, id, tc.Costing)
+	if err := insertTechCardCosting(ctx, db, id, tc.Costing); err != nil {
+		return err
+	}
+	return insertTechCardIssues(ctx, db, id, tc.Issues)
 }
 
 func insertTechCardSizes(ctx context.Context, db dependency.DB, id int, sizeIDs []int) error {

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -171,7 +171,7 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 		params := techCardHeaderParams(tc)
 		params["id"] = id
 		params["expected_lock_version"] = expectedLockVersion
-		if err := storeutil.ExecNamed(ctx, rep.DB(), `
+		rows, err := storeutil.ExecNamedRows(ctx, rep.DB(), `
 			UPDATE tech_card SET
 				lock_version = lock_version + 1,
 				style_number = :style_number, name = :name, brand = :brand, season = :season,
@@ -186,8 +186,14 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 				description = :description, concept = :concept, silhouette = :silhouette, collar = :collar,
 				fastening = :fastening, pockets = :pockets, sleeve_cuff = :sleeve_cuff, extra_details = :extra_details,
 				topstitching = :topstitching, aux_materials = :aux_materials, notes = :notes
-			WHERE id = :id AND lock_version = :expected_lock_version`, params); err != nil {
+			WHERE id = :id AND lock_version = :expected_lock_version`, params)
+		if err != nil {
 			return fmt.Errorf("failed to update tech card: %w", err)
+		}
+		// The row provably exists (loaded above), so 0 rows means lock_version moved
+		// under us — make the WHERE guard load-bearing, not just the in-Go check.
+		if rows == 0 {
+			return entity.ErrTechCardConflict
 		}
 
 		// Delete tech_card_bom_item before tech_card_colorway so the bom-colourway

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -276,7 +276,7 @@ func (s *Store) ListTechCards(ctx context.Context, limit, offset int, orderFacto
 // insertTechCardChildren inserts the size range, product links, sketch media,
 // callouts and revisions for a tech card (used by both Add and Update).
 func insertTechCardChildren(ctx context.Context, db dependency.DB, id int, tc *entity.TechCardInsert) error {
-	if err := insertTechCardSizes(ctx, db, id, tc.SizeIds); err != nil {
+	if err := insertTechCardSizes(ctx, db, id, tc.SizeIds, tc.SizeQuantities); err != nil {
 		return err
 	}
 	if err := insertTechCardProducts(ctx, db, id, tc.ProductIds); err != nil {
@@ -322,13 +322,21 @@ func insertTechCardChildren(ctx context.Context, db dependency.DB, id int, tc *e
 	return insertTechCardIssues(ctx, db, id, tc.Issues)
 }
 
-func insertTechCardSizes(ctx context.Context, db dependency.DB, id int, sizeIDs []int) error {
+func insertTechCardSizes(ctx context.Context, db dependency.DB, id int, sizeIDs []int, quantities []entity.TechCardSizeQuantity) error {
 	if len(sizeIDs) == 0 {
 		return nil
 	}
+	qtyBySize := make(map[int]int, len(quantities))
+	for _, q := range quantities {
+		qtyBySize[q.SizeId] = q.OrderQty
+	}
 	rows := make([]map[string]any, 0, len(sizeIDs))
 	for i, sid := range sizeIDs {
-		rows = append(rows, map[string]any{"tech_card_id": id, "size_id": sid, "display_order": i})
+		var orderQty any
+		if q, ok := qtyBySize[sid]; ok {
+			orderQty = q
+		}
+		rows = append(rows, map[string]any{"tech_card_id": id, "size_id": sid, "order_qty": orderQty, "display_order": i})
 	}
 	if err := storeutil.BulkInsert(ctx, db, "tech_card_size", rows); err != nil {
 		return fmt.Errorf("failed to insert tech card sizes: %w", err)
@@ -360,6 +368,7 @@ func insertTechCardMedia(ctx context.Context, db dependency.DB, id int, media []
 			"tech_card_id":  id,
 			"media_id":      m.MediaId,
 			"kind":          string(m.Kind),
+			"caption":       m.Caption,
 			"display_order": i,
 		})
 	}
@@ -382,6 +391,8 @@ func insertTechCardCallouts(ctx context.Context, db dependency.DB, id int, callo
 			"description":    c.Description,
 			"dimensions":     c.Dimensions,
 			"media_id":       c.MediaId,
+			"pos_x":          c.PosX,
+			"pos_y":          c.PosY,
 			"display_order":  i,
 		})
 	}

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -179,7 +179,7 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 			"tech_card_callout", "tech_card_revision",
 			"tech_card_bom_item", "tech_card_colorway", "tech_card_pom_point",
 			"tech_card_construction", "tech_card_operation", "tech_card_label",
-			"tech_card_packaging", "tech_card_costing", "tech_card_issue",
+			"tech_card_packaging", "tech_card_costing", "tech_card_issue", "tech_card_signoff",
 		} {
 			if err := storeutil.ExecNamed(ctx, rep.DB(),
 				fmt.Sprintf(`DELETE FROM %s WHERE tech_card_id = :id`, table),
@@ -319,7 +319,10 @@ func insertTechCardChildren(ctx context.Context, db dependency.DB, id int, tc *e
 	if err := insertTechCardCosting(ctx, db, id, tc.Costing); err != nil {
 		return err
 	}
-	return insertTechCardIssues(ctx, db, id, tc.Issues)
+	if err := insertTechCardIssues(ctx, db, id, tc.Issues); err != nil {
+		return err
+	}
+	return insertTechCardSignoffs(ctx, db, id, tc.Signoffs)
 }
 
 func insertTechCardSizes(ctx context.Context, db dependency.DB, id int, sizeIDs []int, quantities []entity.TechCardSizeQuantity) error {

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -35,17 +35,17 @@ func New(base storeutil.Base, txFunc TxFunc) *Store {
 
 // header columns shared by INSERT (AddTechCard) and UPDATE (UpdateTechCard).
 const techCardHeaderColumns = `style_number, name, brand, season, collection, category_id,
-	target_gender, stage, status, approval_state, approved_by, released_at, version, revision_date,
+	target_gender, stage, status, approval_state, approved_by, approved_at, released_at, version, revision_date,
 	base_model_id, base_sample_size_id, designer, constructor, technologist,
 	target_cost, target_retail_price, currency, measurement_unit,
-	description, silhouette, collar, fastening, pockets, sleeve_cuff, extra_details,
+	description, concept, silhouette, fastening, pockets, sleeve_cuff, extra_details, collar,
 	topstitching, aux_materials, notes`
 
 const techCardHeaderValues = `:style_number, :name, :brand, :season, :collection, :category_id,
-	:target_gender, :stage, :status, :approval_state, :approved_by, :released_at, :version, :revision_date,
+	:target_gender, :stage, :status, :approval_state, :approved_by, :approved_at, :released_at, :version, :revision_date,
 	:base_model_id, :base_sample_size_id, :designer, :constructor, :technologist,
 	:target_cost, :target_retail_price, :currency, :measurement_unit,
-	:description, :silhouette, :collar, :fastening, :pockets, :sleeve_cuff, :extra_details,
+	:description, :concept, :silhouette, :fastening, :pockets, :sleeve_cuff, :extra_details, :collar,
 	:topstitching, :aux_materials, :notes`
 
 func techCardHeaderParams(tc *entity.TechCardInsert) map[string]any {
@@ -61,6 +61,7 @@ func techCardHeaderParams(tc *entity.TechCardInsert) map[string]any {
 		"status":              tc.Status,
 		"approval_state":      string(tc.ApprovalState),
 		"approved_by":         tc.ApprovedBy,
+		"approved_at":         tc.ApprovedAt,
 		"released_at":         tc.ReleasedAt,
 		"version":             tc.Version,
 		"revision_date":       tc.RevisionDate,
@@ -83,11 +84,26 @@ func techCardHeaderParams(tc *entity.TechCardInsert) map[string]any {
 		"topstitching":        tc.Topstitching,
 		"aux_materials":       tc.AuxMaterials,
 		"notes":               tc.Notes,
+		"concept":             tc.Concept,
+	}
+}
+
+// stampApprovalTimes auto-sets approved_at/released_at when the card enters the
+// corresponding state without the timestamp already provided.
+func (s *Store) stampApprovalTimes(tc *entity.TechCardInsert) {
+	approvedOrReleased := tc.ApprovalState == entity.TechCardApprovalApproved ||
+		tc.ApprovalState == entity.TechCardApprovalReleased
+	if approvedOrReleased && !tc.ApprovedAt.Valid {
+		tc.ApprovedAt = sql.NullTime{Time: s.Now(), Valid: true}
+	}
+	if tc.ApprovalState == entity.TechCardApprovalReleased && !tc.ReleasedAt.Valid {
+		tc.ReleasedAt = sql.NullTime{Time: s.Now(), Valid: true}
 	}
 }
 
 // AddTechCard inserts a tech card and its child sections, returning the new id.
 func (s *Store) AddTechCard(ctx context.Context, tc *entity.TechCardInsert) (int, error) {
+	s.stampApprovalTimes(tc)
 	var id int
 	err := s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
 		var err error
@@ -105,36 +121,53 @@ func (s *Store) AddTechCard(ctx context.Context, tc *entity.TechCardInsert) (int
 	return id, nil
 }
 
-// UpdateTechCard updates a tech card and replaces its child sections. Returns
-// sql.ErrNoRows when no tech card with the given id exists.
-func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardInsert) error {
+// UpdateTechCard updates a tech card and replaces its child sections. It is
+// optimistically locked on expectedLockVersion (entity.ErrTechCardConflict on a
+// mismatch), refuses to mutate a RELEASED card unless it is re-opened to DRAFT
+// (entity.ErrTechCardReleased), and returns sql.ErrNoRows when no card exists.
+func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardInsert, expectedLockVersion int) error {
+	s.stampApprovalTimes(tc)
 	err := s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
-		exists, err := storeutil.QueryCountNamed(ctx, rep.DB(),
-			`SELECT COUNT(*) FROM tech_card WHERE id = :id`, map[string]any{"id": id})
+		cur, err := storeutil.QueryNamedOne[struct {
+			LockVersion   int    `db:"lock_version"`
+			ApprovalState string `db:"approval_state"`
+		}](ctx, rep.DB(),
+			`SELECT lock_version, approval_state FROM tech_card WHERE id = :id`, map[string]any{"id": id})
 		if err != nil {
-			return fmt.Errorf("failed to check tech card existence: %w", err)
+			if err == sql.ErrNoRows {
+				return sql.ErrNoRows
+			}
+			return fmt.Errorf("failed to load tech card for update: %w", err)
 		}
-		if exists == 0 {
-			return sql.ErrNoRows
+		if cur.LockVersion != expectedLockVersion {
+			return entity.ErrTechCardConflict
+		}
+		// A released card is frozen for the factory: only a re-open to draft is
+		// allowed; any other edit while still released is rejected.
+		if cur.ApprovalState == string(entity.TechCardApprovalReleased) &&
+			tc.ApprovalState != entity.TechCardApprovalDraft {
+			return entity.ErrTechCardReleased
 		}
 
 		params := techCardHeaderParams(tc)
 		params["id"] = id
+		params["expected_lock_version"] = expectedLockVersion
 		if err := storeutil.ExecNamed(ctx, rep.DB(), `
 			UPDATE tech_card SET
+				lock_version = lock_version + 1,
 				style_number = :style_number, name = :name, brand = :brand, season = :season,
 				collection = :collection, category_id = :category_id, target_gender = :target_gender,
 				stage = :stage, status = :status, approval_state = :approval_state,
-				approved_by = :approved_by, released_at = :released_at,
+				approved_by = :approved_by, approved_at = :approved_at, released_at = :released_at,
 				version = :version, revision_date = :revision_date,
 				base_model_id = :base_model_id, base_sample_size_id = :base_sample_size_id,
 				designer = :designer, constructor = :constructor, technologist = :technologist,
 				target_cost = :target_cost, target_retail_price = :target_retail_price, currency = :currency,
 				measurement_unit = :measurement_unit,
-				description = :description, silhouette = :silhouette, collar = :collar, fastening = :fastening,
-				pockets = :pockets, sleeve_cuff = :sleeve_cuff, extra_details = :extra_details,
+				description = :description, concept = :concept, silhouette = :silhouette, collar = :collar,
+				fastening = :fastening, pockets = :pockets, sleeve_cuff = :sleeve_cuff, extra_details = :extra_details,
 				topstitching = :topstitching, aux_materials = :aux_materials, notes = :notes
-			WHERE id = :id`, params); err != nil {
+			WHERE id = :id AND lock_version = :expected_lock_version`, params); err != nil {
 			return fmt.Errorf("failed to update tech card: %w", err)
 		}
 
@@ -157,7 +190,8 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 		return insertTechCardChildren(ctx, rep.DB(), id, tc)
 	})
 	if err != nil {
-		if err == sql.ErrNoRows {
+		switch err {
+		case sql.ErrNoRows, entity.ErrTechCardConflict, entity.ErrTechCardReleased:
 			return err
 		}
 		return fmt.Errorf("can't update tech card: %w", err)

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -2241,6 +2241,7 @@ message GetTechCardResponse {
 message UpdateTechCardRequest {
   int32 id = 1;
   common.TechCardInsert tech_card = 2;
+  int32 expected_lock_version = 3; // from GetTechCard; a mismatch means a concurrent edit -> Aborted
 }
 
 message UpdateTechCardResponse {}

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -264,6 +264,7 @@ message TechCardOperation {
   string seam_allowance = 10; // seam allowance for this узел
   string needle = 11; // needle size / type
   google.type.Decimal time_norm = 12; // SAM / норма времени, minutes
+  string attachment = 13; // folder / binder / guide / hemmer / presser-foot (приспособление)
 }
 
 // TechCardIssueSeverity ranks a flagged construction issue.
@@ -473,4 +474,5 @@ message TechCardListItem {
   google.protobuf.Timestamp created_at = 9;
   google.protobuf.Timestamp updated_at = 10;
   TechCardApprovalState approval_state = 11;
+  int32 lock_version = 12; // optimistic-lock token, so a list→edit needs no extra GET
 }

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -212,6 +212,8 @@ message TechCardConstruction {
   string pressing = 6; // ВТО / финишная отделка
   string machine_class = 7; // класс / группа машин
   string notes = 8;
+  google.type.Decimal labour_rate = 9; // cost per minute; × Σ(operation SAM) = labour cost
+  string labour_rate_currency = 10; // ISO 4217 for labour_rate
 }
 
 // TechCardOperation is one per-node sewing operation (Sheet «Обработка»).
@@ -223,6 +225,39 @@ message TechCardOperation {
   string topstitch_width = 5; // ширина отстрочки
   string thread = 6; // нитки (арт.)
   string note = 7;
+  int32 operation_number = 8; // human operation number (оп. 10, 20, …); 0 = unset
+  string machine = 9; // machine / equipment
+  string seam_allowance = 10; // seam allowance for this узел
+  string needle = 11; // needle size / type
+  google.type.Decimal time_norm = 12; // SAM / норма времени, minutes
+}
+
+// TechCardIssueSeverity ranks a flagged construction issue.
+enum TechCardIssueSeverity {
+  TECH_CARD_ISSUE_SEVERITY_UNKNOWN = 0; // defaults to MEDIUM on write
+  TECH_CARD_ISSUE_SEVERITY_LOW = 1;
+  TECH_CARD_ISSUE_SEVERITY_MEDIUM = 2;
+  TECH_CARD_ISSUE_SEVERITY_HIGH = 3;
+}
+
+// TechCardIssueStatus is the resolution state of a flagged issue.
+enum TechCardIssueStatus {
+  TECH_CARD_ISSUE_STATUS_UNKNOWN = 0; // defaults to OPEN on write
+  TECH_CARD_ISSUE_STATUS_OPEN = 1;
+  TECH_CARD_ISSUE_STATUS_RESOLVED = 2;
+  TECH_CARD_ISSUE_STATUS_WONTFIX = 3;
+}
+
+// TechCardIssue is a maker-flagged problem ("this seam is impossible") against an
+// operation or callout (Sheet «Обработка» / «Тех. эскиз»).
+message TechCardIssue {
+  int32 operation_number = 1; // the operation it concerns; 0 = none
+  int32 callout_number = 2; // the sketch callout it concerns; 0 = none
+  string raised_by = 3; // who flagged it (e.g. seamstress)
+  TechCardIssueSeverity severity = 4; // UNKNOWN defaults to MEDIUM
+  TechCardIssueStatus status = 5; // UNKNOWN defaults to OPEN
+  string description = 6; // what is hard / impossible (required)
+  string resolution_note = 7;
 }
 
 // TechCardLabel is one label / tag spec (Sheet «Этикетки и упаковка»).
@@ -276,6 +311,8 @@ message TechCardCosting {
   google.type.Decimal materials_cost = 13; // Σ BOM line_total in `currency` (and currency-less lines)
   google.type.Decimal total_cost = 14; // (materials_cost + cmt+hardware+packaging+logistics+overhead) × (1 + defect/100)
   bool has_unconverted_currencies = 15; // OUTPUT-ONLY: a BOM line is priced in a currency other than `currency`, so it is excluded from total_cost
+  google.type.Decimal total_sam = 16; // OUTPUT-ONLY: Σ of operation time_norm (minutes)
+  google.type.Decimal labour_cost = 17; // OUTPUT-ONLY: total_sam × construction.labour_rate (in labour_rate_currency)
 }
 
 // TechCardInsert is the writable payload for a tech card. Nested lists are full
@@ -340,9 +377,10 @@ message TechCardInsert {
   // hardening (Phase 3.5a)
   google.protobuf.Timestamp approved_at = 48; // auto-set on approve/release if unset
   string concept = 49; // design concept / intent (designer)
+  repeated TechCardIssue issues = 50; // maker-flagged construction issues
 
   // Reserved so a future field can never collide with a removed one.
-  reserved 39, 50 to 99;
+  reserved 39, 51 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -134,9 +134,13 @@ message TechCardBomItem {
   string color = 6; // base/default colour
   string composition = 7; // состав
   string spec = 8; // ширина / плотность
-  google.type.Decimal consumption = 9; // норма расхода
-  string unit = 10; // ед.
-  google.type.Decimal quantity = 11; // кол-во
+  // consumption vs quantity: fill ONE per line. consumption = per-garment rate of
+  // a measured material (fabric/lining/interlining/insulation/thread) in `unit`
+  // (м/см/г); quantity = discrete count of a countable trim (hardware/label/
+  // packaging), `unit` then = pcs. line_total uses quantity when set, else consumption.
+  google.type.Decimal consumption = 9; // норма расхода (measured materials)
+  string unit = 10; // ед. (м/см/г for consumption; pcs for quantity)
+  google.type.Decimal quantity = 11; // кол-во (countable trims)
   google.type.Decimal unit_price = 12; // цена/ед.
   string currency = 13; // ISO 4217 for unit_price
   string comment = 14;

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -48,12 +48,16 @@ enum TechCardMediaKind {
   TECH_CARD_MEDIA_KIND_DETAIL = 3; // detail / construction node
   TECH_CARD_MEDIA_KIND_LINING = 4; // internal structure / lining
   TECH_CARD_MEDIA_KIND_PREVIEW = 5; // cover preview
+  TECH_CARD_MEDIA_KIND_MOODBOARD = 6; // mood / inspiration board
+  TECH_CARD_MEDIA_KIND_REFERENCE = 7; // reference / fabric photo
+  TECH_CARD_MEDIA_KIND_SWATCH = 8; // colour / fabric swatch
 }
 
 // TechCardMediaItem is a writable sketch-media reference (id + kind).
 message TechCardMediaItem {
   int32 media_id = 1; // FK media(id)
   TechCardMediaKind kind = 2;
+  string caption = 3; // image caption / view name
 }
 
 // TechCardMediaFull is a resolved sketch-media reference for display.
@@ -69,6 +73,8 @@ message TechCardCallout {
   string description = 3; // описание, уточнение
   string dimensions = 4; // размеры / привязка
   int32 media_id = 5; // FK media(id); sketch this callout is pinned to (0 = unanchored)
+  google.type.Decimal pos_x = 6; // normalised x (0..1) of the marker on its sketch
+  google.type.Decimal pos_y = 7; // normalised y (0..1) of the marker on its sketch
 }
 
 // TechCardRevision is one entry in the spec-document changelog (what changed in
@@ -113,6 +119,15 @@ message TechCardColorway {
   TechCardLabDipStatus lab_dip_status = 3; // UNKNOWN defaults to PENDING
   int32 product_id = 4; // FK product(id); 0 = not yet published
   string comment = 5;
+  string pantone = 6; // headline Pantone code
+  string pantone_system = 7; // TCX|TPX|TPG|C|U (Pantone book)
+  string hex = 8; // screen approximation #RRGGBB
+  int32 swatch_media_id = 9; // FK media(id); approved physical swatch; 0 = none
+  int32 lab_dip_round = 10; // submission round (1, 2, …); 0 = unset
+  google.protobuf.Timestamp lab_dip_submitted_at = 11;
+  google.protobuf.Timestamp lab_dip_decided_at = 12;
+  string lab_dip_decided_by = 13;
+  string lab_dip_reject_reason = 14;
 }
 
 // TechCardBomColorwayColor is one «Колористика» matrix cell: the colour of a BOM
@@ -145,7 +160,26 @@ message TechCardBomItem {
   string currency = 13; // ISO 4217 for unit_price
   string comment = 14;
   repeated TechCardBomColorwayColor colorway_colors = 15; // per-colourway colours
-  google.type.Decimal line_total = 16; // OUTPUT-ONLY: quantity*unit_price (else consumption*unit_price)
+  google.type.Decimal line_total = 16; // OUTPUT-ONLY: gross of wastage_percent; quantity*unit_price else consumption*unit_price
+  // fabric data for the cutter / marker (Phase 3.5c)
+  google.type.Decimal fabric_width = 17; // usable width, cm
+  google.type.Decimal fabric_weight_gsm = 18; // weight, g/m²
+  TechCardFabricDirection fabric_direction = 19; // nap / layout
+  google.type.Decimal wastage_percent = 20; // cutting wastage %, folded into line_total
+}
+
+// TechCardFabricDirection is the cutting layout a fabric requires.
+enum TechCardFabricDirection {
+  TECH_CARD_FABRIC_DIRECTION_UNKNOWN = 0;
+  TECH_CARD_FABRIC_DIRECTION_ANY = 1; // all-way (no nap)
+  TECH_CARD_FABRIC_DIRECTION_ONE_WAY = 2; // napped / directional, one-way marker
+  TECH_CARD_FABRIC_DIRECTION_TWO_WAY = 3; // two-way
+}
+
+// TechCardSizeQuantity is the production order quantity for a size (size run).
+message TechCardSizeQuantity {
+  int32 size_id = 1; // FK size(id); must be one of size_ids
+  int32 order_qty = 2;
 }
 
 // TechCardPomGrade is the graded value of a POM point for one size.
@@ -378,9 +412,10 @@ message TechCardInsert {
   google.protobuf.Timestamp approved_at = 48; // auto-set on approve/release if unset
   string concept = 49; // design concept / intent (designer)
   repeated TechCardIssue issues = 50; // maker-flagged construction issues
+  repeated TechCardSizeQuantity size_quantities = 51; // per-size order quantity (size run)
 
   // Reserved so a future field can never collide with a removed one.
-  reserved 39, 51 to 99;
+  reserved 39, 52 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -351,6 +351,37 @@ message TechCardCosting {
 
 // TechCardInsert is the writable payload for a tech card. Nested lists are full
 // replacements on update (like ProductNew).
+// TechCardSignoffSection is the sheet a sign-off covers.
+enum TechCardSignoffSection {
+  TECH_CARD_SIGNOFF_SECTION_UNKNOWN = 0;
+  TECH_CARD_SIGNOFF_SECTION_DESIGN = 1;
+  TECH_CARD_SIGNOFF_SECTION_CONSTRUCTION = 2;
+  TECH_CARD_SIGNOFF_SECTION_POM = 3;
+  TECH_CARD_SIGNOFF_SECTION_MATERIALS = 4;
+  TECH_CARD_SIGNOFF_SECTION_COLOUR = 5;
+  TECH_CARD_SIGNOFF_SECTION_LABELS = 6;
+  TECH_CARD_SIGNOFF_SECTION_PACKAGING = 7;
+  TECH_CARD_SIGNOFF_SECTION_COSTING = 8;
+}
+
+// TechCardSignoffState is the sign-off decision for a section.
+enum TechCardSignoffState {
+  TECH_CARD_SIGNOFF_STATE_UNKNOWN = 0; // defaults to PENDING on write
+  TECH_CARD_SIGNOFF_STATE_PENDING = 1;
+  TECH_CARD_SIGNOFF_STATE_APPROVED = 2;
+  TECH_CARD_SIGNOFF_STATE_REJECTED = 3;
+}
+
+// TechCardSignoff records one responsible role's sign-off of a sheet, so the
+// header approval_state isn't the only gate (Sheet «Титул» coordination).
+message TechCardSignoff {
+  TechCardSignoffSection section = 1; // required; unique per card
+  TechCardSignoffState state = 2; // UNKNOWN defaults to PENDING
+  string signed_by = 3; // who signed (free text / role name)
+  google.protobuf.Timestamp signed_at = 4;
+  string note = 5;
+}
+
 message TechCardInsert {
   // identification (Sheet «Титул»)
   string style_number = 1; // Артикул (required)
@@ -413,9 +444,10 @@ message TechCardInsert {
   string concept = 49; // design concept / intent (designer)
   repeated TechCardIssue issues = 50; // maker-flagged construction issues
   repeated TechCardSizeQuantity size_quantities = 51; // per-size order quantity (size run)
+  repeated TechCardSignoff signoffs = 52; // per-section sign-off
 
   // Reserved so a future field can never collide with a removed one.
-  reserved 39, 52 to 99;
+  reserved 39, 53 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -343,10 +343,10 @@ message TechCardCosting {
   // OUTPUT-ONLY computed rollup (ignored on write; no currency conversion).
   repeated TechCardCostLine materials_total = 12; // Σ BOM line_total grouped by BOM currency
   google.type.Decimal materials_cost = 13; // Σ BOM line_total in `currency` (and currency-less lines)
-  google.type.Decimal total_cost = 14; // (materials_cost + cmt+hardware+packaging+logistics+overhead) × (1 + defect/100)
-  bool has_unconverted_currencies = 15; // OUTPUT-ONLY: a BOM line is priced in a currency other than `currency`, so it is excluded from total_cost
+  google.type.Decimal total_cost = 14; // (materials_cost + make + hardware+packaging+logistics+overhead) × (1 + defect/100); make = cmt_cost, or computed labour_cost when cmt_cost is unset and same currency
+  bool has_unconverted_currencies = 15; // OUTPUT-ONLY: a BOM line (or computed labour) is in a currency other than `currency`, so it is excluded from total_cost
   google.type.Decimal total_sam = 16; // OUTPUT-ONLY: Σ of operation time_norm (minutes)
-  google.type.Decimal labour_cost = 17; // OUTPUT-ONLY: total_sam × construction.labour_rate (in labour_rate_currency)
+  google.type.Decimal labour_cost = 17; // OUTPUT-ONLY: total_sam × construction.labour_rate (in labour_rate_currency); folded into total_cost as the make cost when cmt_cost is unset and currencies match
 }
 
 // TechCardInsert is the writable payload for a tech card. Nested lists are full

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -154,11 +154,25 @@ message TechCardPomGrade {
   google.type.Decimal value = 2;
 }
 
-// TechCardPomActual is an actual measured value, optionally taken in a fitting.
+// TechCardPomVerdict is the computed in/out-of-tolerance result of an actual.
+enum TechCardPomVerdict {
+  TECH_CARD_POM_VERDICT_UNKNOWN = 0; // no target (no grade for the size and no base value)
+  TECH_CARD_POM_VERDICT_IN_TOLERANCE = 1;
+  TECH_CARD_POM_VERDICT_OVER = 2; // above target + tolerance_plus
+  TECH_CARD_POM_VERDICT_UNDER = 3; // below target - tolerance_minus
+}
+
+// TechCardPomActual is an actual measured value, optionally taken in a fitting and
+// at a specific size (so QC can compare it to that size's grade ± tolerance).
 message TechCardPomActual {
   int32 fitting_id = 1; // FK fitting(id); 0 = none
   string label = 2; // free label when no fitting linked (e.g. примерка 1)
   google.type.Decimal value = 3;
+  int32 size_id = 4; // FK size(id); 0 = unset. Must be one of size_ids when set.
+  // OUTPUT-ONLY: deviation = value - target (grade at size_id, else base_value);
+  // verdict compares the deviation against tolerance_plus / tolerance_minus.
+  google.type.Decimal deviation = 5;
+  TechCardPomVerdict verdict = 6;
 }
 
 // TechCardPomPoint is a point of measure with its grade and actuals (Sheet «Измерения»).
@@ -261,6 +275,7 @@ message TechCardCosting {
   repeated TechCardCostLine materials_total = 12; // Σ BOM line_total grouped by BOM currency
   google.type.Decimal materials_cost = 13; // Σ BOM line_total in `currency` (and currency-less lines)
   google.type.Decimal total_cost = 14; // (materials_cost + cmt+hardware+packaging+logistics+overhead) × (1 + defect/100)
+  bool has_unconverted_currencies = 15; // OUTPUT-ONLY: a BOM line is priced in a currency other than `currency`, so it is excluded from total_cost
 }
 
 // TechCardInsert is the writable payload for a tech card. Nested lists are full
@@ -322,8 +337,12 @@ message TechCardInsert {
   TechCardPackaging packaging = 46; // 1:1; null = unset
   TechCardCosting costing = 47; // 1:1; null = unset
 
+  // hardening (Phase 3.5a)
+  google.protobuf.Timestamp approved_at = 48; // auto-set on approve/release if unset
+  string concept = 49; // design concept / intent (designer)
+
   // Reserved so a future field can never collide with a removed one.
-  reserved 39, 48 to 99;
+  reserved 39, 50 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.
@@ -333,6 +352,7 @@ message TechCard {
   google.protobuf.Timestamp created_at = 3;
   google.protobuf.Timestamp updated_at = 4;
   repeated TechCardMediaFull resolved_media = 5; // sketch media with resolved MediaFull
+  int32 lock_version = 6; // optimistic-lock token; echo into UpdateTechCardRequest.expected_lock_version
 }
 
 // TechCardListItem is a lightweight tech-card header for list views.


### PR DESCRIPTION
Brings the tech-card feature on `feat/tech-card` up to date on `beta` (PR #19 stopped at `cf02671`). Adds Phase 3.5 depth/hardening, per-section sign-off, and the fixes from the multi-agent technical + garment-domain reviews.

## What's in this range (cf02671 → f63d895)
- **Phase 3.5a/b/c** (migrations 0071–0073): optimistic locking (`lock_version`) + RELEASED freeze + POM verdict; operations depth (operation_number, machine, needle, seam_allowance, SAM) + `tech_card_issue` maker channel + labour rate; colourway lab-dip audit (pantone/system/hex/swatch/round/dates/decided_by/reject_reason), BOM fabric attrs (width/GSM/direction/wastage), per-size `order_qty`, media captions + moodboard/reference/swatch kinds, callout x/y.
- **Per-section sign-off** (0074): designer/constructor/technologist sign-off.
- **Phase 3 review fixes** (a72a437, f63d895): computed labour folds into `total_cost` as the make cost when no manual CMT (currency-guarded); POM verdict no longer falls back across sizes (ungraded size → UNKNOWN); `approved_at`/`released_at` server-authoritative (cleared on re-open); release gate also blocks on an open high-severity issue; hex/pantone_system validated in DTO (CHECK→400); optimistic `WHERE lock_version` made load-bearing via RowsAffected; operation `attachment` field (0075); `lock_version` on list items.

## Notes
- Migrations **0071–0075** auto-apply to `grbpwr_beta` on deploy. They ALTER unreleased tech_card* tables (no existing data) plus `fitting` (0069: add nullable `tech_card_id`, widen `product_id` to NULL — safe against existing rows).
- Tech pack now covers all 9 sheets (Титул → Калькуляция).
- Reviewed across all 3 phases (technical + tailor/seamstress/confectioner/production lenses); findings fixed or consciously deferred. `internal/store` integration tests need a live MySQL; dto/entity unit tests are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)