### PR TITLE
feat(techcard): per-size PDF patterns, per-size BOM consumption, colorway materials, fitting patterns

### DIFF
--- a/internal/apisrv/admin/content.go
+++ b/internal/apisrv/admin/content.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/jekabolt/grbpwr-manager/internal/bucket"
@@ -11,6 +12,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// maxPatternFilename bounds the echoed/stored original pattern filename (mirrors the
+// tech_card_size_pattern.filename / fitting_pattern.filename VARCHAR(255) columns).
+const maxPatternFilename = 255
 
 // UploadContentImage
 func (s *Server) UploadContentImage(ctx context.Context, req *pb_admin.UploadContentImageRequest) (*pb_admin.UploadContentImageResponse, error) {
@@ -37,6 +42,33 @@ func (s *Server) UploadContentVideo(ctx context.Context, req *pb_admin.UploadCon
 	}
 	return &pb_admin.UploadContentVideoResponse{
 		Media: media,
+	}, nil
+}
+
+// UploadPattern uploads a raw PDF cut pattern (выкройка) and returns its url. The file is
+// stored in object storage (not the media library) and referenced by tech-card per-size
+// patterns and fitting iteration patterns.
+func (s *Server) UploadPattern(ctx context.Context, req *pb_admin.UploadPatternRequest) (*pb_admin.UploadPatternResponse, error) {
+	if len(req.GetFilename()) > maxPatternFilename {
+		return nil, status.Errorf(codes.InvalidArgument, "filename must be at most %d characters", maxPatternFilename)
+	}
+	url, sizeBytes, err := s.bucket.UploadPatternPDF(ctx, req.GetRaw(), bucket.GetMediaName())
+	if err != nil {
+		slog.Default().ErrorContext(ctx, "can't upload pattern pdf",
+			slog.String("err", err.Error()),
+		)
+		// A rejected payload (empty / too large / not a PDF) is the client's fault;
+		// anything else (e.g. an S3 PutObject failure) is an internal error.
+		code := codes.Internal
+		if errors.Is(err, bucket.ErrInvalidPattern) {
+			code = codes.InvalidArgument
+		}
+		return nil, status.Errorf(code, "failed to upload pattern: %v", err)
+	}
+	return &pb_admin.UploadPatternResponse{
+		Url:       url,
+		Filename:  req.GetFilename(),
+		SizeBytes: sizeBytes,
 	}, nil
 }
 

--- a/internal/bucket/pattern.go
+++ b/internal/bucket/pattern.go
@@ -1,0 +1,63 @@
+package bucket
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/minio/minio-go/v7"
+)
+
+const (
+	// maxPatternPayloadBytes caps an uploaded PDF выкройка (cut pattern).
+	maxPatternPayloadBytes = 25 * 1024 * 1024 // 25 MB
+	// patternFolder segregates pattern PDFs from image/video media in the bucket.
+	patternFolder = "tech-card-patterns"
+)
+
+// ErrInvalidPattern marks a rejected pattern payload (empty, too large, or not a PDF) so
+// the API layer can map it to InvalidArgument rather than Internal (an S3 failure).
+var ErrInvalidPattern = errors.New("invalid pattern file")
+
+// UploadPatternPDF stores a raw PDF cut pattern (выкройка) in object storage and returns
+// its CDN url plus the stored byte size. The payload must be a real PDF (sniffed by the
+// %PDF- magic header, not the caller-declared type). Unlike images and videos it is NOT
+// recorded in the media table — pattern files are kept out of the image library.
+func (b *Bucket) UploadPatternPDF(ctx context.Context, raw []byte, objectName string) (string, int64, error) {
+	if len(raw) == 0 {
+		return "", 0, fmt.Errorf("%w: payload is empty", ErrInvalidPattern)
+	}
+	if len(raw) > maxPatternPayloadBytes {
+		return "", 0, fmt.Errorf("%w: payload too large: %d bytes, max %d bytes", ErrInvalidPattern, len(raw), maxPatternPayloadBytes)
+	}
+	if !isPDF(raw) {
+		return "", 0, fmt.Errorf("%w: payload is not a PDF", ErrInvalidPattern)
+	}
+
+	ext, err := fileExtensionFromContentType(contentTypePDF)
+	if err != nil {
+		return "", 0, err
+	}
+	fp := b.constructFullPath(patternFolder, objectName, ext)
+
+	r := bytes.NewReader(raw)
+	_, err = b.Client.PutObject(ctx, b.S3BucketName, fp, r, int64(r.Len()),
+		minio.PutObjectOptions{
+			ContentType:  string(contentTypePDF),
+			CacheControl: "max-age=31536000",
+			UserMetadata: map[string]string{"x-amz-acl": "public-read"},
+		})
+	if err != nil {
+		slog.Default().ErrorContext(ctx, "can't upload pattern pdf",
+			slog.String("err", err.Error()))
+		return "", 0, err
+	}
+	return b.getCDNURL(fp), int64(len(raw)), nil
+}
+
+// isPDF reports whether raw starts with the PDF magic header (%PDF-).
+func isPDF(raw []byte) bool {
+	return len(raw) >= 5 && string(raw[:5]) == "%PDF-"
+}

--- a/internal/bucket/pattern_test.go
+++ b/internal/bucket/pattern_test.go
@@ -1,0 +1,22 @@
+package bucket
+
+import "testing"
+
+func TestIsPDF(t *testing.T) {
+	cases := map[string]struct {
+		in   []byte
+		want bool
+	}{
+		"valid pdf":   {[]byte("%PDF-1.7\n%âãÏÓ"), true},
+		"valid pdf17": {[]byte("%PDF-1.4 rest of file"), true},
+		"not pdf":     {[]byte("not a pdf at all"), false},
+		"png magic":   {[]byte("\x89PNG\r\n\x1a\n"), false},
+		"too short":   {[]byte("%PDF"), false},
+		"empty":       {[]byte(""), false},
+	}
+	for name, c := range cases {
+		if got := isPDF(c.in); got != c.want {
+			t.Errorf("%s: isPDF = %v, want %v", name, got, c.want)
+		}
+	}
+}

--- a/internal/bucket/utils.go
+++ b/internal/bucket/utils.go
@@ -20,6 +20,7 @@ const (
 	contentTypeJSON ContentType = "application/json"
 	contentTypeMP4  ContentType = "video/mp4"
 	contentTypeWEBM ContentType = "video/webm"
+	contentTypePDF  ContentType = "application/pdf"
 
 	// Image formats identified by content sniffing. Only JPEG/PNG/WebP/HEIC are
 	// decodable; AVIF/HEIF/GIF are recognized solely to emit a precise error.
@@ -36,6 +37,7 @@ var mimeTypeToFileExtension = map[ContentType]string{
 	contentTypeMP4:  "mp4",
 	contentTypeWEBM: "webm",
 	contentTypeWEBP: "webp",
+	contentTypePDF:  "pdf",
 }
 
 func fileExtensionFromContentType(contentType ContentType) (string, error) {

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -577,6 +577,9 @@ type (
 		UploadContentImage(ctx context.Context, rawB64Image, folder, imageName string) (*pb_common.MediaFull, error)
 		// UploadContentVideo uploads mp4 video to bucket
 		UploadContentVideo(ctx context.Context, raw []byte, folder, videoName, contentType string) (*pb_common.MediaFull, error)
+		// UploadPatternPDF uploads a raw PDF cut pattern (выкройка) and returns its url and
+		// stored byte size. The file is kept out of the media library.
+		UploadPatternPDF(ctx context.Context, raw []byte, objectName string) (string, int64, error)
 		// GetBaseFolder returns the base folder for the bucket
 		GetBaseFolder() string
 	}

--- a/internal/dto/fitting.go
+++ b/internal/dto/fitting.go
@@ -2,6 +2,7 @@ package dto
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
@@ -96,6 +97,35 @@ func ConvertPbFittingInsertToEntity(pb *pb_common.FittingInsert) (*entity.Fittin
 		mediaIds = append(mediaIds, int(mid))
 	}
 
+	patterns := make([]entity.FittingPattern, 0, len(pb.Patterns))
+	for _, p := range pb.Patterns {
+		if p.SizeId < 0 {
+			return nil, fmt.Errorf("fitting pattern size_id must not be negative")
+		}
+		url := strings.TrimSpace(p.Url)
+		if url == "" {
+			return nil, fmt.Errorf("fitting pattern url is required")
+		}
+		if len(url) > maxVarchar1024 {
+			return nil, fmt.Errorf("fitting pattern url must be at most %d characters", maxVarchar1024)
+		}
+		if !isHTTPURL(url) {
+			return nil, fmt.Errorf("fitting pattern url must be an http(s) URL")
+		}
+		if len(p.Filename) > maxVarchar255 {
+			return nil, fmt.Errorf("fitting pattern filename must be at most %d characters", maxVarchar255)
+		}
+		if p.SizeBytes < 0 {
+			return nil, fmt.Errorf("fitting pattern size_bytes must not be negative")
+		}
+		patterns = append(patterns, entity.FittingPattern{
+			SizeId:    nullInt32FromPb(p.SizeId),
+			URL:       url,
+			Filename:  nullStringFromPb(p.Filename),
+			SizeBytes: nullInt64FromPb(p.SizeBytes),
+		})
+	}
+
 	// Normalize to a UTC calendar date so storage into the DATE column is
 	// deterministic regardless of the incoming timestamp's time-of-day.
 	// (Clients should send the fitting date at UTC midnight.)
@@ -113,6 +143,7 @@ func ConvertPbFittingInsertToEntity(pb *pb_common.FittingInsert) (*entity.Fittin
 		RecordedBy:  nullStringFromPb(pb.RecordedBy),
 		Sizes:       sizes,
 		MediaIds:    mediaIds,
+		Patterns:    patterns,
 	}, nil
 }
 
@@ -151,9 +182,24 @@ func ConvertEntityFittingToPb(f *entity.Fitting) *pb_common.Fitting {
 			RecordedBy:  pbStringFromNull(f.RecordedBy),
 			Sizes:       sizes,
 			MediaIds:    mediaIds,
+			Patterns:    fittingPatternsToPb(f.Patterns),
 		},
 		Media:     media,
 		CreatedAt: timestamppb.New(f.CreatedAt),
 		UpdatedAt: timestamppb.New(f.UpdatedAt),
 	}
