### PR TITLE
Tech card: zero-timestamp NULL fix for CreateTechCard

### DIFF
--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -1256,21 +1256,32 @@ func requiredDecimalFromPb(d *pb_decimal.Decimal, field string, maxFrac int, lim
 }
 
 // nullTimeFromPbTimestamp maps an optional timestamp to a nullable instant,
-// preserving the full time (the column is a TIMESTAMP, e.g. released_at).
+// preserving the full time (the column is a TIMESTAMP, e.g. released_at). The
+// grpc-gateway serialises an unset Go time.Time as "0001-01-01T00:00:00Z" — a
+// non-nil timestamp holding the zero instant — so that is treated as NULL too,
+// otherwise MySQL rejects it ("Incorrect date value: '0000-00-00'", err 1292).
 func nullTimeFromPbTimestamp(ts *timestamppb.Timestamp) sql.NullTime {
 	if ts == nil {
 		return sql.NullTime{}
 	}
-	return sql.NullTime{Time: ts.AsTime().UTC(), Valid: true}
+	t := ts.AsTime().UTC()
+	if t.IsZero() {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: t, Valid: true}
 }
 
 // nullDateFromPbTimestamp maps an optional timestamp to a nullable DATE value,
-// normalised to UTC midnight (the column is a DATE).
+// normalised to UTC midnight (the column is a DATE). Like nullTimeFromPbTimestamp,
+// the zero instant ("0001-01-01T00:00:00Z") is treated as NULL.
 func nullDateFromPbTimestamp(ts *timestamppb.Timestamp) sql.NullTime {
 	if ts == nil {
 		return sql.NullTime{}
 	}
 	t := ts.AsTime().UTC()
+	if t.IsZero() {
+		return sql.NullTime{}
+	}
 	return sql.NullTime{Time: time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC), Valid: true}
 }
 

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -582,6 +582,37 @@ func TestConvertTechCardMaterialsDepth(t *testing.T) {
 	}
 }
 
+// TestConvertTechCardZeroTimestampsAreNull guards the grpc-gateway behaviour
+// where an unset Go time.Time is serialised as "0001-01-01T00:00:00Z" — a
+// non-nil timestamp at the zero instant. These must map to NULL, not be passed
+// through, or MySQL rejects the DATE/TIMESTAMP ("Incorrect date value:
+// '0000-00-00'", err 1292) and the whole tech card insert fails.
+func TestConvertTechCardZeroTimestampsAreNull(t *testing.T) {
+	zero := timestamppb.New(time.Time{})
+	in := &pb_common.TechCardInsert{
+		StyleNumber:  "ST-060",
+		Name:         "Hoodie",
+		RevisionDate: zero,
+		ReleasedAt:   zero,
+		ApprovedAt:   zero,
+		Revisions:    []*pb_common.TechCardRevision{{Version: "1", RevisionDate: zero}},
+		Colorways:    []*pb_common.TechCardColorway{{Name: "Ecru", LabDipSubmittedAt: zero, LabDipDecidedAt: zero}},
+	}
+	got, err := ConvertPbTechCardInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RevisionDate.Valid || got.ReleasedAt.Valid || got.ApprovedAt.Valid {
+		t.Errorf("header zero timestamps should be NULL: rev=%+v rel=%+v app=%+v", got.RevisionDate, got.ReleasedAt, got.ApprovedAt)
+	}
+	if got.Revisions[0].RevisionDate.Valid {
+		t.Errorf("revision zero date should be NULL: %+v", got.Revisions[0].RevisionDate)
+	}
+	if got.Colorways[0].LabDipSubmittedAt.Valid || got.Colorways[0].LabDipDecidedAt.Valid {
+		t.Errorf("colorway zero lab-dip dates should be NULL: %+v", got.Colorways[0])
+	}
+}
+
 func TestConvertTechCardSignoffs(t *testing.T) {
 	in := &pb_common.TechCardInsert{
 		StyleNumber: "ST-050", Name: "Tee",


### PR DESCRIPTION
## What

Fixes `CreateTechCard` failing when a tech card has any empty date field.

The grpc-gateway serialises an unset Go `time.Time` as `"0001-01-01T00:00:00Z"` — a non-nil timestamp at the zero instant. `nullDateFromPbTimestamp` / `nullTimeFromPbTimestamp` only guarded against `ts == nil`, so the zero instant was passed through with `Valid: true`. MySQL then rejected it on the DATE/TIMESTAMP columns (`Incorrect date value: '0000-00-00'`, err 1292), which surfaced as an opaque `Internal` / "can't add tech card".

Now the zero instant maps to NULL in both helpers, covering header `revision_date`, `approved_at`/`released_at`, per-row `revision_date`, and the colourway lab-dip dates. Adds a regression test.

## Scope

- Pure Go change (`internal/dto/techcard.go` + test). **No new migration.**
- The tech-card feature is already live on master/prod; this is a correctness fix on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)