+}
+
+// fittingPatternsToPb emits a fitting's PDF выкройка iterations for display.
+func fittingPatternsToPb(ps []entity.FittingPattern) []*pb_common.FittingPattern {
+	out := make([]*pb_common.FittingPattern, 0, len(ps))
+	for _, p := range ps {
+		out = append(out, &pb_common.FittingPattern{
+			SizeId:    pbInt32FromNull(p.SizeId),
+			Url:       p.URL,
+			Filename:  pbStringFromNull(p.Filename),
+			SizeBytes: p.SizeBytes.Int64,
+		})
+	}
+	return out
 }

--- a/internal/dto/fitting_patterns_test.go
+++ b/internal/dto/fitting_patterns_test.go
@@ -1,0 +1,52 @@
+package dto
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestFittingPatternsRoundTrip(t *testing.T) {
+	in := &pb_common.FittingInsert{
+		TechCardId:  5,
+		FittingDate: timestamppb.New(time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)),
+		Patterns: []*pb_common.FittingPattern{
+			{SizeId: 4, Url: "https://cdn/iter1.pdf", Filename: "iter1.pdf", SizeBytes: 99},
+			{Url: "https://cdn/iter2.pdf"}, // size unset
+		},
+	}
+	ent, err := ConvertPbFittingInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(ent.Patterns) != 2 || ent.Patterns[0].URL != "https://cdn/iter1.pdf" ||
+		!ent.Patterns[0].SizeId.Valid || ent.Patterns[0].SizeId.Int32 != 4 {
+		t.Fatalf("fitting patterns parse mismatch: %+v", ent.Patterns)
+	}
+	if ent.Patterns[1].SizeId.Valid {
+		t.Fatalf("second pattern size should be unset")
+	}
+
+	out := ConvertEntityFittingToPb(&entity.Fitting{FittingInsert: *ent})
+	if len(out.Fitting.Patterns) != 2 || out.Fitting.Patterns[0].Filename != "iter1.pdf" ||
+		out.Fitting.Patterns[0].SizeBytes != 99 {
+		t.Fatalf("fitting patterns round-trip mismatch: %+v", out.Fitting.Patterns)
+	}
+	if out.Fitting.Patterns[1].SizeId != 0 {
+		t.Fatalf("second pattern size should emit 0, got %d", out.Fitting.Patterns[1].SizeId)
+	}
+}
+
+func TestFittingPatternURLRequired(t *testing.T) {
+	in := &pb_common.FittingInsert{
+		TechCardId:  5,
+		FittingDate: timestamppb.New(time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)),
+		Patterns:    []*pb_common.FittingPattern{{SizeId: 4, Url: ""}},
+	}
+	if _, err := ConvertPbFittingInsertToEntity(in); err == nil {
+		t.Fatalf("expected error for empty pattern url")
+	}
+}

--- a/internal/dto/model.go
+++ b/internal/dto/model.go
@@ -200,6 +200,13 @@ func nullInt32FromPb(v int32) sql.NullInt32 {
 	return sql.NullInt32{Int32: v, Valid: true}
 }
 
+func nullInt64FromPb(v int64) sql.NullInt64 {
+	if v == 0 {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: v, Valid: true}
+}
+
 func pbInt32FromNull(ni sql.NullInt32) int32 {
 	if ni.Valid {
 		return ni.Int32

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
@@ -16,9 +17,10 @@ import (
 // Column length bounds for tech-card varchar fields, mirroring the schema so that
 // over-length input fails as InvalidArgument rather than a MySQL 1406 Internal error.
 const (
-	maxVarchar32 = 32
-	maxVarchar64 = 64
-	maxCurrency  = 3
+	maxVarchar32   = 32
+	maxVarchar64   = 64
+	maxVarchar1024 = 1024
+	maxCurrency    = 3
 
 	// Decimal bounds mirroring the Phase 2 column types so over-range input fails
 	// as InvalidArgument, not a MySQL out-of-range Internal error.
@@ -325,7 +327,7 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 	if err != nil {
 		return nil, err
 	}
-	bomItems, err := parseTechCardBomItems(pb.BomItems, len(colorways))
+	bomItems, err := parseTechCardBomItems(pb.BomItems, len(colorways), sizeIds)
 	if err != nil {
 		return nil, err
 	}
@@ -371,6 +373,10 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		return nil, err
 	}
 	signoffs, err := parseTechCardSignoffs(pb.Signoffs)
+	if err != nil {
+		return nil, err
+	}
+	patterns, err := parseTechCardPatterns(pb.Patterns, sizeIds)
 	if err != nil {
 		return nil, err
 	}
@@ -443,7 +449,43 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		Issues:            issues,
 		SizeQuantities:    sizeQuantities,
 		Signoffs:          signoffs,
+		Patterns:          patterns,
 	}, nil
+}
+
+// parseTechCardPatterns parses the per-size PDF выкройки, validating each size is in the
+// card's size range, the url is present, and the filename is not over-long.
+func parseTechCardPatterns(pbs []*pb_common.TechCardSizePattern, sizeIds []int) ([]entity.TechCardSizePattern, error) {
+	out := make([]entity.TechCardSizePattern, 0, len(pbs))
+	for _, p := range pbs {
+		sid := int(p.SizeId)
+		if sid <= 0 || !slices.Contains(sizeIds, sid) {
+			return nil, fmt.Errorf("pattern size_id %d must be one of size_ids", p.SizeId)
+		}
+		url := strings.TrimSpace(p.Url)
+		if url == "" {
+			return nil, fmt.Errorf("pattern url is required")
+		}
+		if len(url) > maxVarchar1024 {
+			return nil, fmt.Errorf("pattern url must be at most %d characters", maxVarchar1024)
+		}
+		if !isHTTPURL(url) {
+			return nil, fmt.Errorf("pattern url must be an http(s) URL")
+		}
+		if len(p.Filename) > maxVarchar255 {
+			return nil, fmt.Errorf("pattern filename must be at most %d characters", maxVarchar255)
+		}
+		if p.SizeBytes < 0 {
+			return nil, fmt.Errorf("pattern size_bytes must not be negative")
+		}
+		out = append(out, entity.TechCardSizePattern{
+			SizeId:    sid,
+			URL:       url,
+			Filename:  nullStringFromPb(p.Filename),
+			SizeBytes: nullInt64FromPb(p.SizeBytes),
+		})
+	}
+	return out, nil
 }
 
 // ConvertEntityTechCardToPb converts an entity.TechCard to pb_common.TechCard.
@@ -496,6 +538,12 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 	sizeIds := intsToInt32(tc.SizeIds)
 	productIds := intsToInt32(tc.ProductIds)
 
+	// order quantity per size, used to compute each BOM line's size-run material cost.
+	orderQtyBySize := make(map[int]int, len(tc.SizeQuantities))
+	for _, q := range tc.SizeQuantities {
+		orderQtyBySize[q.SizeId] = q.OrderQty
+	}
+
 	return &pb_common.TechCard{
 		Id:          int32(tc.Id),
 		LockVersion: int32(tc.LockVersion),
@@ -542,8 +590,8 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Media:             media,
 			Callouts:          callouts,
 			Revisions:         revisions,
-			BomItems:          techCardBomItemsToPb(tc.BomItems),
-			Colorways:         techCardColorwaysToPb(tc.Colorways),
+			BomItems:          techCardBomItemsToPb(tc.BomItems, orderQtyBySize),
+			Colorways:         techCardColorwaysToPb(tc.Colorways, tc.BomItems),
 			PomPoints:         techCardPomPointsToPb(tc.PomPoints),
 			Construction:      techCardConstructionToPb(tc.Construction),
 			Operations:        techCardOperationsToPb(tc.Operations),
@@ -553,9 +601,24 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Issues:            techCardIssuesToPb(tc.Issues),
 			SizeQuantities:    techCardSizeQuantitiesToPb(tc.SizeQuantities),
 			Signoffs:          techCardSignoffsToPb(tc.Signoffs),
+			Patterns:          techCardPatternsToPb(tc.Patterns),
 		},
 		ResolvedMedia: resolved,
 	}
+}
+
+// techCardPatternsToPb emits the per-size PDF выкройки for display.
+func techCardPatternsToPb(ps []entity.TechCardSizePattern) []*pb_common.TechCardSizePattern {
+	out := make([]*pb_common.TechCardSizePattern, 0, len(ps))
+	for _, p := range ps {
+		out = append(out, &pb_common.TechCardSizePattern{
+			SizeId:    int32(p.SizeId),
+			Url:       p.URL,
+			Filename:  pbStringFromNull(p.Filename),
+			SizeBytes: p.SizeBytes.Int64,
+		})
+	}
+	return out
 }
 
 // ConvertEntityTechCardToListItemPb converts a header-only entity.TechCard to a
@@ -697,7 +760,7 @@ func parseTechCardColorways(pbs []*pb_common.TechCardColorway, productIds []int)
 	return out, nil
 }
 
-func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int) ([]entity.TechCardBomItem, error) {
+func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int, sizeIds []int) ([]entity.TechCardBomItem, error) {
 	out := make([]entity.TechCardBomItem, 0, len(pbs))
 	for _, b := range pbs {
 		section, ok := techCardBomSectionPbToEntity[b.Section]
@@ -771,6 +834,11 @@ func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int) 
 			})
 		}
 
+		sizeConsumptions, err := parseTechCardBomSizeConsumptions(b.SizeConsumptions, sizeIds)
+		if err != nil {
+			return nil, err
+		}
+
 		fabricWidth, err := nullDecimalFromPb(b.FabricWidth)
 		if err != nil {
 			return nil, fmt.Errorf("bom fabric_width: %w", err)
@@ -807,26 +875,54 @@ func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int) 
 		}
 
 		out = append(out, entity.TechCardBomItem{
-			Section:         section,
-			Name:            b.Name,
-			Placement:       nullStringFromPb(b.Placement),
-			Supplier:        nullStringFromPb(b.Supplier),
-			SupplierRef:     nullStringFromPb(b.SupplierRef),
-			Color:           nullStringFromPb(b.Color),
-			Composition:     nullStringFromPb(b.Composition),
-			Spec:            nullStringFromPb(b.Spec),
-			Consumption:     consumption,
-			Unit:            nullStringFromPb(b.Unit),
-			Quantity:        quantity,
-			UnitPrice:       unitPrice,
-			Currency:        nullStringFromPb(b.Currency),
-			Comment:         nullStringFromPb(b.Comment),
-			FabricWidth:     fabricWidth,
-			FabricWeightGsm: fabricGsm,
-			FabricDirection: direction,
-			WastagePercent:  wastage,
-			ColorwayColors:  colors,
+			Section:          section,
+			Name:             b.Name,
+			Placement:        nullStringFromPb(b.Placement),
+			Supplier:         nullStringFromPb(b.Supplier),
+			SupplierRef:      nullStringFromPb(b.SupplierRef),
+			Color:            nullStringFromPb(b.Color),
+			Composition:      nullStringFromPb(b.Composition),
+			Spec:             nullStringFromPb(b.Spec),
+			Consumption:      consumption,
+			Unit:             nullStringFromPb(b.Unit),
+			Quantity:         quantity,
+			UnitPrice:        unitPrice,
+			Currency:         nullStringFromPb(b.Currency),
+			Comment:          nullStringFromPb(b.Comment),
+			FabricWidth:      fabricWidth,
+			FabricWeightGsm:  fabricGsm,
+			FabricDirection:  direction,
+			WastagePercent:   wastage,
+			ColorwayColors:   colors,
+			SizeConsumptions: sizeConsumptions,
 		})
+	}
+	return out, nil
+}
+
+// parseTechCardBomSizeConsumptions parses the per-size consumption of a BOM material,
+// validating each size is in the card's size range, consumption is present and
+// non-negative, and no size repeats.
+func parseTechCardBomSizeConsumptions(pbs []*pb_common.TechCardBomSizeConsumption, sizeIds []int) ([]entity.TechCardBomSizeConsumption, error) {
+	out := make([]entity.TechCardBomSizeConsumption, 0, len(pbs))
+	seen := make(map[int]bool, len(pbs))
+	for _, sc := range pbs {
+		sid := int(sc.SizeId)
+		if sid <= 0 || !slices.Contains(sizeIds, sid) {
+			return nil, fmt.Errorf("bom size_consumption size_id %d must be one of size_ids", sc.SizeId)
+		}
+		if seen[sid] {
+			return nil, fmt.Errorf("duplicate bom size_consumption for size_id %d", sc.SizeId)
+		}
+		seen[sid] = true
+		consumption, err := requiredDecimalFromPb(sc.Consumption, "bom size_consumption", bomQtyMaxFrac, bomQtyLimit)
+		if err != nil {
+			return nil, err
+		}
+		if consumption.IsNegative() {
+			return nil, fmt.Errorf("bom size_consumption must not be negative")
+		}
+		out = append(out, entity.TechCardBomSizeConsumption{SizeId: sid, Consumption: consumption})
 	}
 	return out, nil
 }
@@ -945,9 +1041,27 @@ func parseTechCardPomPoints(pbs []*pb_common.TechCardPomPoint, sizeIds []int) ([
 
 // --- materials (Phase 2): emit entity -> pb ---
 
-func techCardColorwaysToPb(cws []entity.TechCardColorway) []*pb_common.TechCardColorway {
+// techCardColorwaysToPb emits colourways, attaching to each an OUTPUT-ONLY list of the BOM
+// materials used in it (inverted from bom_items[].colorway_colors — a colour cell means
+// the material is used in that colourway). This answers «which fabrics in which colourway»
+// without the frontend re-joining. The source of truth stays the BOM colour matrix.
+func techCardColorwaysToPb(cws []entity.TechCardColorway, bomItems []entity.TechCardBomItem) []*pb_common.TechCardColorway {
+	materialsByColorway := make(map[int][]*pb_common.TechCardColorwayMaterial, len(cws))
+	for i := range bomItems {
+		b := &bomItems[i]
+		for _, cc := range b.ColorwayColors {
+			materialsByColorway[cc.ColorwayIndex] = append(materialsByColorway[cc.ColorwayIndex],
+				&pb_common.TechCardColorwayMaterial{
+					BomItemIndex: int32(i),
+					MaterialName: b.Name,
+					Section:      pbBomSection(b.Section),
+					Color:        pbStringFromNull(cc.Color),
+					Pantone:      pbStringFromNull(cc.Pantone),
+				})
+		}
+	}
 	out := make([]*pb_common.TechCardColorway, 0, len(cws))
-	for _, c := range cws {
+	for idx, c := range cws {
 		out = append(out, &pb_common.TechCardColorway{
 			Code:               pbStringFromNull(c.Code),
 			Name:               c.Name,
@@ -963,12 +1077,13 @@ func techCardColorwaysToPb(cws []entity.TechCardColorway) []*pb_common.TechCardC
 			LabDipDecidedAt:    pbTimestampFromNullTime(c.LabDipDecidedAt),
 			LabDipDecidedBy:    pbStringFromNull(c.LabDipDecidedBy),
 			LabDipRejectReason: pbStringFromNull(c.LabDipRejectReason),
+			Materials:          materialsByColorway[idx],
 		})
 	}
 	return out
 }
 
-func techCardBomItemsToPb(items []entity.TechCardBomItem) []*pb_common.TechCardBomItem {
+func techCardBomItemsToPb(items []entity.TechCardBomItem, orderQtyBySize map[int]int) []*pb_common.TechCardBomItem {
 	out := make([]*pb_common.TechCardBomItem, 0, len(items))
 	for i := range items {
 		b := &items[i]
@@ -980,27 +1095,36 @@ func techCardBomItemsToPb(items []entity.TechCardBomItem) []*pb_common.TechCardB
 				Pantone:       pbStringFromNull(cc.Pantone),
 			})
 		}
+		sizeCons := make([]*pb_common.TechCardBomSizeConsumption, 0, len(b.SizeConsumptions))
+		for _, sc := range b.SizeConsumptions {
+			sizeCons = append(sizeCons, &pb_common.TechCardBomSizeConsumption{
+				SizeId:      int32(sc.SizeId),
+				Consumption: pbDecimalFromDecimal(sc.Consumption),
+			})
+		}
 		out = append(out, &pb_common.TechCardBomItem{
-			Section:         pbBomSection(b.Section),
-			Name:            b.Name,
-			Placement:       pbStringFromNull(b.Placement),
-			Supplier:        pbStringFromNull(b.Supplier),
-			SupplierRef:     pbStringFromNull(b.SupplierRef),
-			Color:           pbStringFromNull(b.Color),
-			Composition:     pbStringFromNull(b.Composition),
-			Spec:            pbStringFromNull(b.Spec),
-			Consumption:     pbDecimalFromNull(b.Consumption),
-			Unit:            pbStringFromNull(b.Unit),
-			Quantity:        pbDecimalFromNull(b.Quantity),
-			UnitPrice:       pbDecimalFromNull(b.UnitPrice),
-			Currency:        pbStringFromNull(b.Currency),
-			Comment:         pbStringFromNull(b.Comment),
-			ColorwayColors:  colors,
-			LineTotal:       pbDecimalFromNull(b.LineTotal()),
-			FabricWidth:     pbDecimalFromNull(b.FabricWidth),
-			FabricWeightGsm: pbDecimalFromNull(b.FabricWeightGsm),
-			FabricDirection: pbFabricDirection(b.FabricDirection),
-			WastagePercent:  pbDecimalFromNull(b.WastagePercent),
+			Section:          pbBomSection(b.Section),
+			Name:             b.Name,
+			Placement:        pbStringFromNull(b.Placement),
+			Supplier:         pbStringFromNull(b.Supplier),
+			SupplierRef:      pbStringFromNull(b.SupplierRef),
+			Color:            pbStringFromNull(b.Color),
+			Composition:      pbStringFromNull(b.Composition),
+			Spec:             pbStringFromNull(b.Spec),
+			Consumption:      pbDecimalFromNull(b.Consumption),
+			Unit:             pbStringFromNull(b.Unit),
+			Quantity:         pbDecimalFromNull(b.Quantity),
+			UnitPrice:        pbDecimalFromNull(b.UnitPrice),
+			Currency:         pbStringFromNull(b.Currency),
+			Comment:          pbStringFromNull(b.Comment),
+			ColorwayColors:   colors,
+			LineTotal:        pbDecimalFromNull(b.LineTotal()),
+			FabricWidth:      pbDecimalFromNull(b.FabricWidth),
+			FabricWeightGsm:  pbDecimalFromNull(b.FabricWeightGsm),
+			FabricDirection:  pbFabricDirection(b.FabricDirection),
+			WastagePercent:   pbDecimalFromNull(b.WastagePercent),
+			SizeConsumptions: sizeCons,
+			SizeRunTotal:     pbDecimalFromNull(b.SizeRunTotal(orderQtyBySize)),
 		})
 	}
 	return out
@@ -1018,6 +1142,12 @@ func pbFabricDirection(s sql.NullString) pb_common.TechCardFabricDirection {
 
 // validPantoneSystems mirrors the tech_card_colorway.pantone_system CHECK.
 var validPantoneSystems = map[string]bool{"TCX": true, "TPX": true, "TPG": true, "C": true, "U": true}
+
+// isHTTPURL reports whether s is an http(s) URL — pattern PDFs are served over the CDN,
+// so a non-http scheme (e.g. javascript:/data:) is rejected at the write boundary.
+func isHTTPURL(s string) bool {
+	return strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "http://")
+}
 
 // isHexColor reports whether s is a #RRGGBB colour (mirrors the colorway.hex CHECK).
 func isHexColor(s string) bool {

--- a/internal/dto/techcard_patterns_test.go
+++ b/internal/dto/techcard_patterns_test.go
@@ -1,0 +1,177 @@
+package dto
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
+	"github.com/shopspring/decimal"
+	pb_decimal "google.golang.org/genproto/googleapis/type/decimal"
+)
+
+// ndFrom builds a valid NullDecimal from a string for tests.
+func ndFrom(s string) decimal.NullDecimal {
+	return decimal.NullDecimal{Decimal: decimal.RequireFromString(s), Valid: true}
+}
+
+func TestTechCardBomSizeRunTotal(t *testing.T) {
+	b := entity.TechCardBomItem{
+		UnitPrice: ndFrom("2.00"),
+		SizeConsumptions: []entity.TechCardBomSizeConsumption{
+			{SizeId: 4, Consumption: decimal.RequireFromString("1.5")},
+			{SizeId: 5, Consumption: decimal.RequireFromString("1.8")},
+		},
+	}
+	// (1.5*10 + 1.8*20) * 2.00 = 51 * 2 = 102
+	got := b.SizeRunTotal(map[int]int{4: 10, 5: 20})
+	if !got.Valid || !got.Decimal.Equal(decimal.RequireFromString("102")) {
+		t.Fatalf("run total = %v (valid=%v), want 102", got.Decimal, got.Valid)
+	}
+	// with 10% wastage: 102 * 1.1 = 112.2
+	b.WastagePercent = ndFrom("10")
+	got = b.SizeRunTotal(map[int]int{4: 10, 5: 20})
+	if !got.Valid || !got.Decimal.Equal(decimal.RequireFromString("112.2")) {
+		t.Fatalf("run total w/ wastage = %v, want 112.2", got.Decimal)
+	}
+	// a size with no order quantity contributes nothing; here only size 4 has qty.
+	got = b.SizeRunTotal(map[int]int{4: 10})
+	if !got.Valid || !got.Decimal.Equal(decimal.RequireFromString("33")) { // 1.5*10*2*1.1
+		t.Fatalf("run total (partial qty) = %v, want 33", got.Decimal)
+	}
+	// no order quantities at all -> invalid so the rollup falls back to LineTotal.
+	if got := b.SizeRunTotal(map[int]int{}); got.Valid {
+		t.Fatalf("run total with no quantities should be invalid, got %v", got.Decimal)
+	}
+	// no per-size consumption -> invalid.
+	empty := entity.TechCardBomItem{UnitPrice: ndFrom("2")}
+	if got := empty.SizeRunTotal(map[int]int{4: 10}); got.Valid {
+		t.Fatalf("run total with no size consumption should be invalid")
+	}
+}
+
+func TestEffectiveBomLineTotalFallback(t *testing.T) {
+	// no per-size -> per-garment LineTotal (consumption*price).
+	perGarment := entity.TechCardBomItem{Consumption: ndFrom("2"), UnitPrice: ndFrom("3")}
+	if eff := effectiveBomLineTotal(&perGarment, map[int]int{4: 10}); !eff.Valid || !eff.Decimal.Equal(decimal.RequireFromString("6")) {
+		t.Fatalf("effective (fallback) = %v, want 6", eff.Decimal)
+	}
+	// per-size present + quantities -> size-run total.
+	perSize := entity.TechCardBomItem{
+		UnitPrice:        ndFrom("2"),
+		SizeConsumptions: []entity.TechCardBomSizeConsumption{{SizeId: 4, Consumption: decimal.RequireFromString("1.5")}},
+	}
+	if eff := effectiveBomLineTotal(&perSize, map[int]int{4: 10}); !eff.Valid || !eff.Decimal.Equal(decimal.RequireFromString("30")) {
+		t.Fatalf("effective (run) = %v, want 30", eff.Decimal)
+	}
+}
+
+func TestBomMaterialsRollupUsesRunTotal(t *testing.T) {
+	eur := sql.NullString{String: "EUR", Valid: true}
+	items := []entity.TechCardBomItem{
+		{ // per-size line: 1.5*10*2 = 30
+			Currency:         eur,
+			UnitPrice:        ndFrom("2"),
+			SizeConsumptions: []entity.TechCardBomSizeConsumption{{SizeId: 4, Consumption: decimal.RequireFromString("1.5")}},
+		},
+		{Currency: eur, Consumption: ndFrom("2"), UnitPrice: ndFrom("3")}, // per-garment: 6
+	}
+	lines, cost := bomMaterialsRollup(items, eur, map[int]int{4: 10})
+	if !cost.Equal(decimal.RequireFromString("36")) { // 30 + 6
+		t.Fatalf("materials cost = %v, want 36", cost)
+	}
+	if len(lines) != 1 || lines[0].Currency != "EUR" {
+		t.Fatalf("unexpected rollup lines: %+v", lines)
+	}
+}
+
+func TestTechCardPatternsAndColorwayMaterialsRoundTrip(t *testing.T) {
+	in := &pb_common.TechCardInsert{
+		StyleNumber: "ST-PAT",
+		Name:        "Coat",
+		SizeIds:     []int32{4, 5},
+		Colorways: []*pb_common.TechCardColorway{
+			{Name: "Black"},
+			{Name: "Navy"},
+		},
+		BomItems: []*pb_common.TechCardBomItem{
+			{
+				Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC,
+				Name:    "Main fabric",
+				ColorwayColors: []*pb_common.TechCardBomColorwayColor{
+					{ColorwayIndex: 0, Color: "Jet"},
+					{ColorwayIndex: 1, Color: "Indigo"},
+				},
+				SizeConsumptions: []*pb_common.TechCardBomSizeConsumption{
+					{SizeId: 4, Consumption: &pb_decimal.Decimal{Value: "1.5"}},
+					{SizeId: 5, Consumption: &pb_decimal.Decimal{Value: "1.8"}},
+				},
+			},
+		},
+		Patterns: []*pb_common.TechCardSizePattern{
+			{SizeId: 4, Url: "https://cdn/x4.pdf", Filename: "front-m.pdf", SizeBytes: 1234},
+			{SizeId: 4, Url: "https://cdn/x4b.pdf"}, // multiple per size is allowed
+			{SizeId: 5, Url: "https://cdn/x5.pdf"},
+		},
+	}
+	ent, err := ConvertPbTechCardInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(ent.Patterns) != 3 || ent.Patterns[0].SizeId != 4 || ent.Patterns[0].URL != "https://cdn/x4.pdf" {
+		t.Fatalf("patterns not parsed: %+v", ent.Patterns)
+	}
+	if len(ent.BomItems[0].SizeConsumptions) != 2 {
+		t.Fatalf("size consumptions not parsed: %+v", ent.BomItems[0].SizeConsumptions)
+	}
+
+	out := ConvertEntityTechCardToPb(&entity.TechCard{TechCardInsert: *ent})
+	if len(out.TechCard.Patterns) != 3 || out.TechCard.Patterns[0].Filename != "front-m.pdf" || out.TechCard.Patterns[0].SizeBytes != 1234 {
+		t.Fatalf("patterns round-trip mismatch: %+v", out.TechCard.Patterns)
+	}
+	if len(out.TechCard.Colorways) != 2 {
+		t.Fatalf("colorways: %d", len(out.TechCard.Colorways))
+	}
+	black := out.TechCard.Colorways[0]
+	if len(black.Materials) != 1 || black.Materials[0].MaterialName != "Main fabric" ||
+		black.Materials[0].Color != "Jet" || black.Materials[0].BomItemIndex != 0 {
+		t.Fatalf("colorway[0] materials mismatch: %+v", black.Materials)
+	}
+	navy := out.TechCard.Colorways[1]
+	if len(navy.Materials) != 1 || navy.Materials[0].Color != "Indigo" {
+		t.Fatalf("colorway[1] materials mismatch: %+v", navy.Materials)
+	}
+	// size-run total surfaced on the BOM line: (1.5*10 + 1.8*20)*... but no quantities
+	// here, so it must be empty and line_total carries the per-garment value (none set).
+	if out.TechCard.BomItems[0].SizeRunTotal != nil {
+		t.Fatalf("size_run_total should be empty without order quantities: %v", out.TechCard.BomItems[0].SizeRunTotal)
+	}
+}
+
+func TestTechCardPatternAndConsumptionValidation(t *testing.T) {
+	cases := map[string]*pb_common.TechCardInsert{
+		"pattern size not in range": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
+			Patterns: []*pb_common.TechCardSizePattern{{SizeId: 9, Url: "u"}}},
+		"pattern url required": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
+			Patterns: []*pb_common.TechCardSizePattern{{SizeId: 4, Url: "  "}}},
+		"pattern url not http": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
+			Patterns: []*pb_common.TechCardSizePattern{{SizeId: 4, Url: "javascript:alert(1)"}}},
+		"bom consumption size not in range": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
+			BomItems: []*pb_common.TechCardBomItem{{
+				Section:          pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC,
+				Name:             "f",
+				SizeConsumptions: []*pb_common.TechCardBomSizeConsumption{{SizeId: 9, Consumption: &pb_decimal.Decimal{Value: "1"}}},
+			}}},
+		"bom consumption negative": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
+			BomItems: []*pb_common.TechCardBomItem{{
+				Section:          pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC,
+				Name:             "f",
+				SizeConsumptions: []*pb_common.TechCardBomSizeConsumption{{SizeId: 4, Consumption: &pb_decimal.Decimal{Value: "-1"}}},
+			}}},
+	}
+	for name, in := range cases {
+		if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {
+			t.Errorf("%s: expected error, got nil", name)
+		}
+	}
+}

--- a/internal/dto/techcard_production.go
+++ b/internal/dto/techcard_production.go
@@ -624,7 +624,11 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 		return nil
 	}
 	c := tc.Costing
-	materialsTotal, materialsCost := bomMaterialsRollup(tc.BomItems, c.Currency)
+	orderQtyBySize := make(map[int]int, len(tc.SizeQuantities))
+	for _, q := range tc.SizeQuantities {
+		orderQtyBySize[q.SizeId] = q.OrderQty
+	}
+	materialsTotal, materialsCost := bomMaterialsRollup(tc.BomItems, c.Currency, orderQtyBySize)
 	out := &pb_common.TechCardCosting{
 		CmtCost:          pbDecimalFromNull(c.CmtCost),
 		HardwareCost:     pbDecimalFromNull(c.HardwareCost),
@@ -697,7 +701,7 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 	// the make cost but is in a different currency than the costing one.
 	for i := range tc.BomItems {
 		b := &tc.BomItems[i]
-		if b.Currency.Valid && b.Currency.String != "" && b.Currency.String != costingCcy && b.LineTotal().Valid {
+		if b.Currency.Valid && b.Currency.String != "" && b.Currency.String != costingCcy && effectiveBomLineTotal(b, orderQtyBySize).Valid {
 			out.HasUnconvertedCurrencies = true
 			break
 		}
@@ -708,14 +712,26 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 	return out
 }
 
+// effectiveBomLineTotal is a BOM line's contribution to the materials rollup: the size-run
+// total (Σ consumption_size × order_qty_size × price, gross of wastage) when the line has
+// per-size consumption and order quantities, otherwise the per-garment LineTotal. This is
+// the user's «per-size if present, else the old formula» rule applied per line.
+func effectiveBomLineTotal(b *entity.TechCardBomItem, orderQtyBySize map[int]int) decimal.NullDecimal {
+	if rt := b.SizeRunTotal(orderQtyBySize); rt.Valid {
+		return rt
+	}
+	return b.LineTotal()
+}
+
 // bomMaterialsRollup sums BOM line totals grouped by the line's currency (first-
 // seen order preserved), and returns the subtotal foldable into costingCurrency
-// (matching-currency lines plus currency-less lines).
-func bomMaterialsRollup(items []entity.TechCardBomItem, costingCurrency sql.NullString) ([]*pb_common.TechCardCostLine, decimal.Decimal) {
+// (matching-currency lines plus currency-less lines). A line with per-size consumption
+// contributes its full size-run cost (see effectiveBomLineTotal).
+func bomMaterialsRollup(items []entity.TechCardBomItem, costingCurrency sql.NullString, orderQtyBySize map[int]int) ([]*pb_common.TechCardCostLine, decimal.Decimal) {
 	byCcy := map[string]decimal.Decimal{}
 	order := make([]string, 0)
 	for i := range items {
-		lt := items[i].LineTotal()
+		lt := effectiveBomLineTotal(&items[i], orderQtyBySize)
 		if !lt.Valid {
 			continue
 		}

--- a/internal/entity/fitting.go
+++ b/internal/entity/fitting.go
@@ -45,20 +45,31 @@ type FittingSize struct {
 	FitNote sql.NullString `db:"fit_note"`
 }
 
+// FittingPattern is a PDF cut-pattern (выкройка) iteration measured in a fitting. It is a
+// snapshot of the uploaded file (url + filename), not a live reference to a tech-card
+// pattern — the tech card holds the final pattern, a fitting captures the iteration tried.
+type FittingPattern struct {
+	SizeId    sql.NullInt32  `db:"size_id"`
+	URL       string         `db:"url"`
+	Filename  sql.NullString `db:"filename"`
+	SizeBytes sql.NullInt64  `db:"size_bytes"`
+}
+
 // FittingInsert is the writable payload for a fitting session. A fitting anchors
 // to a tech card (the style) and/or a specific product (the colour/SKU sample);
 // at least one of TechCardId / ProductId is set (enforced in the API layer).
 type FittingInsert struct {
-	TechCardId  sql.NullInt32  `db:"tech_card_id"`
-	ProductId   sql.NullInt32  `db:"product_id"`
-	ModelId     sql.NullInt32  `db:"model_id"`
-	FittingDate time.Time      `db:"fitting_date"`
-	Comment     sql.NullString `db:"comment"`
-	Status      FittingStatus  `db:"status"`
-	Verdict     FittingVerdict `db:"verdict"`
-	RecordedBy  sql.NullString `db:"recorded_by"`
-	Sizes       []FittingSize  `db:"-"`
-	MediaIds    []int          `db:"-"`
+	TechCardId  sql.NullInt32    `db:"tech_card_id"`
+	ProductId   sql.NullInt32    `db:"product_id"`
+	ModelId     sql.NullInt32    `db:"model_id"`
+	FittingDate time.Time        `db:"fitting_date"`
+	Comment     sql.NullString   `db:"comment"`
+	Status      FittingStatus    `db:"status"`
+	Verdict     FittingVerdict   `db:"verdict"`
+	RecordedBy  sql.NullString   `db:"recorded_by"`
+	Sizes       []FittingSize    `db:"-"`
+	MediaIds    []int            `db:"-"`
+	Patterns    []FittingPattern `db:"-"`
 }
 
 // Fitting is a stored fitting session (fitting row + sizes + resolved media).

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -267,6 +267,16 @@ type TechCardBomItem struct {
 	// ColorwayColors are the per-colourway colours (in-memory; persisted to
 	// tech_card_bom_colorway).
 	ColorwayColors []TechCardBomColorwayColor `db:"-"`
+	// SizeConsumptions is the per-size material rate (in-memory; persisted to
+	// tech_card_bom_consumption). When non-empty it grades fabric usage per size.
+	SizeConsumptions []TechCardBomSizeConsumption `db:"-"`
+}
+
+// TechCardBomSizeConsumption is the per-size consumption (норма расхода) of a BOM
+// material — different sizes consume different amounts of fabric.
+type TechCardBomSizeConsumption struct {
+	SizeId      int             `db:"size_id"`
+	Consumption decimal.Decimal `db:"consumption"`
 }
 
 // TechCardFabricDirection enumerates the cutting layout a fabric requires.
@@ -303,10 +313,49 @@ func (b *TechCardBomItem) LineTotal() decimal.NullDecimal {
 	return decimal.NullDecimal{Decimal: total, Valid: true}
 }
 
+// SizeRunTotal returns the total material cost over the whole size run when this line has
+// per-size consumption: Σ(consumption_size × order_qty_size) × unit_price, grossed up by
+// wastage_percent. orderQtyBySize maps size_id → order quantity (a size with no order
+// quantity contributes nothing). It returns an INVALID NullDecimal when there is no
+// per-size consumption, no unit_price, or no order quantities at all — so the costing
+// rollup can fall back to the per-garment LineTotal (the user's "if per-size empty → old
+// formula" rule, extended to "no quantities yet → old formula"). NOTE: a per-size line's
+// run total is order-scale, whereas LineTotal is per-garment; a costing that mixes both
+// (some lines per-size, some not) mixes scales — kept per-line by explicit choice.
+func (b *TechCardBomItem) SizeRunTotal(orderQtyBySize map[int]int) decimal.NullDecimal {
+	if len(b.SizeConsumptions) == 0 || !b.UnitPrice.Valid {
+		return decimal.NullDecimal{}
+	}
+	totalQty := decimal.Zero
+	for _, sc := range b.SizeConsumptions {
+		qty, ok := orderQtyBySize[sc.SizeId]
+		if !ok || qty <= 0 {
+			continue
+		}
+		totalQty = totalQty.Add(sc.Consumption.Mul(decimal.NewFromInt(int64(qty))))
+	}
+	if totalQty.IsZero() {
+		return decimal.NullDecimal{}
+	}
+	total := totalQty.Mul(b.UnitPrice.Decimal)
+	if b.WastagePercent.Valid {
+		total = total.Mul(decimal.NewFromInt(1).Add(b.WastagePercent.Decimal.Div(decimal.NewFromInt(100))))
+	}
+	return decimal.NullDecimal{Decimal: total, Valid: true}
+}
+
 // TechCardSizeQuantity is the production order quantity for a size (size run).
 type TechCardSizeQuantity struct {
 	SizeId   int `db:"size_id"`
 	OrderQty int `db:"order_qty"`
+}
+
+// TechCardSizePattern is a final PDF cut pattern (выкройка) for one size of a tech card.
+type TechCardSizePattern struct {
+	SizeId    int            `db:"size_id"`
+	URL       string         `db:"url"`
+	Filename  sql.NullString `db:"filename"`
+	SizeBytes sql.NullInt64  `db:"size_bytes"`
 }
 
 // TechCardPomGrade is the graded value of a POM point for a size.
@@ -633,6 +682,7 @@ type TechCardInsert struct {
 	Issues         []TechCardIssue        `db:"-"`
 	SizeQuantities []TechCardSizeQuantity `db:"-"`
 	Signoffs       []TechCardSignoff      `db:"-"`
+	Patterns       []TechCardSizePattern  `db:"-"`
 }
 
 // TechCardListFilter holds optional filters for listing tech cards. Empty/zero

--- a/internal/store/fitting/fitting.go
+++ b/internal/store/fitting/fitting.go
@@ -47,7 +47,10 @@ func (s *Store) AddFitting(ctx context.Context, f *entity.FittingInsert) (int, e
 		if err := insertFittingSizes(ctx, rep.DB(), id, f.Sizes); err != nil {
 			return err
 		}
-		return insertFittingMedia(ctx, rep.DB(), id, f.MediaIds)
+		if err := insertFittingMedia(ctx, rep.DB(), id, f.MediaIds); err != nil {
+			return err
+		}
+		return insertFittingPatterns(ctx, rep.DB(), id, f.Patterns)
 	})
 	if err != nil {
 		return 0, fmt.Errorf("can't add fitting: %w", err)
@@ -92,10 +95,17 @@ func (s *Store) UpdateFitting(ctx context.Context, id int, f *entity.FittingInse
 			`DELETE FROM fitting_media WHERE fitting_id = :id`, map[string]any{"id": id}); err != nil {
 			return fmt.Errorf("failed to clear fitting media: %w", err)
 		}
+		if err := storeutil.ExecNamed(ctx, rep.DB(),
+			`DELETE FROM fitting_pattern WHERE fitting_id = :id`, map[string]any{"id": id}); err != nil {
+			return fmt.Errorf("failed to clear fitting patterns: %w", err)
+		}
 		if err := insertFittingSizes(ctx, rep.DB(), id, f.Sizes); err != nil {
 			return err
 		}
-		return insertFittingMedia(ctx, rep.DB(), id, f.MediaIds)
+		if err := insertFittingMedia(ctx, rep.DB(), id, f.MediaIds); err != nil {
+			return err
+		}
+		return insertFittingPatterns(ctx, rep.DB(), id, f.Patterns)
 	})
 	if err != nil {
 		return fmt.Errorf("can't update fitting: %w", err)
@@ -127,8 +137,13 @@ func (s *Store) GetFittingById(ctx context.Context, id int) (*entity.Fitting, er
 	if err != nil {
 		return nil, err
 	}
+	patterns, err := s.patternsByFittingIds(ctx, []int{id})
+	if err != nil {
+		return nil, err
+	}
 	f.Sizes = sizes[id]
 	f.Media = media[id]
+	f.Patterns = patterns[id]
 	return &f, nil
 }
 
@@ -188,9 +203,14 @@ func (s *Store) ListFittings(ctx context.Context, limit, offset int, orderFactor
 	if err != nil {
 		return nil, 0, err
 	}
+	patterns, err := s.patternsByFittingIds(ctx, ids)
+	if err != nil {
+		return nil, 0, err
+	}
 	for i := range fittings {
 		fittings[i].Sizes = sizes[fittings[i].Id]
 		fittings[i].Media = media[fittings[i].Id]
+		fittings[i].Patterns = patterns[fittings[i].Id]
 	}
 	return fittings, total, nil
 }
@@ -242,6 +262,27 @@ func insertFittingSizes(ctx context.Context, db dependency.DB, fittingID int, si
 	return nil
 }
 
+func insertFittingPatterns(ctx context.Context, db dependency.DB, fittingID int, patterns []entity.FittingPattern) error {
+	if len(patterns) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(patterns))
+	for i, p := range patterns {
+		rows = append(rows, map[string]any{
+			"fitting_id":    fittingID,
+			"size_id":       p.SizeId,
+			"url":           p.URL,
+			"filename":      p.Filename,
+			"size_bytes":    p.SizeBytes,
+			"display_order": i,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "fitting_pattern", rows); err != nil {
+		return fmt.Errorf("failed to insert fitting patterns: %w", err)
+	}
+	return nil
+}
+
 func insertFittingMedia(ctx context.Context, db dependency.DB, fittingID int, mediaIDs []int) error {
 	if len(mediaIDs) == 0 {
 		return nil
@@ -287,6 +328,30 @@ func (s *Store) sizesByFittingIds(ctx context.Context, ids []int) (map[int][]ent
 type fittingMediaRow struct {
 	FittingID int `db:"fitting_id"`
 	entity.MediaFull
+}
+
+type fittingPatternRow struct {
+	FittingID int `db:"fitting_id"`
+	entity.FittingPattern
+}
+
+func (s *Store) patternsByFittingIds(ctx context.Context, ids []int) (map[int][]entity.FittingPattern, error) {
+	if len(ids) == 0 {
+		return map[int][]entity.FittingPattern{}, nil
+	}
+	rows, err := storeutil.QueryListNamed[fittingPatternRow](ctx, s.DB, `
+		SELECT fitting_id, size_id, url, filename, size_bytes
+		FROM fitting_pattern
+		WHERE fitting_id IN (:ids)
+		ORDER BY fitting_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return nil, fmt.Errorf("can't load fitting patterns: %w", err)
+	}
+	out := make(map[int][]entity.FittingPattern, len(ids))
+	for _, r := range rows {
+		out[r.FittingID] = append(out[r.FittingID], r.FittingPattern)
+	}
+	return out, nil
 }
 
 func (s *Store) mediaByFittingIds(ctx context.Context, ids []int) (map[int][]entity.MediaFull, error) {

--- a/internal/store/sql/0077_tech_card_and_fitting_patterns.sql
+++ b/internal/store/sql/0077_tech_card_and_fitting_patterns.sql
@@ -1,0 +1,43 @@
+-- +migrate Up
+-- PDF выкройки (cut patterns) for tech cards and fittings.
+--
+-- A tech card stores the FINAL pattern per size (tech_card_size_pattern); a fitting
+-- stores the ITERATION pattern(s) actually tried on (fitting_pattern). Both reference a
+-- raw PDF in object storage by url (uploaded via Admin.UploadPattern) — the binary is
+-- NOT kept in the `media` table, which is image/video-shaped (full/compressed/thumbnail
+-- + dimensions + blurhash) and backs the image library. A size can carry several
+-- patterns (pieces split across sheets), so neither table is UNIQUE on (parent, size).
+
+CREATE TABLE tech_card_size_pattern (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  size_id INT NOT NULL COMMENT 'FK size(id); the graded size this выкройка is for',
+  url VARCHAR(1024) NOT NULL COMMENT 'CDN url of the uploaded PDF',
+  filename VARCHAR(255) NULL COMMENT 'original filename for display / download',
+  size_bytes BIGINT NULL COMMENT 'stored file size in bytes',
+  content_type VARCHAR(64) NOT NULL DEFAULT 'application/pdf',
+  display_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_tech_card_size_pattern_card_size (tech_card_id, size_id),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE,
+  FOREIGN KEY (size_id) REFERENCES size(id)
+) COMMENT 'Final PDF cut patterns (выкройки) per tech-card size';
+
+CREATE TABLE fitting_pattern (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  fitting_id INT NOT NULL,
+  size_id INT NULL COMMENT 'FK size(id); NULL = unset (which size this iteration is for)',
+  url VARCHAR(1024) NOT NULL COMMENT 'CDN url of the uploaded PDF',
+  filename VARCHAR(255) NULL COMMENT 'original filename for display / download',
+  size_bytes BIGINT NULL COMMENT 'stored file size in bytes',
+  content_type VARCHAR(64) NOT NULL DEFAULT 'application/pdf',
+  display_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_fitting_pattern_fitting (fitting_id),
+  FOREIGN KEY (fitting_id) REFERENCES fitting(id) ON DELETE CASCADE,
+  FOREIGN KEY (size_id) REFERENCES size(id)
+) COMMENT 'PDF cut-pattern iterations measured in a fitting';
+
+-- +migrate Down
+DROP TABLE fitting_pattern;
+DROP TABLE tech_card_size_pattern;

--- a/internal/store/sql/0078_tech_card_bom_size_consumption.sql
+++ b/internal/store/sql/0078_tech_card_bom_size_consumption.sql
@@ -1,0 +1,22 @@
+-- +migrate Up
+-- Per-size fabric consumption for BOM lines. Different sizes consume different amounts of
+-- fabric, so a single per-garment `consumption` on tech_card_bom_item understates the size
+-- run. tech_card_bom_consumption holds the measured rate per size; the size-run cost folds
+-- it against the per-size order quantities (tech_card_size.order_qty). When a line has no
+-- per-size rows, the single `consumption` stays the fallback (existing behaviour), so this
+-- migration is safe against existing tech cards.
+
+CREATE TABLE tech_card_bom_consumption (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  bom_item_id INT NOT NULL,
+  size_id INT NOT NULL COMMENT 'FK size(id); one of the tech card size range',
+  consumption DECIMAL(10, 3) NOT NULL COMMENT 'per-garment rate at this size'
+    CHECK (consumption >= 0),
+  display_order INT NOT NULL DEFAULT 0,
+  UNIQUE KEY uniq_tech_card_bom_consumption (bom_item_id, size_id),
+  FOREIGN KEY (bom_item_id) REFERENCES tech_card_bom_item(id) ON DELETE CASCADE,
+  FOREIGN KEY (size_id) REFERENCES size(id)
+) COMMENT 'Per-size consumption (норма расхода) of a BOM material';
+
+-- +migrate Down
+DROP TABLE tech_card_bom_consumption;

--- a/internal/store/techcard/enrich.go
+++ b/internal/store/techcard/enrich.go
@@ -70,6 +70,10 @@ func (s *Store) enrich(ctx context.Context, cards []entity.TechCard) error {
 	if err != nil {
 		return err
 	}
+	patterns, err := s.patternsByTechCardIds(ctx, ids)
+	if err != nil {
+		return err
+	}
 
 	for i := range cards {
 		id := cards[i].Id
@@ -80,6 +84,7 @@ func (s *Store) enrich(ctx context.Context, cards []entity.TechCard) error {
 		cards[i].ResolvedMedia = mediaFull[id]
 		cards[i].Callouts = callouts[id]
 		cards[i].Revisions = revisions[id]
+		cards[i].Patterns = patterns[id]
 	}
 	if err := s.enrichMaterials(ctx, cards); err != nil {
 		return err
@@ -194,6 +199,31 @@ func (s *Store) calloutsByTechCardIds(ctx context.Context, ids []int) (map[int][
 type techCardRevisionRow struct {
 	TechCardID int `db:"tech_card_id"`
 	entity.TechCardRevision
+}
+
+type techCardPatternRow struct {
+	TechCardID int `db:"tech_card_id"`
+	entity.TechCardSizePattern
+}
+
+// patternsByTechCardIds loads the per-size PDF выкройки grouped by tech card.
+func (s *Store) patternsByTechCardIds(ctx context.Context, ids []int) (map[int][]entity.TechCardSizePattern, error) {
+	if len(ids) == 0 {
+		return map[int][]entity.TechCardSizePattern{}, nil
+	}
+	rows, err := storeutil.QueryListNamed[techCardPatternRow](ctx, s.DB, `
+		SELECT tech_card_id, size_id, url, filename, size_bytes
+		FROM tech_card_size_pattern
+		WHERE tech_card_id IN (:ids)
+		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return nil, fmt.Errorf("can't load tech card patterns: %w", err)
+	}
+	out := make(map[int][]entity.TechCardSizePattern, len(ids))
+	for _, r := range rows {
+		out[r.TechCardID] = append(out[r.TechCardID], r.TechCardSizePattern)
+	}
+	return out, nil
 }
 
 func (s *Store) revisionsByTechCardIds(ctx context.Context, ids []int) (map[int][]entity.TechCardRevision, error) {

--- a/internal/store/techcard/materials.go
+++ b/internal/store/techcard/materials.go
@@ -91,24 +91,37 @@ func insertTechCardBom(ctx context.Context, db dependency.DB, tcID int, items []
 		if err != nil {
 			return fmt.Errorf("failed to insert tech card bom item: %w", err)
 		}
-		if len(b.ColorwayColors) == 0 {
-			continue
-		}
-		rows := make([]map[string]any, 0, len(b.ColorwayColors))
-		for j, cc := range b.ColorwayColors {
-			if cc.ColorwayIndex < 0 || cc.ColorwayIndex >= len(colorwayIds) {
-				return fmt.Errorf("bom colorway_index %d out of range", cc.ColorwayIndex)
+		if len(b.ColorwayColors) > 0 {
+			rows := make([]map[string]any, 0, len(b.ColorwayColors))
+			for j, cc := range b.ColorwayColors {
+				if cc.ColorwayIndex < 0 || cc.ColorwayIndex >= len(colorwayIds) {
+					return fmt.Errorf("bom colorway_index %d out of range", cc.ColorwayIndex)
+				}
+				rows = append(rows, map[string]any{
+					"bom_item_id":   bomID,
+					"colorway_id":   colorwayIds[cc.ColorwayIndex],
+					"color":         cc.Color,
+					"pantone":       cc.Pantone,
+					"display_order": j,
+				})
 			}
-			rows = append(rows, map[string]any{
-				"bom_item_id":   bomID,
-				"colorway_id":   colorwayIds[cc.ColorwayIndex],
-				"color":         cc.Color,
-				"pantone":       cc.Pantone,
-				"display_order": j,
-			})
+			if err := storeutil.BulkInsert(ctx, db, "tech_card_bom_colorway", rows); err != nil {
+				return fmt.Errorf("failed to insert tech card bom colorway: %w", err)
+			}
 		}
-		if err := storeutil.BulkInsert(ctx, db, "tech_card_bom_colorway", rows); err != nil {
-			return fmt.Errorf("failed to insert tech card bom colorway: %w", err)
+		if len(b.SizeConsumptions) > 0 {
+			scRows := make([]map[string]any, 0, len(b.SizeConsumptions))
+			for j, sc := range b.SizeConsumptions {
+				scRows = append(scRows, map[string]any{
+					"bom_item_id":   bomID,
+					"size_id":       sc.SizeId,
+					"consumption":   sc.Consumption,
+					"display_order": j,
+				})
+			}
+			if err := storeutil.BulkInsert(ctx, db, "tech_card_bom_consumption", scRows); err != nil {
+				return fmt.Errorf("failed to insert tech card bom consumption: %w", err)
+			}
 		}
 	}
 	return nil
@@ -187,6 +200,11 @@ type techCardBomColorwayRow struct {
 	ColorwayID int            `db:"colorway_id"`
 	Color      sql.NullString `db:"color"`
 	Pantone    sql.NullString `db:"pantone"`
+}
+
+type techCardBomConsumptionRow struct {
+	BomItemID int `db:"bom_item_id"`
+	entity.TechCardBomSizeConsumption
 }
 
 type techCardPomPointRow struct {
@@ -286,6 +304,21 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 				Color:         c.Color,
 				Pantone:       c.Pantone,
 			})
+		}
+
+		// Per-size consumption matrix, attached to each BOM line by id.
+		consRows, err := storeutil.QueryListNamed[techCardBomConsumptionRow](ctx, s.DB, `
+			SELECT bom_item_id, size_id, consumption
+			FROM tech_card_bom_consumption
+			WHERE bom_item_id IN (:ids)
+			ORDER BY bom_item_id, display_order`, map[string]any{"ids": bomItemIDs})
+		if err != nil {
+			return fmt.Errorf("can't load tech card bom consumptions: %w", err)
+		}
+		for _, c := range consRows {
+			if item, ok := bomItemByID[c.BomItemID]; ok {
+				item.SizeConsumptions = append(item.SizeConsumptions, c.TechCardBomSizeConsumption)
+			}
 		}
 	}
 

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -205,6 +205,7 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 			"tech_card_bom_item", "tech_card_colorway", "tech_card_pom_point",
 			"tech_card_construction", "tech_card_operation", "tech_card_label",
 			"tech_card_packaging", "tech_card_costing", "tech_card_issue", "tech_card_signoff",
+			"tech_card_size_pattern",
 		} {
 			if err := storeutil.ExecNamed(ctx, rep.DB(),
 				fmt.Sprintf(`DELETE FROM %s WHERE tech_card_id = :id`, table),
@@ -347,7 +348,31 @@ func insertTechCardChildren(ctx context.Context, db dependency.DB, id int, tc *e
 	if err := insertTechCardIssues(ctx, db, id, tc.Issues); err != nil {
 		return err
 	}
-	return insertTechCardSignoffs(ctx, db, id, tc.Signoffs)
+	if err := insertTechCardSignoffs(ctx, db, id, tc.Signoffs); err != nil {
+		return err
+	}
+	return insertTechCardPatterns(ctx, db, id, tc.Patterns)
+}
+
+func insertTechCardPatterns(ctx context.Context, db dependency.DB, id int, patterns []entity.TechCardSizePattern) error {
+	if len(patterns) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(patterns))
+	for i, p := range patterns {
+		rows = append(rows, map[string]any{
+			"tech_card_id":  id,
+			"size_id":       p.SizeId,
+			"url":           p.URL,
+			"filename":      p.Filename,
+			"size_bytes":    p.SizeBytes,
+			"display_order": i,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_size_pattern", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card patterns: %w", err)
+	}
+	return nil
 }
 
 func insertTechCardSizes(ctx context.Context, db dependency.DB, id int, sizeIDs []int, quantities []entity.TechCardSizeQuantity) error {

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -50,6 +50,16 @@ service AdminService {
     };
   }
 
+  // UploadPattern uploads a PDF выкройка (cut pattern) to object storage and returns its
+  // url. Used for both tech-card per-size patterns and fitting iteration patterns. The
+  // file is stored raw (no image processing) and is NOT added to the media library.
+  rpc UploadPattern(UploadPatternRequest) returns (UploadPatternResponse) {
+    option (google.api.http) = {
+      post: "/api/admin/content/pattern"
+      body: "*"
+    };
+  }
+
   // DeleteFromBucket deletes objects specified by their keys.
   rpc DeleteFromBucket(DeleteFromBucketRequest) returns (DeleteFromBucketResponse) {
     option (google.api.http) = {delete: "/api/admin/content"};
@@ -575,6 +585,17 @@ message UploadContentVideoRequest {
 
 message UploadContentVideoResponse {
   common.MediaFull media = 1;
+}
+
+message UploadPatternRequest {
+  bytes raw = 1; // raw PDF bytes
+  string filename = 2; // original filename (for display / download)
+}
+
+message UploadPatternResponse {
+  string url = 1; // CDN url of the stored PDF
+  string filename = 2; // echoed original filename
+  int64 size_bytes = 3; // stored file size in bytes
 }
 
 message ListObjectsPagedRequest {

--- a/proto/common/common/fitting.proto
+++ b/proto/common/common/fitting.proto
@@ -44,6 +44,21 @@ message FittingInsert {
   repeated FittingSizeInsert sizes = 8;
   repeated int32 media_ids = 9;
   int32 tech_card_id = 10; // FK tech_card(id); 0 = unset (the style being fitted)
+  // PDF выкройки measured in this fitting. The tech card holds the FINAL pattern per
+  // size; a fitting captures the ITERATION that was actually tried on (so you know which
+  // pattern you measured). A fitting may carry several (it can span sizes). Each PDF is
+  // uploaded via Admin.UploadPattern; the url is stored as a snapshot (immune to later
+  // tech-card edits).
+  repeated FittingPattern patterns = 11;
+}
+
+// FittingPattern is one PDF выкройка iteration tried in a fitting (snapshot of the
+// uploaded file, not a live reference to a tech-card pattern).
+message FittingPattern {
+  int32 size_id = 1; // FK size(id); 0 = unset (which size this pattern is for)
+  string url = 2; // CDN url of the uploaded PDF (required)
+  string filename = 3; // original filename, for display / download
+  int64 size_bytes = 4; // file size in bytes (0 = unknown)
 }
 
 // Fitting is a stored try-on session with resolved media for display.

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -129,6 +129,21 @@ message TechCardColorway {
   google.protobuf.Timestamp lab_dip_decided_at = 12;
   string lab_dip_decided_by = 13;
   string lab_dip_reject_reason = 14;
+  // OUTPUT-ONLY (read paths only): the BOM materials used in this colourway, with the
+  // colour each takes here. Built by inverting the BOM colour matrix
+  // (tech_card_bom_colorway) so the frontend can show «which fabrics in which colourway»
+  // without re-joining. Ignored on write — the source of truth is bom_items[].colorway_colors.
+  repeated TechCardColorwayMaterial materials = 15;
+}
+
+// TechCardColorwayMaterial is one entry of a colourway's resolved material list: a BOM
+// material used in the colourway and the colour it takes there. OUTPUT-ONLY (derived).
+message TechCardColorwayMaterial {
+  int32 bom_item_index = 1; // 0-based index into TechCardInsert.bom_items
+  string material_name = 2; // BOM line name
+  TechCardBomSection section = 3; // material family
+  string color = 4; // colour of this material in this colourway
+  string pantone = 5; // Pantone / code for this colourway
 }
 
 // TechCardBomColorwayColor is one «Колористика» matrix cell: the colour of a BOM
@@ -167,6 +182,23 @@ message TechCardBomItem {
   google.type.Decimal fabric_weight_gsm = 18; // weight, g/m²
   TechCardFabricDirection fabric_direction = 19; // nap / layout
   google.type.Decimal wastage_percent = 20; // cutting wastage %, folded into line_total
+  // per-size consumption (Sheet «Спецификация» grading): the measured material rate for
+  // each size, since different sizes consume different amounts of fabric. When set, the
+  // size-run cost folds per-size consumption against the per-size order quantities
+  // (TechCardInsert.size_quantities); `consumption` above is the fallback single rate used
+  // only when this is empty. Each size_id must be one of TechCardInsert.size_ids.
+  repeated TechCardBomSizeConsumption size_consumptions = 21;
+  // OUTPUT-ONLY: total material cost over the whole size run when size_consumptions is set —
+  // Σ(consumption_size × order_qty_size) × unit_price, gross of wastage_percent. Empty when
+  // no per-size consumption is given (line_total then carries the cost).
+  google.type.Decimal size_run_total = 22;
+}
+
+// TechCardBomSizeConsumption is the per-size consumption (норма расхода) of one BOM
+// material — different sizes consume different amounts of fabric.
+message TechCardBomSizeConsumption {
+  int32 size_id = 1; // FK size(id); must be one of TechCardInsert.size_ids
+  google.type.Decimal consumption = 2; // per-garment rate at this size, in the line's `unit`
 }
 
 // TechCardFabricDirection is the cutting layout a fabric requires.
@@ -181,6 +213,17 @@ enum TechCardFabricDirection {
 message TechCardSizeQuantity {
   int32 size_id = 1; // FK size(id); must be one of size_ids
   int32 order_qty = 2;
+}
+
+// TechCardSizePattern is a downloadable PDF выкройка (cut pattern) for one size of a
+// tech card — the FINAL pattern for that size. A size can carry many patterns (pieces
+// split across sheets). The PDF is uploaded via Admin.UploadPattern, which returns the
+// url stored here; the binary lives in object storage, not the media library.
+message TechCardSizePattern {
+  int32 size_id = 1; // FK size(id); must be one of TechCardInsert.size_ids
+  string url = 2; // CDN url of the uploaded PDF (required)
+  string filename = 3; // original filename, for display / download
+  int64 size_bytes = 4; // file size in bytes (0 = unknown)
 }
 
 // TechCardPomGrade is the graded value of a POM point for one size.
@@ -381,8 +424,12 @@ message TechCardCosting {
   string notes = 11;
 
   // OUTPUT-ONLY computed rollup (ignored on write; no currency conversion).
-  repeated TechCardCostLine materials_total = 12; // Σ BOM line_total grouped by BOM currency
-  google.type.Decimal materials_cost = 13; // Σ BOM line_total in `currency` (and currency-less lines)
+  // OUTPUT-ONLY. A BOM line with per-size consumption (size_consumptions) contributes its
+  // whole-run size_run_total (order-scale); a line without contributes its per-garment
+  // line_total. A card that mixes both mixes scales — so when size_consumptions is used,
+  // read materials_total/materials_cost as the size-run material spend, not per-garment.
+  repeated TechCardCostLine materials_total = 12; // Σ BOM line cost grouped by BOM currency
+  google.type.Decimal materials_cost = 13; // Σ BOM line cost in `currency` (and currency-less lines)
   google.type.Decimal total_cost = 14; // (materials_cost + make + hardware+packaging+logistics+overhead) × (1 + defect/100); make = cmt_cost, or computed labour_cost when cmt_cost is unset and same currency
   bool has_unconverted_currencies = 15; // OUTPUT-ONLY: a BOM line (or computed labour) is in a currency other than `currency`, so it is excluded from total_cost
   google.type.Decimal total_sam = 16; // OUTPUT-ONLY: Σ of operation time_norm (minutes)
@@ -485,9 +532,10 @@ message TechCardInsert {
   repeated TechCardIssue issues = 50; // maker-flagged construction issues
   repeated TechCardSizeQuantity size_quantities = 51; // per-size order quantity (size run)
   repeated TechCardSignoff signoffs = 52; // per-section sign-off
+  repeated TechCardSizePattern patterns = 53; // per-size PDF выкройки (cut patterns)
 
   // Reserved so a future field can never collide with a removed one.
-  reserved 39, 53 to 99;
+  reserved 39, 54 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.


### PR DESCRIPTION
Tech-card overhaul from a 5-item request. All changes are **additive** (proto reserved-field discipline), so existing clients keep working. Migrations `0077`/`0078` add new (empty) tables — safe under `MYSQL_AUTOMIGRATE`.

## What's included
- **Per-size PDF выкройки on a tech card** — `tech_card_size_pattern` (0077), `TechCardInsert.patterns=53`. Multiple PDFs per size.
- **Iteration PDF выкройки on a fitting** — `fitting_pattern` (0077), `FittingInsert.patterns=11`. Snapshot (url+filename+size); card holds the final pattern, fitting holds the iteration measured.
- **Per-size fabric consumption in BOM** — `tech_card_bom_consumption` (0078), `TechCardBomItem.size_consumptions=21` + output-only `size_run_total=22`. Costing folds `Σ(consumption_size × order_qty_size) × price × (1+wastage)` per line, falling back to the per-garment `line_total` when a line has no per-size data / no order quantities.
- **Colorway↔material clarity** — output-only `TechCardColorway.materials=15` inverts the BOM colour matrix so a colourway's fabrics read directly.
- **PDF upload infra** — `bucket.UploadPatternPDF` (`%PDF-` magic sniff, 25 MB cap, raw `PutObject`, kept out of the `media` table) + `Admin.UploadPattern` RPC (`POST /api/admin/content/pattern`).
- "Product link optional" needed no change — already optional in the backend.

## Notes
- Per-size BOM lines are order-scale while per-garment lines / CMT / overhead are per-garment; a card mixing both mixes scales in the costing total. Documented in proto + entity; recommend keeping a card's BOM lines consistent.
- Frontend (separate admin repo) spec: `tmp/frontend-techcard-patterns-plan.md`.

## Verification
- `go build ./...`, `go vet ./...` clean.
- `dto` / `bucket` / `entity` / `apisrv` unit tests pass, incl. new tests (run-total math, colorway grouping, pattern round-trips, `%PDF-` sniff).
- Adversarial multi-agent review (17 findings → 3 real + 3 judgment fixes applied, 10 false-positive): NULL-safe fitting size emit, http(s)-only pattern urls, `InvalidArgument` vs `Internal` on upload + filename cap, mixed-scale costing documented.
- Store integration tests need live MySQL (run on beta after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)