### PR TITLE
feat(techcard): overhaul to material catalog + colourway recipe

### DIFF
--- a/internal/apisrv/admin/techcard.go
+++ b/internal/apisrv/admin/techcard.go
@@ -22,11 +22,35 @@ const techCardFKMsg = "tech card references a non-existent category, model, size
 // techCardDupMsg is returned when style_number collides within the same season.
 const techCardDupMsg = "a tech card with this style_number and season already exists"
 
+// validateCategoryLeaf rejects a non-leaf category_id (one that has child categories): a
+// tech card must be filed under a leaf type, not a parent bucket (plan Q5). An unset/zero
+// category is allowed; an unknown id falls through to the FK check on write. The category
+// tree comes from the dictionary cache (the same source the product admin uses).
+func (s *Server) validateCategoryLeaf(ctx context.Context, categoryId sql.NullInt32) error {
+	if !categoryId.Valid || categoryId.Int32 <= 0 {
+		return nil
+	}
+	di, err := s.repo.Cache().GetDictionaryInfo(ctx)
+	if err != nil {
+		slog.Default().ErrorContext(ctx, "can't load categories for leaf check", slog.String("err", err.Error()))
+		return status.Error(codes.Internal, "can't validate category")
+	}
+	for _, c := range di.Categories {
+		if c.ParentID != nil && int32(*c.ParentID) == categoryId.Int32 {
+			return status.Error(codes.InvalidArgument, "category_id must be a leaf category (it has sub-categories)")
+		}
+	}
+	return nil
+}
+
 // CreateTechCard creates a new tech card with its nested sections.
 func (s *Server) CreateTechCard(ctx context.Context, req *pb_admin.CreateTechCardRequest) (*pb_admin.CreateTechCardResponse, error) {
 	tc, err := dto.ConvertPbTechCardInsertToEntity(req.TechCard)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := s.validateCategoryLeaf(ctx, tc.CategoryId); err != nil {
+		return nil, err
 	}
 
 	id, err := s.repo.TechCards().AddTechCard(ctx, tc)
@@ -71,6 +95,9 @@ func (s *Server) UpdateTechCard(ctx context.Context, req *pb_admin.UpdateTechCar
 	tc, err := dto.ConvertPbTechCardInsertToEntity(req.TechCard)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := s.validateCategoryLeaf(ctx, tc.CategoryId); err != nil {
+		return nil, err
 	}
 	if err := s.repo.TechCards().UpdateTechCard(ctx, int(req.Id), tc, int(req.ExpectedLockVersion)); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -28,8 +28,6 @@ const (
 	bomQtyLimit     = 10_000_000
 	bomPriceMaxFrac = 4 // unit_price DECIMAL(12,4)
 	bomPriceLimit   = 100_000_000
-	pomMaxFrac      = 2 // POM values DECIMAL(8,2)
-	pomLimit        = 1_000_000
 )
 
 var techCardStagePbToEntity = map[pb_common.TechCardStage]entity.TechCardStage{
@@ -120,6 +118,8 @@ var techCardBomSectionPbToEntity = map[pb_common.TechCardBomSection]entity.TechC
 	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_LABEL:       entity.BomSectionLabel,
 	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_PACKAGING:   entity.BomSectionPackaging,
 	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_TRIM:        entity.BomSectionTrim,
+	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_DECORATION:  entity.BomSectionDecoration,
+	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_OTHER:       entity.BomSectionOther,
 }
 
 var techCardBomSectionEntityToPb = func() map[entity.TechCardBomSection]pb_common.TechCardBomSection {
@@ -178,10 +178,6 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 			return nil, fmt.Errorf("%s must be at most %d characters", c.field, c.max)
 		}
 	}
-	if pb.Currency != "" && len(pb.Currency) != maxCurrency {
-		return nil, fmt.Errorf("currency must be a 3-letter ISO 4217 code")
-	}
-
 	stage := entity.TechCardStageProto
 	if pb.Stage != pb_common.TechCardStage_TECH_CARD_STAGE_UNKNOWN {
 		s, ok := techCardStagePbToEntity[pb.Stage]
@@ -218,21 +214,6 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 
 	if pb.CategoryId < 0 || pb.BaseModelId < 0 || pb.BaseSampleSizeId < 0 {
 		return nil, fmt.Errorf("category_id, base_model_id and base_sample_size_id must not be negative")
-	}
-
-	targetCost, err := nullDecimalFromPb(pb.TargetCost)
-	if err != nil {
-		return nil, fmt.Errorf("target_cost: %w", err)
-	}
-	if err := validateMoney(targetCost, "target_cost"); err != nil {
-		return nil, err
-	}
-	targetRetail, err := nullDecimalFromPb(pb.TargetRetailPrice)
-	if err != nil {
-		return nil, fmt.Errorf("target_retail_price: %w", err)
-	}
-	if err := validateMoney(targetRetail, "target_retail_price"); err != nil {
-		return nil, err
 	}
 
 	sizeIds, err := dedupePositiveIDs(pb.SizeIds, "size_ids")
@@ -321,17 +302,18 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		})
 	}
 
-	// materials (Phase 2). Colorways are parsed first so BOM colorway_index can be
-	// range-checked against them.
-	colorways, err := parseTechCardColorways(pb.Colorways, productIds)
+	details, err := parseTechCardDetails(pb.Details)
 	if err != nil {
 		return nil, err
 	}
-	bomItems, err := parseTechCardBomItems(pb.BomItems, len(colorways), sizeIds)
+
+	// materials (Phase 2). The BOM is parsed first (a pure article catalog); colourways
+	// carry the usage recipe whose bom_item_index is range-checked against the BOM.
+	bomItems, err := parseTechCardBomItems(pb.BomItems)
 	if err != nil {
 		return nil, err
 	}
-	pomPoints, err := parseTechCardPomPoints(pb.PomPoints, sizeIds)
+	colorways, err := parseTechCardColorways(pb.Colorways, productIds, len(bomItems), sizeIds)
 	if err != nil {
 		return nil, err
 	}
@@ -415,42 +397,60 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		RevisionDate:      nullDateFromPbTimestamp(pb.RevisionDate),
 		BaseModelId:       nullInt32FromPb(pb.BaseModelId),
 		BaseSampleSizeId:  nullInt32FromPb(pb.BaseSampleSizeId),
-		Designer:          nullStringFromPb(pb.Designer),
-		Constructor:       nullStringFromPb(pb.Constructor),
-		Technologist:      nullStringFromPb(pb.Technologist),
-		TargetCost:        targetCost,
-		TargetRetailPrice: targetRetail,
-		Currency:          nullStringFromPb(pb.Currency),
-		MeasurementUnit:   unit,
-		Description:       nullStringFromPb(pb.Description),
-		Concept:           nullStringFromPb(pb.Concept),
-		Silhouette:        nullStringFromPb(pb.Silhouette),
-		Collar:            nullStringFromPb(pb.Collar),
-		Fastening:         nullStringFromPb(pb.Fastening),
-		Pockets:           nullStringFromPb(pb.Pockets),
-		SleeveCuff:        nullStringFromPb(pb.SleeveCuff),
-		ExtraDetails:      nullStringFromPb(pb.ExtraDetails),
-		Topstitching:      nullStringFromPb(pb.Topstitching),
-		AuxMaterials:      nullStringFromPb(pb.AuxMaterials),
-		Notes:             nullStringFromPb(pb.Notes),
-		SizeIds:           sizeIds,
-		ProductIds:        productIds,
-		Media:             media,
-		Callouts:          callouts,
-		Revisions:         revisions,
-		BomItems:          bomItems,
-		Colorways:         colorways,
-		PomPoints:         pomPoints,
-		Construction:      construction,
-		Operations:        operations,
-		Labels:            labels,
-		Packaging:         packaging,
-		Costing:           costing,
-		Issues:            issues,
-		SizeQuantities:    sizeQuantities,
-		Signoffs:          signoffs,
-		Patterns:          patterns,
+		Designer:         nullStringFromPb(pb.Designer),
+		Constructor:      nullStringFromPb(pb.Constructor),
+		Technologist:     nullStringFromPb(pb.Technologist),
+		MeasurementUnit:  unit,
+		Concept:          nullStringFromPb(pb.Concept),
+		Notes:            nullStringFromPb(pb.Notes),
+		SizeIds:          sizeIds,
+		ProductIds:       productIds,
+		Media:            media,
+		Callouts:         callouts,
+		Revisions:        revisions,
+		Details:          details,
+		BomItems:         bomItems,
+		Colorways:        colorways,
+		Construction:     construction,
+		Operations:       operations,
+		Labels:           labels,
+		Packaging:        packaging,
+		Costing:          costing,
+		Issues:           issues,
+		SizeQuantities:   sizeQuantities,
+		Signoffs:         signoffs,
+		Patterns:         patterns,
 	}, nil
+}
+
+// parseTechCardDetails parses the construction-description aspects, validating the key
+// length and that each referenced media_id is positive (existence is enforced by the
+// tech_card_detail_media FK → surfaces as InvalidArgument on write).
+func parseTechCardDetails(pbs []*pb_common.TechCardDetail) ([]entity.TechCardDetail, error) {
+	out := make([]entity.TechCardDetail, 0, len(pbs))
+	for _, d := range pbs {
+		if len(d.Key) > maxVarchar64 {
+			return nil, fmt.Errorf("detail key must be at most %d characters", maxVarchar64)
+		}
+		mediaIds := make([]int, 0, len(d.MediaIds))
+		seen := make(map[int]bool, len(d.MediaIds))
+		for _, mid := range d.MediaIds {
+			if mid <= 0 {
+				return nil, fmt.Errorf("detail media_id must be positive")
+			}
+			if seen[int(mid)] {
+				return nil, fmt.Errorf("detail has duplicate media_id %d", mid)
+			}
+			seen[int(mid)] = true
+			mediaIds = append(mediaIds, int(mid))
+		}
+		out = append(out, entity.TechCardDetail{
+			Key:      nullStringFromPb(d.Key),
+			Text:     nullStringFromPb(d.Text),
+			MediaIds: mediaIds,
+		})
+	}
+	return out, nil
 }
 
 // parseTechCardPatterns parses the per-size PDF выкройки, validating each size is in the
@@ -567,44 +567,45 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			RevisionDate:      pbTimestampFromNullTime(tc.RevisionDate),
 			BaseModelId:       pbInt32FromNull(tc.BaseModelId),
 			BaseSampleSizeId:  pbInt32FromNull(tc.BaseSampleSizeId),
-			Designer:          pbStringFromNull(tc.Designer),
-			Constructor:       pbStringFromNull(tc.Constructor),
-			Technologist:      pbStringFromNull(tc.Technologist),
-			TargetCost:        pbDecimalFromNull(tc.TargetCost),
-			TargetRetailPrice: pbDecimalFromNull(tc.TargetRetailPrice),
-			Currency:          pbStringFromNull(tc.Currency),
-			MeasurementUnit:   pbTechCardMeasurementUnit(tc.MeasurementUnit),
-			Description:       pbStringFromNull(tc.Description),
-			Concept:           pbStringFromNull(tc.Concept),
-			Silhouette:        pbStringFromNull(tc.Silhouette),
-			Collar:            pbStringFromNull(tc.Collar),
-			Fastening:         pbStringFromNull(tc.Fastening),
-			Pockets:           pbStringFromNull(tc.Pockets),
-			SleeveCuff:        pbStringFromNull(tc.SleeveCuff),
-			ExtraDetails:      pbStringFromNull(tc.ExtraDetails),
-			Topstitching:      pbStringFromNull(tc.Topstitching),
-			AuxMaterials:      pbStringFromNull(tc.AuxMaterials),
-			Notes:             pbStringFromNull(tc.Notes),
-			SizeIds:           sizeIds,
-			ProductIds:        productIds,
-			Media:             media,
-			Callouts:          callouts,
-			Revisions:         revisions,
-			BomItems:          techCardBomItemsToPb(tc.BomItems, orderQtyBySize),
-			Colorways:         techCardColorwaysToPb(tc.Colorways, tc.BomItems),
-			PomPoints:         techCardPomPointsToPb(tc.PomPoints),
-			Construction:      techCardConstructionToPb(tc.Construction),
-			Operations:        techCardOperationsToPb(tc.Operations),
-			Labels:            techCardLabelsToPb(tc.Labels),
-			Packaging:         techCardPackagingToPb(tc.Packaging),
-			Costing:           techCardCostingToPb(tc),
-			Issues:            techCardIssuesToPb(tc.Issues),
-			SizeQuantities:    techCardSizeQuantitiesToPb(tc.SizeQuantities),
-			Signoffs:          techCardSignoffsToPb(tc.Signoffs),
-			Patterns:          techCardPatternsToPb(tc.Patterns),
+			Designer:         pbStringFromNull(tc.Designer),
+			Constructor:      pbStringFromNull(tc.Constructor),
+			Technologist:     pbStringFromNull(tc.Technologist),
+			MeasurementUnit:  pbTechCardMeasurementUnit(tc.MeasurementUnit),
+			Concept:          pbStringFromNull(tc.Concept),
+			Notes:            pbStringFromNull(tc.Notes),
+			SizeIds:          sizeIds,
+			ProductIds:       productIds,
+			Media:            media,
+			Callouts:         callouts,
+			Revisions:        revisions,
+			Details:          techCardDetailsToPb(tc.Details),
+			BomItems:         techCardBomItemsToPb(tc.BomItems),
+			Colorways:        techCardColorwaysToPb(tc.Colorways, tc.BomItems, orderQtyBySize),
+			Construction:     techCardConstructionToPb(tc.Construction),
+			Operations:       techCardOperationsToPb(tc.Operations),
+			Labels:           techCardLabelsToPb(tc.Labels),
+			Packaging:        techCardPackagingToPb(tc.Packaging),
+			Costing:          techCardCostingToPb(tc),
+			Issues:           techCardIssuesToPb(tc.Issues),
+			SizeQuantities:   techCardSizeQuantitiesToPb(tc.SizeQuantities),
+			Signoffs:         techCardSignoffsToPb(tc.Signoffs),
+			Patterns:         techCardPatternsToPb(tc.Patterns),
 		},
 		ResolvedMedia: resolved,
 	}
+}
+
+// techCardDetailsToPb emits the construction-description aspects (+ media) for display.
+func techCardDetailsToPb(details []entity.TechCardDetail) []*pb_common.TechCardDetail {
+	out := make([]*pb_common.TechCardDetail, 0, len(details))
+	for _, d := range details {
+		out = append(out, &pb_common.TechCardDetail{
+			Key:      pbStringFromNull(d.Key),
+			Text:     pbStringFromNull(d.Text),
+			MediaIds: intsToInt32(d.MediaIds),
+		})
+	}
+	return out
 }
 
 // techCardPatternsToPb emits the per-size PDF выкройки for display.
@@ -686,7 +687,7 @@ func pbTechCardMediaKind(k entity.TechCardMediaKind) pb_common.TechCardMediaKind
 
 // --- materials (Phase 2): parse pb -> entity ---
 
-func parseTechCardColorways(pbs []*pb_common.TechCardColorway, productIds []int) ([]entity.TechCardColorway, error) {
+func parseTechCardColorways(pbs []*pb_common.TechCardColorway, productIds []int, bomItemCount int, sizeIds []int) ([]entity.TechCardColorway, error) {
 	out := make([]entity.TechCardColorway, 0, len(pbs))
 	// Non-empty codes must be unique within the card (DB enforces
 	// uniq_tech_card_colorway_code); dedupe here so a collision fails as a precise
@@ -740,6 +741,10 @@ func parseTechCardColorways(pbs []*pb_common.TechCardColorway, productIds []int)
 		if c.SwatchMediaId < 0 || c.LabDipRound < 0 {
 			return nil, fmt.Errorf("colorway swatch_media_id/lab_dip_round must not be negative")
 		}
+		usages, err := parseTechCardColorwayUsages(c.Usages, bomItemCount, sizeIds)
+		if err != nil {
+			return nil, err
+		}
 		out = append(out, entity.TechCardColorway{
 			Code:               nullStringFromPb(c.Code),
 			Name:               c.Name,
@@ -755,12 +760,64 @@ func parseTechCardColorways(pbs []*pb_common.TechCardColorway, productIds []int)
 			LabDipDecidedAt:    nullDateFromPbTimestamp(c.LabDipDecidedAt),
 			LabDipDecidedBy:    nullStringFromPb(c.LabDipDecidedBy),
 			LabDipRejectReason: nullStringFromPb(c.LabDipRejectReason),
+			Usages:             usages,
 		})
 	}
 	return out, nil
 }
 
-func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int, sizeIds []int) ([]entity.TechCardBomItem, error) {
+// parseTechCardColorwayUsages parses one colourway's material recipe. A usage's
+// bom_item_index (when set) must point at a submitted BOM line; placement is normalised
+// (trim+lower) so the construction resolver can match operation.placement to it (plan §3).
+func parseTechCardColorwayUsages(pbs []*pb_common.TechCardColorwayUsage, bomItemCount int, sizeIds []int) ([]entity.TechCardColorwayUsage, error) {
+	out := make([]entity.TechCardColorwayUsage, 0, len(pbs))
+	for _, u := range pbs {
+		var bomItemIndex sql.NullInt32
+		if u.BomItemIndex != nil {
+			idx := *u.BomItemIndex
+			if idx < 0 || int(idx) >= bomItemCount {
+				return nil, fmt.Errorf("usage bom_item_index %d out of range (have %d bom_items)", idx, bomItemCount)
+			}
+			bomItemIndex = sql.NullInt32{Int32: idx, Valid: true}
+		}
+		if len(u.Placement) > maxVarchar255 {
+			return nil, fmt.Errorf("usage placement must be at most %d characters", maxVarchar255)
+		}
+		if len(u.Color) > maxVarchar255 || len(u.Pantone) > maxVarchar64 {
+			return nil, fmt.Errorf("usage color/pantone too long")
+		}
+		consumption, err := nullDecimalFromPb(u.Consumption)
+		if err != nil {
+			return nil, fmt.Errorf("usage consumption: %w", err)
+		}
+		if err := validateDecimalScale(consumption, "usage consumption", bomQtyMaxFrac, bomQtyLimit); err != nil {
+			return nil, err
+		}
+		quantity, err := nullDecimalFromPb(u.Quantity)
+		if err != nil {
+			return nil, fmt.Errorf("usage quantity: %w", err)
+		}
+		if err := validateDecimalScale(quantity, "usage quantity", bomQtyMaxFrac, bomQtyLimit); err != nil {
+			return nil, err
+		}
+		sizeConsumptions, err := parseTechCardSizeConsumptions(u.SizeConsumptions, sizeIds)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, entity.TechCardColorwayUsage{
+			BomItemIndex:     bomItemIndex,
+			Placement:        normalizedPlacementNull(u.Placement),
+			Color:            nullStringFromPb(u.Color),
+			Pantone:          nullStringFromPb(u.Pantone),
+			Consumption:      consumption,
+			Quantity:         quantity,
+			SizeConsumptions: sizeConsumptions,
+		})
+	}
+	return out, nil
+}
+
+func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem) ([]entity.TechCardBomItem, error) {
 	out := make([]entity.TechCardBomItem, 0, len(pbs))
 	for _, b := range pbs {
 		section, ok := techCardBomSectionPbToEntity[b.Section]
@@ -776,7 +833,6 @@ func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int, 
 			max   int
 		}{
 			{"bom name", b.Name, maxVarchar255},
-			{"bom placement", b.Placement, maxVarchar255},
 			{"bom supplier", b.Supplier, maxVarchar255},
 			{"bom supplier_ref", b.SupplierRef, maxVarchar255},
 			{"bom color", b.Color, maxVarchar255},
@@ -791,20 +847,6 @@ func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int, 
 		if b.Currency != "" && len(b.Currency) != maxCurrency {
 			return nil, fmt.Errorf("bom currency must be a 3-letter ISO 4217 code")
 		}
-		consumption, err := nullDecimalFromPb(b.Consumption)
-		if err != nil {
-			return nil, fmt.Errorf("bom consumption: %w", err)
-		}
-		if err := validateDecimalScale(consumption, "bom consumption", bomQtyMaxFrac, bomQtyLimit); err != nil {
-			return nil, err
-		}
-		quantity, err := nullDecimalFromPb(b.Quantity)
-		if err != nil {
-			return nil, fmt.Errorf("bom quantity: %w", err)
-		}
-		if err := validateDecimalScale(quantity, "bom quantity", bomQtyMaxFrac, bomQtyLimit); err != nil {
-			return nil, err
-		}
 		unitPrice, err := nullDecimalFromPb(b.UnitPrice)
 		if err != nil {
 			return nil, fmt.Errorf("bom unit_price: %w", err)
@@ -812,33 +854,6 @@ func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int, 
 		if err := validateDecimalScale(unitPrice, "bom unit_price", bomPriceMaxFrac, bomPriceLimit); err != nil {
 			return nil, err
 		}
-
-		colors := make([]entity.TechCardBomColorwayColor, 0, len(b.ColorwayColors))
-		seen := make(map[int]bool, len(b.ColorwayColors))
-		for _, cc := range b.ColorwayColors {
-			idx := int(cc.ColorwayIndex)
-			if idx < 0 || idx >= colorwayCount {
-				return nil, fmt.Errorf("bom colorway_index %d out of range (have %d colorways)", idx, colorwayCount)
-			}
-			if seen[idx] {
-				return nil, fmt.Errorf("bom item has duplicate colorway_index %d", idx)
-			}
-			seen[idx] = true
-			if len(cc.Color) > maxVarchar255 || len(cc.Pantone) > maxVarchar64 {
-				return nil, fmt.Errorf("bom colorway color/pantone too long")
-			}
-			colors = append(colors, entity.TechCardBomColorwayColor{
-				ColorwayIndex: idx,
-				Color:         nullStringFromPb(cc.Color),
-				Pantone:       nullStringFromPb(cc.Pantone),
-			})
-		}
-
-		sizeConsumptions, err := parseTechCardBomSizeConsumptions(b.SizeConsumptions, sizeIds)
-		if err != nil {
-			return nil, err
-		}
-
 		fabricWidth, err := nullDecimalFromPb(b.FabricWidth)
 		if err != nil {
 			return nil, fmt.Errorf("bom fabric_width: %w", err)
@@ -875,193 +890,62 @@ func parseTechCardBomItems(pbs []*pb_common.TechCardBomItem, colorwayCount int, 
 		}
 
 		out = append(out, entity.TechCardBomItem{
-			Section:          section,
-			Name:             b.Name,
-			Placement:        nullStringFromPb(b.Placement),
-			Supplier:         nullStringFromPb(b.Supplier),
-			SupplierRef:      nullStringFromPb(b.SupplierRef),
-			Color:            nullStringFromPb(b.Color),
-			Composition:      nullStringFromPb(b.Composition),
-			Spec:             nullStringFromPb(b.Spec),
-			Consumption:      consumption,
-			Unit:             nullStringFromPb(b.Unit),
-			Quantity:         quantity,
-			UnitPrice:        unitPrice,
-			Currency:         nullStringFromPb(b.Currency),
-			Comment:          nullStringFromPb(b.Comment),
-			FabricWidth:      fabricWidth,
-			FabricWeightGsm:  fabricGsm,
-			FabricDirection:  direction,
-			WastagePercent:   wastage,
-			ColorwayColors:   colors,
-			SizeConsumptions: sizeConsumptions,
+			Section:         section,
+			Name:            b.Name,
+			Supplier:        nullStringFromPb(b.Supplier),
+			SupplierRef:     nullStringFromPb(b.SupplierRef),
+			Color:           nullStringFromPb(b.Color),
+			Composition:     nullStringFromPb(b.Composition),
+			Spec:            nullStringFromPb(b.Spec),
+			Unit:            nullStringFromPb(b.Unit),
+			UnitPrice:       unitPrice,
+			Currency:        nullStringFromPb(b.Currency),
+			Comment:         nullStringFromPb(b.Comment),
+			FabricWidth:     fabricWidth,
+			FabricWeightGsm: fabricGsm,
+			FabricDirection: direction,
+			WastagePercent:  wastage,
 		})
 	}
 	return out, nil
 }
 
-// parseTechCardBomSizeConsumptions parses the per-size consumption of a BOM material,
+// parseTechCardSizeConsumptions parses the per-size consumption of a colourway usage,
 // validating each size is in the card's size range, consumption is present and
 // non-negative, and no size repeats.
-func parseTechCardBomSizeConsumptions(pbs []*pb_common.TechCardBomSizeConsumption, sizeIds []int) ([]entity.TechCardBomSizeConsumption, error) {
+func parseTechCardSizeConsumptions(pbs []*pb_common.TechCardBomSizeConsumption, sizeIds []int) ([]entity.TechCardBomSizeConsumption, error) {
 	out := make([]entity.TechCardBomSizeConsumption, 0, len(pbs))
 	seen := make(map[int]bool, len(pbs))
 	for _, sc := range pbs {
 		sid := int(sc.SizeId)
 		if sid <= 0 || !slices.Contains(sizeIds, sid) {
-			return nil, fmt.Errorf("bom size_consumption size_id %d must be one of size_ids", sc.SizeId)
+			return nil, fmt.Errorf("usage size_consumption size_id %d must be one of size_ids", sc.SizeId)
 		}
 		if seen[sid] {
-			return nil, fmt.Errorf("duplicate bom size_consumption for size_id %d", sc.SizeId)
+			return nil, fmt.Errorf("duplicate usage size_consumption for size_id %d", sc.SizeId)
 		}
 		seen[sid] = true
-		consumption, err := requiredDecimalFromPb(sc.Consumption, "bom size_consumption", bomQtyMaxFrac, bomQtyLimit)
+		consumption, err := requiredDecimalFromPb(sc.Consumption, "usage size_consumption", bomQtyMaxFrac, bomQtyLimit)
 		if err != nil {
 			return nil, err
 		}
 		if consumption.IsNegative() {
-			return nil, fmt.Errorf("bom size_consumption must not be negative")
+			return nil, fmt.Errorf("usage size_consumption must not be negative")
 		}
 		out = append(out, entity.TechCardBomSizeConsumption{SizeId: sid, Consumption: consumption})
 	}
 	return out, nil
 }
 
-func parseTechCardPomPoints(pbs []*pb_common.TechCardPomPoint, sizeIds []int) ([]entity.TechCardPomPoint, error) {
-	sizeSet := make(map[int]bool, len(sizeIds))
-	for _, s := range sizeIds {
-		sizeSet[s] = true
-	}
-	out := make([]entity.TechCardPomPoint, 0, len(pbs))
-	// Non-empty POM codes must be unique within the card (DB enforces
-	// uniq_tech_card_pom_code); dedupe here for a precise InvalidArgument.
-	seenCode := make(map[string]bool, len(pbs))
-	for _, p := range pbs {
-		if p.Name == "" {
-			return nil, fmt.Errorf("pom point name is required")
-		}
-		if len(p.Name) > maxVarchar255 || len(p.Section) > maxVarchar255 {
-			return nil, fmt.Errorf("pom point name/section must be at most %d characters", maxVarchar255)
-		}
-		if len(p.Code) > maxVarchar32 {
-			return nil, fmt.Errorf("pom code must be at most %d characters", maxVarchar32)
-		}
-		if p.Code != "" {
-			if seenCode[p.Code] {
-				return nil, fmt.Errorf("pom points contain a duplicate code: %q", p.Code)
-			}
-			seenCode[p.Code] = true
-		}
-		baseValue, err := nullDecimalFromPb(p.BaseValue)
-		if err != nil {
-			return nil, fmt.Errorf("pom base_value: %w", err)
-		}
-		if err := validateDecimalScale(baseValue, "pom base_value", pomMaxFrac, pomLimit); err != nil {
-			return nil, err
-		}
-		tolPlus, err := nullDecimalFromPb(p.TolerancePlus)
-		if err != nil {
-			return nil, fmt.Errorf("pom tolerance_plus: %w", err)
-		}
-		if err := validateDecimalScale(tolPlus, "pom tolerance_plus", pomMaxFrac, pomLimit); err != nil {
-			return nil, err
-		}
-		tolMinus, err := nullDecimalFromPb(p.ToleranceMinus)
-		if err != nil {
-			return nil, fmt.Errorf("pom tolerance_minus: %w", err)
-		}
-		if err := validateDecimalScale(tolMinus, "pom tolerance_minus", pomMaxFrac, pomLimit); err != nil {
-			return nil, err
-		}
-		// Symmetric-tolerance ergonomic: if only one side is given, mirror it.
-		if tolPlus.Valid && !tolMinus.Valid {
-			tolMinus = tolPlus
-		} else if tolMinus.Valid && !tolPlus.Valid {
-			tolPlus = tolMinus
-		}
-
-		grades := make([]entity.TechCardPomGrade, 0, len(p.Grades))
-		seenSize := make(map[int]bool, len(p.Grades))
-		for _, g := range p.Grades {
-			sid := int(g.SizeId)
-			if !sizeSet[sid] {
-				return nil, fmt.Errorf("pom grade size_id %d must be one of size_ids", sid)
-			}
-			if seenSize[sid] {
-				return nil, fmt.Errorf("pom point has duplicate grade for size_id %d", sid)
-			}
-			seenSize[sid] = true
-			val, err := requiredDecimalFromPb(g.Value, "pom grade value", pomMaxFrac, pomLimit)
-			if err != nil {
-				return nil, err
-			}
-			grades = append(grades, entity.TechCardPomGrade{SizeId: sid, Value: val})
-		}
-
-		actuals := make([]entity.TechCardPomActual, 0, len(p.Actuals))
-		for _, a := range p.Actuals {
-			if a.FittingId < 0 {
-				return nil, fmt.Errorf("pom actual fitting_id must not be negative")
-			}
-			if a.SizeId < 0 {
-				return nil, fmt.Errorf("pom actual size_id must not be negative")
-			}
-			if a.SizeId > 0 && !sizeSet[int(a.SizeId)] {
-				return nil, fmt.Errorf("pom actual size_id %d must be one of size_ids", a.SizeId)
-			}
-			if len(a.Label) > maxVarchar64 {
-				return nil, fmt.Errorf("pom actual label must be at most %d characters", maxVarchar64)
-			}
-			val, err := requiredDecimalFromPb(a.Value, "pom actual value", pomMaxFrac, pomLimit)
-			if err != nil {
-				return nil, err
-			}
-			actuals = append(actuals, entity.TechCardPomActual{
-				FittingId: nullInt32FromPb(a.FittingId),
-				SizeId:    nullInt32FromPb(a.SizeId),
-				Label:     nullStringFromPb(a.Label),
-				Value:     val,
-			})
-		}
-
-		out = append(out, entity.TechCardPomPoint{
-			Section:        nullStringFromPb(p.Section),
-			Code:           nullStringFromPb(p.Code),
-			Name:           p.Name,
-			HowToMeasure:   nullStringFromPb(p.HowToMeasure),
-			BaseValue:      baseValue,
-			TolerancePlus:  tolPlus,
-			ToleranceMinus: tolMinus,
-			Grades:         grades,
-			Actuals:        actuals,
-		})
-	}
-	return out, nil
-}
-
 // --- materials (Phase 2): emit entity -> pb ---
 
-// techCardColorwaysToPb emits colourways, attaching to each an OUTPUT-ONLY list of the BOM
-// materials used in it (inverted from bom_items[].colorway_colors — a colour cell means
-// the material is used in that colourway). This answers «which fabrics in which colourway»
-// without the frontend re-joining. The source of truth stays the BOM colour matrix.
-func techCardColorwaysToPb(cws []entity.TechCardColorway, bomItems []entity.TechCardBomItem) []*pb_common.TechCardColorway {
-	materialsByColorway := make(map[int][]*pb_common.TechCardColorwayMaterial, len(cws))
-	for i := range bomItems {
-		b := &bomItems[i]
-		for _, cc := range b.ColorwayColors {
-			materialsByColorway[cc.ColorwayIndex] = append(materialsByColorway[cc.ColorwayIndex],
-				&pb_common.TechCardColorwayMaterial{
-					BomItemIndex: int32(i),
-					MaterialName: b.Name,
-					Section:      pbBomSection(b.Section),
-					Color:        pbStringFromNull(cc.Color),
-					Pantone:      pbStringFromNull(cc.Pantone),
-				})
-		}
-	}
+// techCardColorwaysToPb emits colourways with their material recipe (usages). Each usage
+// carries its computed per-garment line_total and whole-run size_run_total, resolved
+// against the BOM article it points at.
+func techCardColorwaysToPb(cws []entity.TechCardColorway, bomItems []entity.TechCardBomItem, orderQtyBySize map[int]int) []*pb_common.TechCardColorway {
 	out := make([]*pb_common.TechCardColorway, 0, len(cws))
-	for idx, c := range cws {
+	for ci := range cws {
+		c := &cws[ci]
 		out = append(out, &pb_common.TechCardColorway{
 			Code:               pbStringFromNull(c.Code),
 			Name:               c.Name,
@@ -1077,54 +961,75 @@ func techCardColorwaysToPb(cws []entity.TechCardColorway, bomItems []entity.Tech
 			LabDipDecidedAt:    pbTimestampFromNullTime(c.LabDipDecidedAt),
 			LabDipDecidedBy:    pbStringFromNull(c.LabDipDecidedBy),
 			LabDipRejectReason: pbStringFromNull(c.LabDipRejectReason),
-			Materials:          materialsByColorway[idx],
+			Usages:             techCardUsagesToPb(c.Usages, bomItems, orderQtyBySize),
 		})
 	}
 	return out
 }
 
-func techCardBomItemsToPb(items []entity.TechCardBomItem, orderQtyBySize map[int]int) []*pb_common.TechCardBomItem {
-	out := make([]*pb_common.TechCardBomItem, 0, len(items))
-	for i := range items {
-		b := &items[i]
-		colors := make([]*pb_common.TechCardBomColorwayColor, 0, len(b.ColorwayColors))
-		for _, cc := range b.ColorwayColors {
-			colors = append(colors, &pb_common.TechCardBomColorwayColor{
-				ColorwayIndex: int32(cc.ColorwayIndex),
-				Color:         pbStringFromNull(cc.Color),
-				Pantone:       pbStringFromNull(cc.Pantone),
-			})
+// techCardUsagesToPb emits a colourway's usages, each with its computed per-garment
+// line_total and whole-run size_run_total (resolved against the referenced BOM article).
+func techCardUsagesToPb(usages []entity.TechCardColorwayUsage, bomItems []entity.TechCardBomItem, orderQtyBySize map[int]int) []*pb_common.TechCardColorwayUsage {
+	out := make([]*pb_common.TechCardColorwayUsage, 0, len(usages))
+	for i := range usages {
+		u := &usages[i]
+		bom := bomItemAtIndex(bomItems, u.BomItemIndex)
+		var bomItemIndex *int32
+		if u.BomItemIndex.Valid {
+			v := u.BomItemIndex.Int32
+			bomItemIndex = &v
 		}
-		sizeCons := make([]*pb_common.TechCardBomSizeConsumption, 0, len(b.SizeConsumptions))
-		for _, sc := range b.SizeConsumptions {
+		sizeCons := make([]*pb_common.TechCardBomSizeConsumption, 0, len(u.SizeConsumptions))
+		for _, sc := range u.SizeConsumptions {
 			sizeCons = append(sizeCons, &pb_common.TechCardBomSizeConsumption{
 				SizeId:      int32(sc.SizeId),
 				Consumption: pbDecimalFromDecimal(sc.Consumption),
 			})
 		}
-		out = append(out, &pb_common.TechCardBomItem{
-			Section:          pbBomSection(b.Section),
-			Name:             b.Name,
-			Placement:        pbStringFromNull(b.Placement),
-			Supplier:         pbStringFromNull(b.Supplier),
-			SupplierRef:      pbStringFromNull(b.SupplierRef),
-			Color:            pbStringFromNull(b.Color),
-			Composition:      pbStringFromNull(b.Composition),
-			Spec:             pbStringFromNull(b.Spec),
-			Consumption:      pbDecimalFromNull(b.Consumption),
-			Unit:             pbStringFromNull(b.Unit),
-			Quantity:         pbDecimalFromNull(b.Quantity),
-			UnitPrice:        pbDecimalFromNull(b.UnitPrice),
-			Currency:         pbStringFromNull(b.Currency),
-			Comment:          pbStringFromNull(b.Comment),
-			ColorwayColors:   colors,
-			LineTotal:        pbDecimalFromNull(b.LineTotal()),
-			FabricWidth:      pbDecimalFromNull(b.FabricWidth),
-			FabricWeightGsm:  pbDecimalFromNull(b.FabricWeightGsm),
-			FabricDirection:  pbFabricDirection(b.FabricDirection),
-			WastagePercent:   pbDecimalFromNull(b.WastagePercent),
+		out = append(out, &pb_common.TechCardColorwayUsage{
+			BomItemIndex:     bomItemIndex,
+			Placement:        pbStringFromNull(u.Placement),
+			Color:            pbStringFromNull(u.Color),
+			Pantone:          pbStringFromNull(u.Pantone),
+			Consumption:      pbDecimalFromNull(u.Consumption),
+			Quantity:         pbDecimalFromNull(u.Quantity),
 			SizeConsumptions: sizeCons,
-			SizeRunTotal:     pbDecimalFromNull(b.SizeRunTotal(orderQtyBySize)),
+			LineTotal:        pbMoneyFromNull(u.LineTotal(bom)),
+			SizeRunTotal:     pbMoneyFromNull(u.SizeRunTotal(bom, orderQtyBySize)),
+		})
+	}
+	return out
+}
+
+// bomItemAtIndex returns the BOM article a usage/operation bom_item_index points at, or
+// nil when unset or out of range (a draft can reference a not-yet-added article).
+func bomItemAtIndex(bomItems []entity.TechCardBomItem, idx sql.NullInt32) *entity.TechCardBomItem {
+	if !idx.Valid || idx.Int32 < 0 || int(idx.Int32) >= len(bomItems) {
+		return nil
+	}
+	return &bomItems[idx.Int32]
+}
+
+func techCardBomItemsToPb(items []entity.TechCardBomItem) []*pb_common.TechCardBomItem {
+	out := make([]*pb_common.TechCardBomItem, 0, len(items))
+	for i := range items {
+		b := &items[i]
+		out = append(out, &pb_common.TechCardBomItem{
+			Section:         pbBomSection(b.Section),
+			Name:            b.Name,
+			Supplier:        pbStringFromNull(b.Supplier),
+			SupplierRef:     pbStringFromNull(b.SupplierRef),
+			Color:           pbStringFromNull(b.Color),
+			Composition:     pbStringFromNull(b.Composition),
+			Spec:            pbStringFromNull(b.Spec),
+			Unit:            pbStringFromNull(b.Unit),
+			UnitPrice:       pbDecimalFromNull(b.UnitPrice),
+			Currency:        pbStringFromNull(b.Currency),
+			Comment:         pbStringFromNull(b.Comment),
+			FabricWidth:     pbDecimalFromNull(b.FabricWidth),
+			FabricWeightGsm: pbDecimalFromNull(b.FabricWeightGsm),
+			FabricDirection: pbFabricDirection(b.FabricDirection),
+			WastagePercent:  pbDecimalFromNull(b.WastagePercent),
 		})
 	}
 	return out
@@ -1201,83 +1106,6 @@ func techCardSizeQuantitiesToPb(qs []entity.TechCardSizeQuantity) []*pb_common.T
 	return out
 }
 
-func techCardPomPointsToPb(points []entity.TechCardPomPoint) []*pb_common.TechCardPomPoint {
-	out := make([]*pb_common.TechCardPomPoint, 0, len(points))
-	for i := range points {
-		p := &points[i]
-		grades := make([]*pb_common.TechCardPomGrade, 0, len(p.Grades))
-		gradeBySize := make(map[int]decimal.Decimal, len(p.Grades))
-		for _, g := range p.Grades {
-			gradeBySize[g.SizeId] = g.Value
-			grades = append(grades, &pb_common.TechCardPomGrade{
-				SizeId: int32(g.SizeId),
-				Value:  pbDecimalFromDecimal(g.Value),
-			})
-		}
-		actuals := make([]*pb_common.TechCardPomActual, 0, len(p.Actuals))
-		for _, a := range p.Actuals {
-			pa := &pb_common.TechCardPomActual{
-				FittingId: pbInt32FromNull(a.FittingId),
-				SizeId:    pbInt32FromNull(a.SizeId),
-				Label:     pbStringFromNull(a.Label),
-				Value:     pbDecimalFromDecimal(a.Value),
-			}
-			pa.Deviation, pa.Verdict = pomActualVerdict(p, a, gradeBySize)
-			actuals = append(actuals, pa)
-		}
-		out = append(out, &pb_common.TechCardPomPoint{
-			Section:        pbStringFromNull(p.Section),
-			Code:           pbStringFromNull(p.Code),
-			Name:           p.Name,
-			HowToMeasure:   pbStringFromNull(p.HowToMeasure),
-			BaseValue:      pbDecimalFromNull(p.BaseValue),
-			TolerancePlus:  pbDecimalFromNull(p.TolerancePlus),
-			ToleranceMinus: pbDecimalFromNull(p.ToleranceMinus),
-			Grades:         grades,
-			Actuals:        actuals,
-		})
-	}
-	return out
-}
-
-// pomActualVerdict computes an actual's deviation from its target (the graded value
-// at the measured size, else the point's base value) and the in/out-of-tolerance
-// verdict. Returns (nil, UNKNOWN) when there is no target to compare against.
-func pomActualVerdict(p *entity.TechCardPomPoint, a entity.TechCardPomActual, gradeBySize map[int]decimal.Decimal) (*pb_decimal.Decimal, pb_common.TechCardPomVerdict) {
-	var target decimal.Decimal
-	hasTarget := false
-	if a.SizeId.Valid {
-		// An actual measured at a specific size can only be judged against THAT
-		// size's grade. Do not fall back to base_value (a different size) — that
-		// would emit a confident but cross-size verdict. Ungraded size -> UNKNOWN.
-		if gv, ok := gradeBySize[int(a.SizeId.Int32)]; ok {
-			target, hasTarget = gv, true
-		}
-	} else if p.BaseValue.Valid {
-		// No size given: judge the generic actual against the base-sample value.
-		target, hasTarget = p.BaseValue.Decimal, true
-	}
-	if !hasTarget {
-		return nil, pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_UNKNOWN
-	}
-	tolPlus := decimal.Zero
-	if p.TolerancePlus.Valid {
-		tolPlus = p.TolerancePlus.Decimal
-	}
-	tolMinus := decimal.Zero
-	if p.ToleranceMinus.Valid {
-		tolMinus = p.ToleranceMinus.Decimal
-	}
-	verdict := pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_IN_TOLERANCE
-	switch {
-	case a.Value.GreaterThan(target.Add(tolPlus)):
-		verdict = pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_OVER
-	case a.Value.LessThan(target.Sub(tolMinus)):
-		verdict = pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_UNDER
-	}
-	return pbDecimalFromDecimal(a.Value.Sub(target)), verdict
-}
-
 func pbBomSection(s entity.TechCardBomSection) pb_common.TechCardBomSection {
 	if v, ok := techCardBomSectionEntityToPb[s]; ok {
 		return v
@@ -1318,24 +1146,33 @@ func dedupePositiveIDs(ids []int32, field string) ([]int, error) {
 	return out, nil
 }
 
-// validateMoney rejects values that won't fit DECIMAL(10,2): negative, more than
-// 2 fraction digits, or 100000000 and up — so they fail as InvalidArgument
-// instead of a MySQL out-of-range Internal error (mirroring the varchar length
-// checks above).
-func validateMoney(nd decimal.NullDecimal, field string) error {
+// normalizePlacement trims and lowercases a freeform garment-part string so usage and
+// operation placements compare equal regardless of casing/whitespace (plan §3 resolver).
+func normalizePlacement(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// normalizedPlacementNull returns the normalised placement, NULL when empty.
+func normalizedPlacementNull(s string) sql.NullString {
+	n := normalizePlacement(s)
+	if n == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: n, Valid: true}
+}
+
+// pbMoneyFromNull emits a computed money amount rounded to 2 decimals (banker's rounding),
+// or nil when absent. The frontend trusts these server totals and never re-sums.
+func pbMoneyFromNull(nd decimal.NullDecimal) *pb_decimal.Decimal {
 	if !nd.Valid {
 		return nil
 	}
-	if nd.Decimal.IsNegative() {
-		return fmt.Errorf("%s must not be negative", field)
-	}
-	if nd.Decimal.Exponent() < -2 {
-		return fmt.Errorf("%s must have at most 2 decimal places", field)
-	}
-	if nd.Decimal.Abs().GreaterThanOrEqual(decimal.NewFromInt(100_000_000)) {
-		return fmt.Errorf("%s must be less than 100000000", field)
-	}
-	return nil
+	return &pb_decimal.Decimal{Value: roundMoney(nd.Decimal).String()}
+}
+
+// roundMoney rounds a money amount to 2 decimals (banker's rounding) for storage/emit.
+func roundMoney(d decimal.Decimal) decimal.Decimal {
+	return d.RoundBank(2)
 }
 
 func nullDecimalFromPb(d *pb_decimal.Decimal) (decimal.NullDecimal, error) {

--- a/internal/dto/techcard_patterns_test.go
+++ b/internal/dto/techcard_patterns_test.go
@@ -15,99 +15,102 @@ func ndFrom(s string) decimal.NullDecimal {
 	return decimal.NullDecimal{Decimal: decimal.RequireFromString(s), Valid: true}
 }
 
-func TestTechCardBomSizeRunTotal(t *testing.T) {
-	b := entity.TechCardBomItem{
-		UnitPrice: ndFrom("2.00"),
+func decEq(t *testing.T, nd decimal.NullDecimal, want string) {
+	t.Helper()
+	if !nd.Valid || !nd.Decimal.Equal(decimal.RequireFromString(want)) {
+		t.Fatalf("got %v (valid=%v), want %s", nd.Decimal, nd.Valid, want)
+	}
+}
+
+// TestColorwayUsageTotals locks the per-usage cost formulas: a measured usage is
+// consumption × price grossed up by the article wastage; a countable trim is quantity ×
+// price with NO wastage; a per-size usage moves its cost to size_run_total (line_total
+// goes invalid) and folds per-size consumption against order quantities.
+func TestColorwayUsageTotals(t *testing.T) {
+	bom := &entity.TechCardBomItem{UnitPrice: ndFrom("10"), WastagePercent: ndFrom("10")}
+	bomNoWaste := &entity.TechCardBomItem{UnitPrice: ndFrom("10")}
+
+	// measured consumption, no per-size: line_total = 2 × 10 × 1.1 = 22; size_run invalid.
+	measured := entity.TechCardColorwayUsage{Consumption: ndFrom("2")}
+	decEq(t, measured.LineTotal(bom), "22")
+	if rt := measured.SizeRunTotal(bom, map[int]int{4: 10}); rt.Valid {
+		t.Fatalf("size_run_total should be invalid without per-size consumption")
+	}
+
+	// countable quantity: 3 × 10 = 30, wastage N/A even though the article has a wastage %.
+	countable := entity.TechCardColorwayUsage{Quantity: ndFrom("3")}
+	decEq(t, countable.LineTotal(bom), "30")
+	decEq(t, countable.LineTotal(bomNoWaste), "30")
+
+	// per-size: line_total invalid; size_run = (1.5×10 + 1.8×20) × 10 × 1.1 = 51 × 11 = 561.
+	perSize := entity.TechCardColorwayUsage{
+		Consumption: ndFrom("2"), // ignored once size consumptions are present
 		SizeConsumptions: []entity.TechCardBomSizeConsumption{
 			{SizeId: 4, Consumption: decimal.RequireFromString("1.5")},
 			{SizeId: 5, Consumption: decimal.RequireFromString("1.8")},
 		},
 	}
-	// (1.5*10 + 1.8*20) * 2.00 = 51 * 2 = 102
-	got := b.SizeRunTotal(map[int]int{4: 10, 5: 20})
-	if !got.Valid || !got.Decimal.Equal(decimal.RequireFromString("102")) {
-		t.Fatalf("run total = %v (valid=%v), want 102", got.Decimal, got.Valid)
+	if lt := perSize.LineTotal(bom); lt.Valid {
+		t.Fatalf("line_total must be invalid when per-size consumption is present")
 	}
-	// with 10% wastage: 102 * 1.1 = 112.2
-	b.WastagePercent = ndFrom("10")
-	got = b.SizeRunTotal(map[int]int{4: 10, 5: 20})
-	if !got.Valid || !got.Decimal.Equal(decimal.RequireFromString("112.2")) {
-		t.Fatalf("run total w/ wastage = %v, want 112.2", got.Decimal)
+	decEq(t, perSize.SizeRunTotal(bom, map[int]int{4: 10, 5: 20}), "561")
+	// a size with no order quantity contributes nothing: only size 4 → 1.5×10 × 10 × 1.1 = 165.
+	decEq(t, perSize.SizeRunTotal(bom, map[int]int{4: 10}), "165")
+	// no order quantities at all → invalid (cost is 0 until a size run is set).
+	if rt := perSize.SizeRunTotal(bom, map[int]int{}); rt.Valid {
+		t.Fatalf("size_run_total with no quantities should be invalid")
 	}
-	// a size with no order quantity contributes nothing; here only size 4 has qty.
-	got = b.SizeRunTotal(map[int]int{4: 10})
-	if !got.Valid || !got.Decimal.Equal(decimal.RequireFromString("33")) { // 1.5*10*2*1.1
-		t.Fatalf("run total (partial qty) = %v, want 33", got.Decimal)
-	}
-	// no order quantities at all -> invalid so the rollup falls back to LineTotal.
-	if got := b.SizeRunTotal(map[int]int{}); got.Valid {
-		t.Fatalf("run total with no quantities should be invalid, got %v", got.Decimal)
-	}
-	// no per-size consumption -> invalid.
-	empty := entity.TechCardBomItem{UnitPrice: ndFrom("2")}
-	if got := empty.SizeRunTotal(map[int]int{4: 10}); got.Valid {
-		t.Fatalf("run total with no size consumption should be invalid")
+
+	// EffectiveTotal prefers size_run when valid, else falls back to line_total.
+	decEq(t, perSize.EffectiveTotal(bom, map[int]int{4: 10, 5: 20}), "561")
+	decEq(t, measured.EffectiveTotal(bom, map[int]int{4: 10}), "22")
+
+	// no article (unresolved index) → no cost.
+	if lt := measured.LineTotal(nil); lt.Valid {
+		t.Fatalf("line_total against a nil article should be invalid")
 	}
 }
 
-func TestEffectiveBomLineTotalFallback(t *testing.T) {
-	// no per-size -> per-garment LineTotal (consumption*price).
-	perGarment := entity.TechCardBomItem{Consumption: ndFrom("2"), UnitPrice: ndFrom("3")}
-	if eff := effectiveBomLineTotal(&perGarment, map[int]int{4: 10}); !eff.Valid || !eff.Decimal.Equal(decimal.RequireFromString("6")) {
-		t.Fatalf("effective (fallback) = %v, want 6", eff.Decimal)
-	}
-	// per-size present + quantities -> size-run total.
-	perSize := entity.TechCardBomItem{
-		UnitPrice:        ndFrom("2"),
-		SizeConsumptions: []entity.TechCardBomSizeConsumption{{SizeId: 4, Consumption: decimal.RequireFromString("1.5")}},
-	}
-	if eff := effectiveBomLineTotal(&perSize, map[int]int{4: 10}); !eff.Valid || !eff.Decimal.Equal(decimal.RequireFromString("30")) {
-		t.Fatalf("effective (run) = %v, want 30", eff.Decimal)
-	}
-}
-
-func TestBomMaterialsRollupUsesRunTotal(t *testing.T) {
+// TestColorwayCostRollup checks one colourway's per-currency rollup: usages bucket by their
+// article currency, currency-less lines fold into the costing currency, a foreign currency
+// is excluded and flags has_unconverted_currencies.
+func TestColorwayCostRollup(t *testing.T) {
 	eur := sql.NullString{String: "EUR", Valid: true}
-	items := []entity.TechCardBomItem{
-		{ // per-size line: 1.5*10*2 = 30
-			Currency:         eur,
-			UnitPrice:        ndFrom("2"),
-			SizeConsumptions: []entity.TechCardBomSizeConsumption{{SizeId: 4, Consumption: decimal.RequireFromString("1.5")}},
-		},
-		{Currency: eur, Consumption: ndFrom("2"), UnitPrice: ndFrom("3")}, // per-garment: 6
+	usd := sql.NullString{String: "USD", Valid: true}
+	bomItems := []entity.TechCardBomItem{
+		{UnitPrice: ndFrom("10"), Currency: eur}, // index 0
+		{UnitPrice: ndFrom("3"), Currency: usd},  // index 1
+		{UnitPrice: ndFrom("5")},                 // index 2, currency-less
 	}
-	lines, cost := bomMaterialsRollup(items, eur, map[int]int{4: 10})
-	if !cost.Equal(decimal.RequireFromString("36")) { // 30 + 6
-		t.Fatalf("materials cost = %v, want 36", cost)
+	idx := func(i int32) sql.NullInt32 { return sql.NullInt32{Int32: i, Valid: true} }
+	cw := entity.TechCardColorway{Usages: []entity.TechCardColorwayUsage{
+		{BomItemIndex: idx(0), Quantity: ndFrom("2")}, // 20 EUR
+		{BomItemIndex: idx(1), Quantity: ndFrom("1")}, // 3 USD
+		{BomItemIndex: idx(2), Quantity: ndFrom("4")}, // 20 currency-less
+	}}
+	res := colorwayCost(&cw, bomItems, "EUR", map[int]int{})
+	// materials_cost = EUR(20) + currency-less(20) = 40; USD excluded.
+	if !res.materialsCost.Equal(decimal.RequireFromString("40")) {
+		t.Fatalf("materials_cost = %v, want 40", res.materialsCost)
 	}
-	if len(lines) != 1 || lines[0].Currency != "EUR" {
-		t.Fatalf("unexpected rollup lines: %+v", lines)
+	if !res.hasUnconverted {
+		t.Fatalf("expected has_unconverted_currencies (USD usage vs EUR costing)")
+	}
+	byCcy := map[string]string{}
+	for _, l := range res.materialsTotal {
+		byCcy[l.Currency] = l.Amount.Value
+	}
+	if byCcy["EUR"] != "20" || byCcy["USD"] != "3" || byCcy[""] != "20" {
+		t.Fatalf("materials_total buckets mismatch: %+v", byCcy)
 	}
 }
 
-func TestTechCardPatternsAndColorwayMaterialsRoundTrip(t *testing.T) {
+// TestTechCardPatternsRoundTrip covers parsing and re-emitting the per-size PDF выкройки.
+func TestTechCardPatternsRoundTrip(t *testing.T) {
 	in := &pb_common.TechCardInsert{
 		StyleNumber: "ST-PAT",
 		Name:        "Coat",
 		SizeIds:     []int32{4, 5},
-		Colorways: []*pb_common.TechCardColorway{
-			{Name: "Black"},
-			{Name: "Navy"},
-		},
-		BomItems: []*pb_common.TechCardBomItem{
-			{
-				Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC,
-				Name:    "Main fabric",
-				ColorwayColors: []*pb_common.TechCardBomColorwayColor{
-					{ColorwayIndex: 0, Color: "Jet"},
-					{ColorwayIndex: 1, Color: "Indigo"},
-				},
-				SizeConsumptions: []*pb_common.TechCardBomSizeConsumption{
-					{SizeId: 4, Consumption: &pb_decimal.Decimal{Value: "1.5"}},
-					{SizeId: 5, Consumption: &pb_decimal.Decimal{Value: "1.8"}},
-				},
-			},
-		},
 		Patterns: []*pb_common.TechCardSizePattern{
 			{SizeId: 4, Url: "https://cdn/x4.pdf", Filename: "front-m.pdf", SizeBytes: 1234},
 			{SizeId: 4, Url: "https://cdn/x4b.pdf"}, // multiple per size is allowed
@@ -121,34 +124,13 @@ func TestTechCardPatternsAndColorwayMaterialsRoundTrip(t *testing.T) {
 	if len(ent.Patterns) != 3 || ent.Patterns[0].SizeId != 4 || ent.Patterns[0].URL != "https://cdn/x4.pdf" {
 		t.Fatalf("patterns not parsed: %+v", ent.Patterns)
 	}
-	if len(ent.BomItems[0].SizeConsumptions) != 2 {
-		t.Fatalf("size consumptions not parsed: %+v", ent.BomItems[0].SizeConsumptions)
-	}
-
 	out := ConvertEntityTechCardToPb(&entity.TechCard{TechCardInsert: *ent})
 	if len(out.TechCard.Patterns) != 3 || out.TechCard.Patterns[0].Filename != "front-m.pdf" || out.TechCard.Patterns[0].SizeBytes != 1234 {
 		t.Fatalf("patterns round-trip mismatch: %+v", out.TechCard.Patterns)
 	}
-	if len(out.TechCard.Colorways) != 2 {
-		t.Fatalf("colorways: %d", len(out.TechCard.Colorways))
-	}
-	black := out.TechCard.Colorways[0]
-	if len(black.Materials) != 1 || black.Materials[0].MaterialName != "Main fabric" ||
-		black.Materials[0].Color != "Jet" || black.Materials[0].BomItemIndex != 0 {
-		t.Fatalf("colorway[0] materials mismatch: %+v", black.Materials)
-	}
-	navy := out.TechCard.Colorways[1]
-	if len(navy.Materials) != 1 || navy.Materials[0].Color != "Indigo" {
-		t.Fatalf("colorway[1] materials mismatch: %+v", navy.Materials)
-	}
-	// size-run total surfaced on the BOM line: (1.5*10 + 1.8*20)*... but no quantities
-	// here, so it must be empty and line_total carries the per-garment value (none set).
-	if out.TechCard.BomItems[0].SizeRunTotal != nil {
-		t.Fatalf("size_run_total should be empty without order quantities: %v", out.TechCard.BomItems[0].SizeRunTotal)
-	}
 }
 
-func TestTechCardPatternAndConsumptionValidation(t *testing.T) {
+func TestTechCardPatternAndUsageValidation(t *testing.T) {
 	cases := map[string]*pb_common.TechCardInsert{
 		"pattern size not in range": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
 			Patterns: []*pb_common.TechCardSizePattern{{SizeId: 9, Url: "u"}}},
@@ -156,18 +138,14 @@ func TestTechCardPatternAndConsumptionValidation(t *testing.T) {
 			Patterns: []*pb_common.TechCardSizePattern{{SizeId: 4, Url: "  "}}},
 		"pattern url not http": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
 			Patterns: []*pb_common.TechCardSizePattern{{SizeId: 4, Url: "javascript:alert(1)"}}},
-		"bom consumption size not in range": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
-			BomItems: []*pb_common.TechCardBomItem{{
-				Section:          pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC,
-				Name:             "f",
+		"usage size_consumption not in range": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
+			Colorways: []*pb_common.TechCardColorway{{Name: "Black", Usages: []*pb_common.TechCardColorwayUsage{{
 				SizeConsumptions: []*pb_common.TechCardBomSizeConsumption{{SizeId: 9, Consumption: &pb_decimal.Decimal{Value: "1"}}},
-			}}},
-		"bom consumption negative": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
-			BomItems: []*pb_common.TechCardBomItem{{
-				Section:          pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC,
-				Name:             "f",
+			}}}}},
+		"usage size_consumption negative": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
+			Colorways: []*pb_common.TechCardColorway{{Name: "Black", Usages: []*pb_common.TechCardColorwayUsage{{
 				SizeConsumptions: []*pb_common.TechCardBomSizeConsumption{{SizeId: 4, Consumption: &pb_decimal.Decimal{Value: "-1"}}},
-			}}},
+			}}}}},
 	}
 	for name, in := range cases {
 		if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {

--- a/internal/dto/techcard_production.go
+++ b/internal/dto/techcard_production.go
@@ -66,28 +66,15 @@ func parseTechCardConstruction(pb *pb_common.TechCardConstruction) (*entity.Tech
 			return nil, fmt.Errorf("%s must be at most %d characters", c.field, c.max)
 		}
 	}
-	if pb.LabourRateCurrency != "" && len(pb.LabourRateCurrency) != maxCurrency {
-		return nil, fmt.Errorf("construction labour_rate_currency must be a 3-letter ISO 4217 code")
-	}
-	labourRate, err := nullDecimalFromPb(pb.LabourRate)
-	if err != nil {
-		return nil, fmt.Errorf("construction labour_rate: %w", err)
-	}
-	// DECIMAL(10,4): 6 integer digits, so the magnitude limit is 1e6, not bomPriceLimit.
-	if err := validateDecimalScale(labourRate, "construction labour_rate", 4, 1_000_000); err != nil {
-		return nil, err
-	}
 	return &entity.TechCardConstruction{
-		MainStitchType:     nullStringFromPb(pb.MainStitchType),
-		StitchDensity:      nullStringFromPb(pb.StitchDensity),
-		OverlockThreads:    nullStringFromPb(pb.OverlockThreads),
-		SeamAllowances:     nullStringFromPb(pb.SeamAllowances),
-		HemFinish:          nullStringFromPb(pb.HemFinish),
-		Pressing:           nullStringFromPb(pb.Pressing),
-		MachineClass:       nullStringFromPb(pb.MachineClass),
-		Notes:              nullStringFromPb(pb.Notes),
-		LabourRate:         labourRate,
-		LabourRateCurrency: nullStringFromPb(pb.LabourRateCurrency),
+		MainStitchType:  nullStringFromPb(pb.MainStitchType),
+		StitchDensity:   nullStringFromPb(pb.StitchDensity),
+		OverlockThreads: nullStringFromPb(pb.OverlockThreads),
+		SeamAllowances:  nullStringFromPb(pb.SeamAllowances),
+		HemFinish:       nullStringFromPb(pb.HemFinish),
+		Pressing:        nullStringFromPb(pb.Pressing),
+		MachineClass:    nullStringFromPb(pb.MachineClass),
+		Notes:           nullStringFromPb(pb.Notes),
 	}, nil
 }
 
@@ -133,7 +120,7 @@ var techCardConstructionZoneEntityToPb = func() map[entity.TechCardConstructionZ
 // bom_items (so an operation's bom_item_index can be range-checked).
 func parseTechCardOperations(pbs []*pb_common.TechCardOperation, calloutNumbers map[int]bool, bomItemCount int) ([]entity.TechCardOperation, error) {
 	out := make([]entity.TechCardOperation, 0, len(pbs))
-	for _, o := range pbs {
+	for i, o := range pbs {
 		if o.Node == "" {
 			return nil, fmt.Errorf("operation node is required")
 		}
@@ -144,8 +131,8 @@ func parseTechCardOperations(pbs []*pb_common.TechCardOperation, calloutNumbers 
 			len(o.SeamAllowance) > maxVarchar64 || len(o.Needle) > maxVarchar64 || len(o.Attachment) > maxVarchar64 {
 			return nil, fmt.Errorf("operation topstitch_width/machine/seam_allowance/needle/attachment must be at most %d characters", maxVarchar64)
 		}
-		if o.OperationNumber < 0 {
-			return nil, fmt.Errorf("operation operation_number must not be negative")
+		if len(o.Placement) > maxVarchar255 {
+			return nil, fmt.Errorf("operation placement must be at most %d characters", maxVarchar255)
 		}
 		opType := entity.OpTypeUnknown
 		if o.OperationType != pb_common.TechCardOperationType_TECH_CARD_OPERATION_TYPE_UNKNOWN {
@@ -194,7 +181,9 @@ func parseTechCardOperations(pbs []*pb_common.TechCardOperation, calloutNumbers 
 			return nil, err
 		}
 		out = append(out, entity.TechCardOperation{
-			OperationNumber: nullInt32FromPb(o.OperationNumber),
+			// operation_number is server-assigned = (position+1)*10 («оп. 10, 20, …»);
+			// any client value is ignored (plan §4). Reorder shifts numbers (Q6).
+			OperationNumber: sql.NullInt32{Int32: int32((i + 1) * 10), Valid: true},
 			Node:            o.Node,
 			Description:     nullStringFromPb(o.Description),
 			SeamType:        nullStringFromPb(o.SeamType),
@@ -211,6 +200,7 @@ func parseTechCardOperations(pbs []*pb_common.TechCardOperation, calloutNumbers 
 			Zone:            zone,
 			BomItemIndex:    bomItemIndex,
 			CalloutNumber:   nullInt32FromPb(o.CalloutNumber),
+			Placement:       normalizedPlacementNull(o.Placement),
 		})
 	}
 	return out, nil
@@ -373,16 +363,14 @@ func techCardConstructionToPb(c *entity.TechCardConstruction) *pb_common.TechCar
 		return nil
 	}
 	return &pb_common.TechCardConstruction{
-		MainStitchType:     pbStringFromNull(c.MainStitchType),
-		StitchDensity:      pbStringFromNull(c.StitchDensity),
-		OverlockThreads:    pbStringFromNull(c.OverlockThreads),
-		SeamAllowances:     pbStringFromNull(c.SeamAllowances),
-		HemFinish:          pbStringFromNull(c.HemFinish),
-		Pressing:           pbStringFromNull(c.Pressing),
-		MachineClass:       pbStringFromNull(c.MachineClass),
-		Notes:              pbStringFromNull(c.Notes),
-		LabourRate:         pbDecimalFromNull(c.LabourRate),
-		LabourRateCurrency: pbStringFromNull(c.LabourRateCurrency),
+		MainStitchType:  pbStringFromNull(c.MainStitchType),
+		StitchDensity:   pbStringFromNull(c.StitchDensity),
+		OverlockThreads: pbStringFromNull(c.OverlockThreads),
+		SeamAllowances:  pbStringFromNull(c.SeamAllowances),
+		HemFinish:       pbStringFromNull(c.HemFinish),
+		Pressing:        pbStringFromNull(c.Pressing),
+		MachineClass:    pbStringFromNull(c.MachineClass),
+		Notes:           pbStringFromNull(c.Notes),
 	}
 }
 
@@ -413,6 +401,7 @@ func techCardOperationsToPb(ops []entity.TechCardOperation) []*pb_common.TechCar
 			Zone:            techCardConstructionZoneEntityToPb[o.Zone],
 			BomItemIndex:    bomItemIndex,
 			CalloutNumber:   pbInt32FromNull(o.CalloutNumber),
+			Placement:       pbStringFromNull(o.Placement),
 		})
 	}
 	return out
@@ -508,7 +497,6 @@ func techCardIssuesToPb(issues []entity.TechCardIssue) []*pb_common.TechCardIssu
 var techCardSignoffSectionPbToEntity = map[pb_common.TechCardSignoffSection]entity.TechCardSignoffSection{
 	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_DESIGN:       entity.SignoffDesign,
 	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_CONSTRUCTION: entity.SignoffConstruction,
-	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_POM:          entity.SignoffPom,
 	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_MATERIALS:    entity.SignoffMaterials,
 	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COLOUR:       entity.SignoffColour,
 	pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_LABELS:       entity.SignoffLabels,
@@ -617,8 +605,9 @@ func techCardPackagingToPb(p *entity.TechCardPackaging) *pb_common.TechCardPacka
 	}
 }
 
-// techCardCostingToPb emits the stored costing articles plus the computed
-// materials rollup and total. Returns nil when no costing row exists.
+// techCardCostingToPb emits the stored costing articles plus the computed per-colourway
+// material costs and the root rollup. The root (materials_total/materials_cost/total_cost)
+// is the PRIMARY colourway = index 0 (plan Q3). Returns nil when no costing row exists.
 func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 	if tc.Costing == nil {
 		return nil
@@ -628,58 +617,55 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 	for _, q := range tc.SizeQuantities {
 		orderQtyBySize[q.SizeId] = q.OrderQty
 	}
-	materialsTotal, materialsCost := bomMaterialsRollup(tc.BomItems, c.Currency, orderQtyBySize)
-	out := &pb_common.TechCardCosting{
-		CmtCost:          pbDecimalFromNull(c.CmtCost),
-		HardwareCost:     pbDecimalFromNull(c.HardwareCost),
-		PackagingCost:    pbDecimalFromNull(c.PackagingCost),
-		LogisticsCost:    pbDecimalFromNull(c.LogisticsCost),
-		OverheadCost:     pbDecimalFromNull(c.OverheadCost),
-		DefectPercent:    pbDecimalFromNull(c.DefectPercent),
-		MarkupMultiplier: pbDecimalFromNull(c.MarkupMultiplier),
-		WholesalePrice:   pbDecimalFromNull(c.WholesalePrice),
-		RetailPrice:      pbDecimalFromNull(c.RetailPrice),
-		Currency:         pbStringFromNull(c.Currency),
-		Notes:            pbStringFromNull(c.Notes),
-		MaterialsTotal:   materialsTotal,
-		MaterialsCost:    pbDecimalFromDecimal(materialsCost.Round(costMaxFrac)),
-	}
-
 	costingCcy := ""
 	if c.Currency.Valid {
 		costingCcy = c.Currency.String
 	}
 
-	// Computed labour: total_sam = Σ(operation time_norm); labour_cost = SAM × rate
-	// (denominated in construction.labour_rate_currency).
-	totalSam := decimal.Zero
-	for i := range tc.Operations {
-		if tc.Operations[i].TimeNorm.Valid {
-			totalSam = totalSam.Add(tc.Operations[i].TimeNorm.Decimal)
-		}
-	}
-	labourCcy := ""
-	var labourCost decimal.NullDecimal
-	if tc.Construction != nil {
-		labourCcy = tc.Construction.LabourRateCurrency.String
-		if totalSam.IsPositive() && tc.Construction.LabourRate.Valid {
-			labourCost = decimal.NullDecimal{Decimal: totalSam.Mul(tc.Construction.LabourRate.Decimal), Valid: true}
+	// Per-colourway material cost (OUTPUT-ONLY), resolving each usage against its BOM
+	// article. The root rollup is the primary colourway (index 0).
+	colorwayCosts := make([]*pb_common.TechCardColorwayCost, 0, len(tc.Colorways))
+	var rootMaterialsTotal []*pb_common.TechCardCostLine
+	rootMaterialsCost := decimal.Zero
+	rootHasUnconverted := false
+	for ci := range tc.Colorways {
+		cc := colorwayCost(&tc.Colorways[ci], tc.BomItems, costingCcy, orderQtyBySize)
+		colorwayCosts = append(colorwayCosts, &pb_common.TechCardColorwayCost{
+			ColorwayIndex:            int32(ci),
+			MaterialsTotal:           cc.materialsTotal,
+			MaterialsCost:            pbDecimalFromDecimal(roundMoney(cc.materialsCost)),
+			SizeRunTotal:             pbDecimalFromDecimal(roundMoney(cc.sizeRunTotal)),
+			HasUnconvertedCurrencies: cc.hasUnconverted,
+		})
+		if ci == 0 {
+			rootMaterialsTotal = cc.materialsTotal
+			rootMaterialsCost = cc.materialsCost
+			rootHasUnconverted = cc.hasUnconverted
 		}
 	}
 
-	// Make (sewing) cost folded into total_cost: a manual cmt_cost is authoritative;
-	// otherwise the computed labour stands in as the make cost — but only when its
-	// currency matches the costing currency, so labour is never silently FX-folded.
-	makeCost := c.CmtCost
-	if !c.CmtCost.Valid && labourCost.Valid && labourCcy == costingCcy {
-		makeCost = labourCost
+	out := &pb_common.TechCardCosting{
+		CmtCost:                  pbDecimalFromNull(c.CmtCost),
+		HardwareCost:             pbDecimalFromNull(c.HardwareCost),
+		PackagingCost:            pbDecimalFromNull(c.PackagingCost),
+		LogisticsCost:            pbDecimalFromNull(c.LogisticsCost),
+		OverheadCost:             pbDecimalFromNull(c.OverheadCost),
+		DefectPercent:            pbDecimalFromNull(c.DefectPercent),
+		MarkupMultiplier:         pbDecimalFromNull(c.MarkupMultiplier),
+		WholesalePrice:           pbDecimalFromNull(c.WholesalePrice),
+		RetailPrice:              pbDecimalFromNull(c.RetailPrice),
+		Currency:                 pbStringFromNull(c.Currency),
+		Notes:                    pbStringFromNull(c.Notes),
+		MaterialsTotal:           rootMaterialsTotal,
+		MaterialsCost:            pbDecimalFromDecimal(roundMoney(rootMaterialsCost)),
+		ColorwayCosts:            colorwayCosts,
+		HasUnconvertedCurrencies: rootHasUnconverted,
 	}
 
-	// total_cost = (materials in costing currency + make + hardware+packaging+
-	// logistics+overhead) grossed up by the defect/reserve %. Single-currency,
-	// best-effort: cross-currency materials are surfaced in materials_total.
-	total := materialsCost
-	for _, d := range []decimal.NullDecimal{makeCost, c.HardwareCost, c.PackagingCost, c.LogisticsCost, c.OverheadCost} {
+	// total_cost = (materials_cost[colourway 0] + cmt + hardware + packaging + logistics
+	// + overhead) × (1 + defect/100). No labour fallback (labour pricing removed).
+	total := rootMaterialsCost
+	for _, d := range []decimal.NullDecimal{c.CmtCost, c.HardwareCost, c.PackagingCost, c.LogisticsCost, c.OverheadCost} {
 		if d.Valid {
 			total = total.Add(d.Decimal)
 		}
@@ -687,84 +673,77 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 	if c.DefectPercent.Valid {
 		total = total.Mul(decimal.NewFromInt(1).Add(c.DefectPercent.Decimal.Div(decimal.NewFromInt(100))))
 	}
-	out.TotalCost = pbDecimalFromDecimal(total.Round(costMaxFrac))
+	out.TotalCost = pbDecimalFromDecimal(roundMoney(total))
 
-	if totalSam.IsPositive() {
-		out.TotalSam = pbDecimalFromDecimal(totalSam.Round(3))
-	}
-	if labourCost.Valid {
-		out.LabourCost = pbDecimalFromDecimal(labourCost.Decimal.Round(costMaxFrac))
-	}
-
-	// Flag when part of the cost is excluded from total_cost for want of an FX
-	// conversion: a BOM line in another currency, or computed labour that would be
-	// the make cost but is in a different currency than the costing one.
-	for i := range tc.BomItems {
-		b := &tc.BomItems[i]
-		if b.Currency.Valid && b.Currency.String != "" && b.Currency.String != costingCcy && effectiveBomLineTotal(b, orderQtyBySize).Valid {
-			out.HasUnconvertedCurrencies = true
-			break
+	// total_sam = Σ(operation time_norm); informative, pricing-independent (plan Q4).
+	totalSam := decimal.Zero
+	for i := range tc.Operations {
+		if tc.Operations[i].TimeNorm.Valid {
+			totalSam = totalSam.Add(tc.Operations[i].TimeNorm.Decimal)
 		}
 	}
-	if labourCost.Valid && !c.CmtCost.Valid && labourCcy != costingCcy {
-		out.HasUnconvertedCurrencies = true
+	if totalSam.IsPositive() {
+		out.TotalSam = pbDecimalFromDecimal(totalSam.Round(3))
 	}
 	return out
 }
 
-// effectiveBomLineTotal is a BOM line's contribution to the materials rollup: the size-run
-// total (Σ consumption_size × order_qty_size × price, gross of wastage) when the line has
-// per-size consumption and order quantities, otherwise the per-garment LineTotal. This is
-// the user's «per-size if present, else the old formula» rule applied per line.
-func effectiveBomLineTotal(b *entity.TechCardBomItem, orderQtyBySize map[int]int) decimal.NullDecimal {
-	if rt := b.SizeRunTotal(orderQtyBySize); rt.Valid {
-		return rt
-	}
-	return b.LineTotal()
+// colorwayCostResult holds one colourway's computed material cost.
+type colorwayCostResult struct {
+	materialsTotal []*pb_common.TechCardCostLine // Σ usage cost grouped by article currency
+	materialsCost  decimal.Decimal               // Σ in costingCcy (and currency-less)
+	sizeRunTotal   decimal.Decimal               // Σ usage size_run_total (whole-run spend)
+	hasUnconverted bool                          // a usage currency ≠ costingCcy (excluded from materialsCost)
 }
 
-// bomMaterialsRollup sums BOM line totals grouped by the line's currency (first-
-// seen order preserved), and returns the subtotal foldable into costingCurrency
-// (matching-currency lines plus currency-less lines). A line with per-size consumption
-// contributes its full size-run cost (see effectiveBomLineTotal).
-func bomMaterialsRollup(items []entity.TechCardBomItem, costingCurrency sql.NullString, orderQtyBySize map[int]int) ([]*pb_common.TechCardCostLine, decimal.Decimal) {
+// colorwayCost computes one colourway's material cost from its usages. Each usage
+// contributes its whole-run size_run_total (when it has per-size consumption) else its
+// per-garment line_total, resolved against the BOM article it points at. Buckets are
+// per-currency (no FX conversion); currency-less lines fold into the costing currency.
+func colorwayCost(cw *entity.TechCardColorway, bomItems []entity.TechCardBomItem, costingCcy string, orderQtyBySize map[int]int) colorwayCostResult {
 	byCcy := map[string]decimal.Decimal{}
 	order := make([]string, 0)
-	for i := range items {
-		lt := effectiveBomLineTotal(&items[i], orderQtyBySize)
-		if !lt.Valid {
+	sizeRunTotal := decimal.Zero
+	hasUnconverted := false
+	for i := range cw.Usages {
+		u := &cw.Usages[i]
+		bom := bomItemAtIndex(bomItems, u.BomItemIndex)
+		if rt := u.SizeRunTotal(bom, orderQtyBySize); rt.Valid {
+			sizeRunTotal = sizeRunTotal.Add(rt.Decimal)
+		}
+		eff := u.EffectiveTotal(bom, orderQtyBySize)
+		if !eff.Valid {
 			continue
 		}
 		ccy := ""
-		if items[i].Currency.Valid {
-			ccy = items[i].Currency.String
+		if bom != nil && bom.Currency.Valid {
+			ccy = bom.Currency.String
 		}
 		if _, ok := byCcy[ccy]; !ok {
 			order = append(order, ccy)
 		}
-		byCcy[ccy] = byCcy[ccy].Add(lt.Decimal)
+		byCcy[ccy] = byCcy[ccy].Add(eff.Decimal)
+		if ccy != "" && ccy != costingCcy {
+			hasUnconverted = true
+		}
 	}
 
 	lines := make([]*pb_common.TechCardCostLine, 0, len(order))
 	for _, ccy := range order {
 		lines = append(lines, &pb_common.TechCardCostLine{
 			Currency: ccy,
-			Amount:   pbDecimalFromDecimal(byCcy[ccy].Round(costMaxFrac)),
+			Amount:   pbDecimalFromDecimal(roundMoney(byCcy[ccy])),
 		})
 	}
 
-	target := ""
-	if costingCurrency.Valid {
-		target = costingCurrency.String
-	}
 	materialsCost := decimal.Zero
-	if v, ok := byCcy[target]; ok {
+	if v, ok := byCcy[costingCcy]; ok {
 		materialsCost = materialsCost.Add(v)
 	}
-	if target != "" {
+	if costingCcy != "" {
 		if v, ok := byCcy[""]; ok { // currency-less lines fold into the costing currency
 			materialsCost = materialsCost.Add(v)
 		}
 	}
-	return lines, materialsCost
+	return colorwayCostResult{materialsTotal: lines, materialsCost: materialsCost, sizeRunTotal: sizeRunTotal, hasUnconverted: hasUnconverted}
 }

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -6,34 +6,33 @@ import (
 
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
 	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
-	"github.com/shopspring/decimal"
 	pb_decimal "google.golang.org/genproto/googleapis/type/decimal"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+func dec(s string) *pb_decimal.Decimal { return &pb_decimal.Decimal{Value: s} }
+func i32(v int32) *int32              { return &v }
+
 func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 	revDate := timestamppb.New(time.Date(2026, 6, 19, 15, 30, 0, 0, time.UTC))
 	valid := &pb_common.TechCardInsert{
-		StyleNumber:       "ST-001",
-		Name:              "Field Jacket",
-		Brand:             "grbpwr",
-		Season:            "FW25",
-		Stage:             pb_common.TechCardStage_TECH_CARD_STAGE_FIT,
-		ApprovalState:     pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_APPROVED,
-		ApprovedBy:        "lead",
-		ReleasedAt:        revDate,
-		MeasurementUnit:   pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_MM,
-		TargetGender:      pb_common.GenderEnum_GENDER_ENUM_MALE,
-		CategoryId:        3,
-		BaseModelId:       7,
-		BaseSampleSizeId:  4,
-		Currency:          "EUR",
-		TargetCost:        &pb_decimal.Decimal{Value: "42.50"},
-		TargetRetailPrice: &pb_decimal.Decimal{Value: "180.00"},
-		RevisionDate:      revDate,
-		Description:       "boxy field jacket",
-		SizeIds:           []int32{4, 5, 6},
-		ProductIds:        []int32{100, 101},
+		StyleNumber:      "ST-001",
+		Name:             "Field Jacket",
+		Brand:            "grbpwr",
+		Season:           "FW25",
+		Stage:            pb_common.TechCardStage_TECH_CARD_STAGE_FIT,
+		ApprovalState:    pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_APPROVED,
+		ApprovedBy:       "lead",
+		ReleasedAt:       revDate,
+		MeasurementUnit:  pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_MM,
+		TargetGender:     pb_common.GenderEnum_GENDER_ENUM_MALE,
+		CategoryId:       3,
+		BaseModelId:      7,
+		BaseSampleSizeId: 4,
+		Concept:          "boxy field jacket",
+		RevisionDate:     revDate,
+		SizeIds:          []int32{4, 5, 6},
+		ProductIds:       []int32{100, 101},
 		Media: []*pb_common.TechCardMediaItem{
 			{MediaId: 11, Kind: pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_FRONT},
 			{MediaId: 12}, // unset kind -> defaults to preview
@@ -42,7 +41,10 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 			{Number: 1, Part: "collar", Description: "two-piece", Dimensions: "h=4cm", MediaId: 11},
 		},
 		Revisions: []*pb_common.TechCardRevision{
-			{Version: "v2", RevisionDate: revDate, Author: "tech", Section: "POM", ChangeNote: "graded"},
+			{Version: "v2", RevisionDate: revDate, Author: "tech", Section: "materials", ChangeNote: "graded"},
+		},
+		Details: []*pb_common.TechCardDetail{
+			{Key: "silhouette", Text: "boxy, hip length", MediaIds: []int32{11, 12}},
 		},
 	}
 
@@ -62,8 +64,8 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 	if !got.CategoryId.Valid || got.CategoryId.Int32 != 3 || !got.BaseModelId.Valid || got.BaseSampleSizeId.Int32 != 4 {
 		t.Errorf("fk fields mismatch: %+v", got)
 	}
-	if !got.TargetCost.Valid || !got.TargetCost.Decimal.Equal(decimal.RequireFromString("42.50")) {
-		t.Errorf("target_cost mismatch: %+v", got.TargetCost)
+	if got.Concept.String != "boxy field jacket" {
+		t.Errorf("concept mismatch: %+v", got.Concept)
 	}
 	if want := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC); !got.RevisionDate.Valid || !got.RevisionDate.Time.Equal(want) {
 		t.Errorf("revision_date not normalized: %+v", got.RevisionDate)
@@ -74,17 +76,14 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 	if len(got.Media) != 2 || got.Media[0].Kind != entity.TechCardMediaFront || got.Media[1].Kind != entity.TechCardMediaPreview {
 		t.Errorf("media mismatch: %+v", got.Media)
 	}
-	if len(got.Callouts) != 1 || got.Callouts[0].Number != 1 || !got.Callouts[0].Part.Valid {
+	if len(got.Callouts) != 1 || got.Callouts[0].Number != 1 || got.Callouts[0].MediaId.Int32 != 11 {
 		t.Errorf("callouts mismatch: %+v", got.Callouts)
 	}
-	if len(got.Revisions) != 1 || got.Revisions[0].Section.String != "POM" {
-		t.Errorf("revisions mismatch: %+v", got.Revisions)
+	if len(got.Details) != 1 || got.Details[0].Key.String != "silhouette" || len(got.Details[0].MediaIds) != 2 || got.Details[0].MediaIds[1] != 12 {
+		t.Errorf("details mismatch: %+v", got.Details)
 	}
 	if got.ApprovalState != entity.TechCardApprovalApproved || got.ApprovedBy.String != "lead" || !got.ReleasedAt.Valid {
 		t.Errorf("approval mismatch: state=%v by=%+v released=%+v", got.ApprovalState, got.ApprovedBy, got.ReleasedAt)
-	}
-	if got.Callouts[0].MediaId.Int32 != 11 {
-		t.Errorf("callout media_id mismatch: %+v", got.Callouts[0].MediaId)
 	}
 	if got.MeasurementUnit != entity.TechCardUnitMm {
 		t.Errorf("measurement_unit mismatch: %v", got.MeasurementUnit)
@@ -95,17 +94,11 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("defaults: %v", err)
 	}
-	if def.Stage != entity.TechCardStageProto {
-		t.Errorf("stage default mismatch: %v", def.Stage)
+	if def.Stage != entity.TechCardStageProto || def.ApprovalState != entity.TechCardApprovalDraft || def.MeasurementUnit != entity.TechCardUnitMm {
+		t.Errorf("defaults mismatch: %+v", def)
 	}
-	if def.ApprovalState != entity.TechCardApprovalDraft {
-		t.Errorf("approval_state default mismatch: %v", def.ApprovalState)
-	}
-	if def.MeasurementUnit != entity.TechCardUnitMm {
-		t.Errorf("measurement_unit default mismatch: %v", def.MeasurementUnit)
-	}
-	if def.BaseModelId.Valid || def.CategoryId.Valid || def.TargetCost.Valid {
-		t.Errorf("zero fields should be NULL: %+v", def)
+	if def.BaseModelId.Valid || def.CategoryId.Valid {
+		t.Errorf("zero fk fields should be NULL: %+v", def)
 	}
 
 	// base_sample_size_id is allowed when the size range is still empty (early proto).
@@ -121,16 +114,14 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 		"no style":          {Name: "x"},
 		"no name":           {StyleNumber: "x"},
 		"neg category":      {StyleNumber: "x", Name: "y", CategoryId: -1},
-		"bad currency":      {StyleNumber: "x", Name: "y", Currency: "EURO"},
 		"dup size":          {StyleNumber: "x", Name: "y", SizeIds: []int32{4, 4}},
 		"dup product":       {StyleNumber: "x", Name: "y", ProductIds: []int32{1, 1}},
 		"size id zero":      {StyleNumber: "x", Name: "y", SizeIds: []int32{0}},
 		"base not in range": {StyleNumber: "x", Name: "y", BaseSampleSizeId: 9, SizeIds: []int32{4, 5}},
 		"media id zero":     {StyleNumber: "x", Name: "y", Media: []*pb_common.TechCardMediaItem{{MediaId: 0}}},
 		"version too long":  {StyleNumber: "x", Name: "y", Version: string(make([]byte, 65))},
-		"neg cost":          {StyleNumber: "x", Name: "y", TargetCost: &pb_decimal.Decimal{Value: "-1"}},
-		"cost overflow":     {StyleNumber: "x", Name: "y", TargetCost: &pb_decimal.Decimal{Value: "100000000"}},
-		"cost decimals":     {StyleNumber: "x", Name: "y", TargetRetailPrice: &pb_decimal.Decimal{Value: "1.999"}},
+		"detail media zero": {StyleNumber: "x", Name: "y", Details: []*pb_common.TechCardDetail{{Key: "k", MediaIds: []int32{0}}}},
+		"detail media dup":  {StyleNumber: "x", Name: "y", Details: []*pb_common.TechCardDetail{{Key: "k", MediaIds: []int32{5, 5}}}},
 		"dup colorway code": {StyleNumber: "x", Name: "y", Colorways: []*pb_common.TechCardColorway{{Name: "a", Code: "BLK"}, {Name: "b", Code: "BLK"}}},
 		"bad hex":           {StyleNumber: "x", Name: "y", Colorways: []*pb_common.TechCardColorway{{Name: "a", Hex: "red"}}},
 		"bad pantone sys":   {StyleNumber: "x", Name: "y", Colorways: []*pb_common.TechCardColorway{{Name: "a", PantoneSystem: "XXX"}}},
@@ -155,12 +146,13 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 			ApprovalState:   entity.TechCardApprovalReleased,
 			MeasurementUnit: entity.TechCardUnitMm,
 			TargetGender:    nullStringFromPb(string(entity.Female)),
-			TargetCost:      decimal.NullDecimal{Decimal: decimal.RequireFromString("42.50"), Valid: true},
+			Concept:         nullStringFromPb("intent"),
 			SizeIds:         []int{4, 5},
 			ProductIds:      []int{100},
 			Media:           []entity.TechCardMediaItem{{MediaId: 11, Kind: entity.TechCardMediaFront}},
 			Callouts:        []entity.TechCardCallout{{Number: 1, MediaId: nullInt32FromPb(11)}},
 			Revisions:       []entity.TechCardRevision{{Version: nullStringFromPb("v1")}},
+			Details:         []entity.TechCardDetail{{Key: nullStringFromPb("collar"), Text: nullStringFromPb("two-piece"), MediaIds: []int{11}}},
 		},
 		CreatedAt:     time.Now(),
 		UpdatedAt:     time.Now(),
@@ -171,238 +163,167 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 	if pb.Id != 9 || pb.TechCard.StyleNumber != "ST-001" {
 		t.Errorf("id/style mismatch: %+v", pb)
 	}
-	if pb.TechCard.Stage != pb_common.TechCardStage_TECH_CARD_STAGE_PROD {
-		t.Errorf("stage mismatch: %v", pb.TechCard.Stage)
+	if pb.TechCard.Stage != pb_common.TechCardStage_TECH_CARD_STAGE_PROD ||
+		pb.TechCard.ApprovalState != pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_RELEASED {
+		t.Errorf("stage/approval mismatch: %+v", pb.TechCard)
 	}
-	if pb.TechCard.ApprovalState != pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_RELEASED {
-		t.Errorf("approval_state mismatch: %v", pb.TechCard.ApprovalState)
+	if pb.TechCard.MeasurementUnit != pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_MM ||
+		pb.TechCard.TargetGender != pb_common.GenderEnum_GENDER_ENUM_FEMALE || pb.TechCard.Concept != "intent" {
+		t.Errorf("unit/gender/concept mismatch: %+v", pb.TechCard)
 	}
-	if pb.TechCard.Callouts[0].MediaId != 11 {
-		t.Errorf("callout media_id round-trip mismatch: %v", pb.TechCard.Callouts[0].MediaId)
-	}
-	if pb.TechCard.MeasurementUnit != pb_common.TechCardMeasurementUnit_TECH_CARD_MEASUREMENT_UNIT_MM {
-		t.Errorf("measurement_unit round-trip mismatch: %v", pb.TechCard.MeasurementUnit)
-	}
-	if pb.TechCard.TargetGender != pb_common.GenderEnum_GENDER_ENUM_FEMALE {
-		t.Errorf("gender mismatch: %v", pb.TechCard.TargetGender)
-	}
-	if pb.TechCard.TargetCost == nil || pb.TechCard.TargetCost.Value != "42.5" {
-		t.Errorf("target_cost mismatch: %+v", pb.TechCard.TargetCost)
-	}
-	if len(pb.TechCard.Media) != 1 || pb.TechCard.Media[0].Kind != pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_FRONT {
-		t.Errorf("media item mismatch: %+v", pb.TechCard.Media)
+	if len(pb.TechCard.Details) != 1 || pb.TechCard.Details[0].Key != "collar" || len(pb.TechCard.Details[0].MediaIds) != 1 {
+		t.Errorf("details round-trip mismatch: %+v", pb.TechCard.Details)
 	}
 	if len(pb.ResolvedMedia) != 1 || pb.ResolvedMedia[0].Media.Id != 11 {
 		t.Errorf("resolved media mismatch: %+v", pb.ResolvedMedia)
 	}
-	if len(pb.TechCard.SizeIds) != 2 || len(pb.TechCard.Callouts) != 1 || len(pb.TechCard.Revisions) != 1 {
-		t.Errorf("child sections mismatch: %+v", pb.TechCard)
-	}
 }
 
-func TestConvertTechCardMaterials(t *testing.T) {
-	valid := &pb_common.TechCardInsert{
+// TestConvertTechCardColorwayUsages covers the colourway recipe: usages parse, bom_item_index
+// is range-checked, placement is normalised (trim+lower), and index 0 survives as present.
+func TestConvertTechCardColorwayUsages(t *testing.T) {
+	in := &pb_common.TechCardInsert{
 		StyleNumber: "ST-010",
 		Name:        "Parka",
 		SizeIds:     []int32{4, 5},
+		BomItems: []*pb_common.TechCardBomItem{
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "shell", UnitPrice: dec("10"), Currency: "EUR"},
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_HARDWARE, Name: "zip", UnitPrice: dec("3"), Currency: "EUR"},
+		},
 		Colorways: []*pb_common.TechCardColorway{
-			{Code: "BLK", Name: "Black", LabDipStatus: pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_APPROVED},
-			{Name: "White"}, // unset lab dip -> pending
-		},
-		BomItems: []*pb_common.TechCardBomItem{
-			{
-				Section:   pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC,
-				Name:      "Main shell",
-				Quantity:  &pb_decimal.Decimal{Value: "2"},
-				UnitPrice: &pb_decimal.Decimal{Value: "10.5"},
-				Currency:  "EUR",
-				ColorwayColors: []*pb_common.TechCardBomColorwayColor{
-					{ColorwayIndex: 0, Color: "black", Pantone: "Black C"},
-					{ColorwayIndex: 1, Color: "white"},
-				},
-			},
-		},
-		PomPoints: []*pb_common.TechCardPomPoint{
-			{
-				Name:          "Chest width",
-				Code:          "A",
-				Section:       "BODY",
-				BaseValue:     &pb_decimal.Decimal{Value: "56"},
-				TolerancePlus: &pb_decimal.Decimal{Value: "1"}, // minus unset -> mirrors to 1
-				Grades: []*pb_common.TechCardPomGrade{
-					{SizeId: 4, Value: &pb_decimal.Decimal{Value: "54"}},
-					{SizeId: 5, Value: &pb_decimal.Decimal{Value: "56"}},
-				},
-				Actuals: []*pb_common.TechCardPomActual{
-					{FittingId: 3, Label: "fit1", Value: &pb_decimal.Decimal{Value: "55.5"}},
-				},
-			},
+			{Code: "BLK", Name: "Black", LabDipStatus: pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_APPROVED,
+				Usages: []*pb_common.TechCardColorwayUsage{
+					{BomItemIndex: i32(0), Placement: "  Outer Shell ", Color: "Jet", Consumption: dec("2")},
+					{BomItemIndex: i32(1), Placement: "front", Color: "black", Quantity: dec("1")},
+				}},
+			{Name: "White"}, // unset lab dip -> pending, no usages
 		},
 	}
-
-	got, err := ConvertPbTechCardInsertToEntity(valid)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(got.Colorways) != 2 || got.Colorways[0].LabDipStatus != entity.LabDipApproved || got.Colorways[1].LabDipStatus != entity.LabDipPending {
-		t.Errorf("colorways mismatch: %+v", got.Colorways)
-	}
-	if len(got.BomItems) != 1 || got.BomItems[0].Section != entity.BomSectionFabric || len(got.BomItems[0].ColorwayColors) != 2 {
-		t.Fatalf("bom mismatch: %+v", got.BomItems)
-	}
-	if lt := got.BomItems[0].LineTotal(); !lt.Valid || !lt.Decimal.Equal(decimal.RequireFromString("21")) {
-		t.Errorf("line_total mismatch: %+v", lt)
-	}
-	if got.BomItems[0].ColorwayColors[1].ColorwayIndex != 1 {
-		t.Errorf("colorway_index mismatch: %+v", got.BomItems[0].ColorwayColors)
-	}
-	if len(got.PomPoints) != 1 || len(got.PomPoints[0].Grades) != 2 || got.PomPoints[0].Grades[0].SizeId != 4 {
-		t.Fatalf("pom grades mismatch: %+v", got.PomPoints)
-	}
-	if len(got.PomPoints[0].Actuals) != 1 || !got.PomPoints[0].Actuals[0].FittingId.Valid || got.PomPoints[0].Actuals[0].FittingId.Int32 != 3 {
-		t.Errorf("pom actuals mismatch: %+v", got.PomPoints[0].Actuals)
-	}
-	// tolerance_minus was unset, so it mirrors tolerance_plus.
-	if tp := got.PomPoints[0].TolerancePlus; !tp.Valid || tp.Decimal.String() != "1" {
-		t.Errorf("tolerance_plus mismatch: %+v", tp)
-	}
-	if tm := got.PomPoints[0].ToleranceMinus; !tm.Valid || tm.Decimal.String() != "1" {
-		t.Errorf("tolerance_minus should mirror plus: %+v", tm)
-	}
-
-	// round-trip back to pb: computed line_total + matrix + grades survive.
-	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
-	if len(pb.TechCard.Colorways) != 2 || pb.TechCard.Colorways[0].LabDipStatus != pb_common.TechCardLabDipStatus_TECH_CARD_LAB_DIP_STATUS_APPROVED {
-		t.Errorf("pb colorways mismatch: %+v", pb.TechCard.Colorways)
-	}
-	if len(pb.TechCard.BomItems) != 1 || pb.TechCard.BomItems[0].LineTotal == nil || pb.TechCard.BomItems[0].LineTotal.Value != "21" {
-		t.Errorf("pb line_total mismatch: %+v", pb.TechCard.BomItems[0].GetLineTotal())
-	}
-	if pb.TechCard.BomItems[0].Section != pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC || len(pb.TechCard.BomItems[0].ColorwayColors) != 2 {
-		t.Errorf("pb bom mismatch: %+v", pb.TechCard.BomItems[0])
-	}
-	if len(pb.TechCard.PomPoints) != 1 || len(pb.TechCard.PomPoints[0].Grades) != 2 || pb.TechCard.PomPoints[0].Grades[0].Value.Value != "54" {
-		t.Errorf("pb pom mismatch: %+v", pb.TechCard.PomPoints)
-	}
-
-	// invalid cases.
-	bad := map[string]*pb_common.TechCardInsert{
-		"bom section unknown": {StyleNumber: "x", Name: "y", BomItems: []*pb_common.TechCardBomItem{{Name: "m"}}},
-		"bom no name":         {StyleNumber: "x", Name: "y", BomItems: []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC}}},
-		"colorway no name":    {StyleNumber: "x", Name: "y", Colorways: []*pb_common.TechCardColorway{{Code: "X"}}},
-		"colorway idx range": {StyleNumber: "x", Name: "y",
-			Colorways: []*pb_common.TechCardColorway{{Name: "a"}},
-			BomItems:  []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "m", ColorwayColors: []*pb_common.TechCardBomColorwayColor{{ColorwayIndex: 5}}}}},
-		"pom grade not in range": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
-			PomPoints: []*pb_common.TechCardPomPoint{{Name: "p", Grades: []*pb_common.TechCardPomGrade{{SizeId: 9, Value: &pb_decimal.Decimal{Value: "1"}}}}}},
-		"pom grade value missing": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
-			PomPoints: []*pb_common.TechCardPomPoint{{Name: "p", Grades: []*pb_common.TechCardPomGrade{{SizeId: 4}}}}},
-		"bom price too many decimals": {StyleNumber: "x", Name: "y",
-			BomItems: []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "m", UnitPrice: &pb_decimal.Decimal{Value: "1.23456"}}}},
-		"colorway product not in card": {StyleNumber: "x", Name: "y",
-			Colorways: []*pb_common.TechCardColorway{{Name: "a", ProductId: 999}}},
-	}
-	for name, in := range bad {
-		if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {
-			t.Errorf("case %q: expected error, got nil", name)
-		}
-	}
-
-	// a colourway whose product is one of the card's linked products is valid.
-	okCw, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{
-		StyleNumber: "ST-011", Name: "Coat", ProductIds: []int32{100},
-		Colorways: []*pb_common.TechCardColorway{{Name: "Black", ProductId: 100}},
-	})
-	if err != nil {
-		t.Fatalf("colorway linked to a card product should be valid: %v", err)
-	}
-	if !okCw.Colorways[0].ProductId.Valid || okCw.Colorways[0].ProductId.Int32 != 100 {
-		t.Errorf("colorway product_id mismatch: %+v", okCw.Colorways[0].ProductId)
-	}
-}
-
-func TestConvertTechCardProductionAndCosting(t *testing.T) {
-	dec := func(s string) *pb_decimal.Decimal { return &pb_decimal.Decimal{Value: s} }
-	in := &pb_common.TechCardInsert{
-		StyleNumber: "ST-020",
-		Name:        "Coat",
-		BomItems: []*pb_common.TechCardBomItem{
-			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "shell", Quantity: dec("2"), UnitPrice: dec("10"), Currency: "EUR"},
-			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_LINING, Name: "lining", Quantity: dec("1"), UnitPrice: dec("5"), Currency: "EUR"},
-			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_HARDWARE, Name: "zip", Quantity: dec("1"), UnitPrice: dec("3"), Currency: "USD"},
-		},
-		Construction: &pb_common.TechCardConstruction{MainStitchType: "lockstitch", StitchDensity: "3-4"},
-		Operations: []*pb_common.TechCardOperation{
-			{Node: "collar", SeamType: "lockstitch", StitchesPerCm: dec("3.5")},
-		},
-		Labels: []*pb_common.TechCardLabel{
-			{LabelType: pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_MAIN, Content: "grbpwr", Placement: "neck"},
-		},
-		Packaging: &pb_common.TechCardPackaging{FoldingMethod: "flat", UnitsPerBox: 10, WeightNet: dec("0.8")},
-		Costing:   &pb_common.TechCardCosting{CmtCost: dec("10"), DefectPercent: dec("10"), Currency: "EUR"},
-	}
-
 	got, err := ConvertPbTechCardInsertToEntity(in)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got.Construction == nil || got.Construction.MainStitchType.String != "lockstitch" {
-		t.Errorf("construction mismatch: %+v", got.Construction)
+	if len(got.Colorways) != 2 || got.Colorways[0].LabDipStatus != entity.LabDipApproved || got.Colorways[1].LabDipStatus != entity.LabDipPending {
+		t.Fatalf("colorways mismatch: %+v", got.Colorways)
 	}
-	if len(got.Operations) != 1 || got.Operations[0].Node != "collar" {
-		t.Errorf("operations mismatch: %+v", got.Operations)
+	us := got.Colorways[0].Usages
+	if len(us) != 2 {
+		t.Fatalf("usages mismatch: %+v", us)
 	}
-	if len(got.Labels) != 1 || got.Labels[0].LabelType != entity.LabelTypeMain {
-		t.Errorf("labels mismatch: %+v", got.Labels)
+	if !us[0].BomItemIndex.Valid || us[0].BomItemIndex.Int32 != 0 {
+		t.Errorf("usage bom_item_index 0 must be present: %+v", us[0].BomItemIndex)
 	}
-	if got.Packaging == nil || !got.Packaging.UnitsPerBox.Valid || got.Packaging.UnitsPerBox.Int32 != 10 {
-		t.Errorf("packaging mismatch: %+v", got.Packaging)
-	}
-	if got.Costing == nil || !got.Costing.CmtCost.Valid {
-		t.Fatalf("costing mismatch: %+v", got.Costing)
+	if us[0].Placement.String != "outer shell" { // trim + lower
+		t.Errorf("placement not normalised: %q", us[0].Placement.String)
 	}
 
-	// round-trip to pb: production sections + computed costing rollup.
-	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
-	if pb.TechCard.Construction.MainStitchType != "lockstitch" || len(pb.TechCard.Operations) != 1 {
-		t.Errorf("pb construction/operations mismatch: %+v", pb.TechCard)
+	// round-trip: usages emit with computed line_total resolved against the BOM article.
+	pb := ConvertEntityTechCardToPb(&entity.TechCard{TechCardInsert: *got})
+	pus := pb.TechCard.Colorways[0].Usages
+	if len(pus) != 2 || pus[0].Placement != "outer shell" {
+		t.Fatalf("pb usages mismatch: %+v", pus)
 	}
-	if pb.TechCard.Labels[0].LabelType != pb_common.TechCardLabelType_TECH_CARD_LABEL_TYPE_MAIN || pb.TechCard.Packaging.UnitsPerBox != 10 {
-		t.Errorf("pb labels/packaging mismatch: %+v", pb.TechCard)
+	// usage 0: consumption 2 × price 10 = 20 (no wastage).
+	if pus[0].LineTotal == nil || pus[0].LineTotal.Value != "20" {
+		t.Errorf("usage line_total mismatch: %+v", pus[0].LineTotal)
 	}
+	// usage 1: countable quantity 1 × price 3 = 3.
+	if pus[1].LineTotal == nil || pus[1].LineTotal.Value != "3" {
+		t.Errorf("countable usage line_total mismatch: %+v", pus[1].LineTotal)
+	}
+
+	// orphaned usage bom_item_index is rejected.
+	if _, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{StyleNumber: "x", Name: "y",
+		BomItems:  []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "f"}},
+		Colorways: []*pb_common.TechCardColorway{{Name: "a", Usages: []*pb_common.TechCardColorwayUsage{{BomItemIndex: i32(5)}}}},
+	}); err == nil {
+		t.Errorf("expected error for orphaned usage bom_item_index")
+	}
+
+	// new BOM sections decoration/other are accepted.
+	if _, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{StyleNumber: "x", Name: "y",
+		BomItems: []*pb_common.TechCardBomItem{
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_DECORATION, Name: "print"},
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_OTHER, Name: "misc"},
+		}}); err != nil {
+		t.Errorf("decoration/other sections should be accepted: %v", err)
+	}
+}
+
+// TestConvertTechCardCosting locks the per-colourway costing and the root rollup (= colourway
+// index 0): per-currency buckets, currency-less fold, total_cost without labour, total_sam.
+func TestConvertTechCardCosting(t *testing.T) {
+	in := &pb_common.TechCardInsert{
+		StyleNumber: "ST-020",
+		Name:        "Coat",
+		SizeIds:     []int32{4},
+		BomItems: []*pb_common.TechCardBomItem{
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "shell", UnitPrice: dec("10"), Currency: "EUR"},
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_HARDWARE, Name: "zip", UnitPrice: dec("3"), Currency: "USD"},
+		},
+		Colorways: []*pb_common.TechCardColorway{
+			{Name: "Black", Usages: []*pb_common.TechCardColorwayUsage{
+				{BomItemIndex: i32(0), Quantity: dec("2")}, // 20 EUR
+				{BomItemIndex: i32(1), Quantity: dec("1")}, // 3 USD
+			}},
+			{Name: "White", Usages: []*pb_common.TechCardColorwayUsage{
+				{BomItemIndex: i32(0), Quantity: dec("3")}, // 30 EUR
+			}},
+		},
+		Operations: []*pb_common.TechCardOperation{
+			{Node: "collar", TimeNorm: dec("2")},
+			{Node: "side", TimeNorm: dec("3")},
+		},
+		Costing: &pb_common.TechCardCosting{CmtCost: dec("10"), DefectPercent: dec("10"), Currency: "EUR"},
+	}
+	got, err := ConvertPbTechCardInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pb := ConvertEntityTechCardToPb(&entity.TechCard{TechCardInsert: *got})
 	cost := pb.TechCard.Costing
 	if cost == nil {
 		t.Fatalf("costing not emitted")
 	}
-	// materials_cost = EUR lines only (20+5); USD line stays out of the single-currency subtotal.
-	if cost.MaterialsCost == nil || cost.MaterialsCost.Value != "25" {
-		t.Errorf("materials_cost mismatch: %+v", cost.MaterialsCost)
+
+	// per-colourway costs.
+	if len(cost.ColorwayCosts) != 2 {
+		t.Fatalf("expected 2 colorway_costs, got %d", len(cost.ColorwayCosts))
 	}
-	// total_cost = (25 materials + 10 cmt) * (1 + 10/100) = 38.5
-	if cost.TotalCost == nil || cost.TotalCost.Value != "38.5" {
-		t.Errorf("total_cost mismatch: %+v", cost.TotalCost)
+	black := cost.ColorwayCosts[0]
+	if black.ColorwayIndex != 0 || black.MaterialsCost.Value != "20" || !black.HasUnconvertedCurrencies {
+		t.Errorf("black colorway cost mismatch: %+v", black)
 	}
-	// materials_total surfaces both currencies (no conversion).
+	white := cost.ColorwayCosts[1]
+	if white.ColorwayIndex != 1 || white.MaterialsCost.Value != "30" || white.HasUnconvertedCurrencies {
+		t.Errorf("white colorway cost mismatch: %+v", white)
+	}
+
+	// root rollup = primary colourway (index 0 = Black).
+	if cost.MaterialsCost.Value != "20" || !cost.HasUnconvertedCurrencies {
+		t.Errorf("root rollup should mirror colourway 0: materials=%v unconv=%v", cost.MaterialsCost, cost.HasUnconvertedCurrencies)
+	}
 	byCcy := map[string]string{}
 	for _, l := range cost.MaterialsTotal {
 		byCcy[l.Currency] = l.Amount.Value
 	}
-	if byCcy["EUR"] != "25" || byCcy["USD"] != "3" {
-		t.Errorf("materials_total mismatch: %+v", byCcy)
+	if byCcy["EUR"] != "20" || byCcy["USD"] != "3" {
+		t.Errorf("root materials_total buckets mismatch: %+v", byCcy)
 	}
-	// USD line against EUR costing → excluded from total_cost, flag must be set.
-	if !cost.HasUnconvertedCurrencies {
-		t.Errorf("expected has_unconverted_currencies (USD BOM line vs EUR costing)")
+	// total_cost = (20 materials + 10 cmt) × 1.1 = 33. No labour fallback.
+	if cost.TotalCost == nil || cost.TotalCost.Value != "33" {
+		t.Errorf("total_cost mismatch: %+v", cost.TotalCost)
+	}
+	// total_sam = 2 + 3 = 5.
+	if cost.TotalSam == nil || cost.TotalSam.Value != "5" {
+		t.Errorf("total_sam mismatch: %+v", cost.TotalSam)
 	}
 
-	// invalid cases.
+	// invalid costing cases.
 	bad := map[string]*pb_common.TechCardInsert{
-		"label type unknown":  {StyleNumber: "x", Name: "y", Labels: []*pb_common.TechCardLabel{{Content: "x"}}},
-		"operation no node":   {StyleNumber: "x", Name: "y", Operations: []*pb_common.TechCardOperation{{SeamType: "x"}}},
-		"defect over 100":     {StyleNumber: "x", Name: "y", Costing: &pb_common.TechCardCosting{DefectPercent: dec("150")}},
-		"costing bad ccy":     {StyleNumber: "x", Name: "y", Costing: &pb_common.TechCardCosting{Currency: "EURO"}},
-		"neg cmt":             {StyleNumber: "x", Name: "y", Costing: &pb_common.TechCardCosting{CmtCost: dec("-1")}},
-		"stitches too scaled": {StyleNumber: "x", Name: "y", Operations: []*pb_common.TechCardOperation{{Node: "n", StitchesPerCm: dec("1.234")}}},
+		"defect over 100": {StyleNumber: "x", Name: "y", Costing: &pb_common.TechCardCosting{DefectPercent: dec("150")}},
+		"costing bad ccy": {StyleNumber: "x", Name: "y", Costing: &pb_common.TechCardCosting{Currency: "EURO"}},
+		"neg cmt":         {StyleNumber: "x", Name: "y", Costing: &pb_common.TechCardCosting{CmtCost: dec("-1")}},
 	}
 	for name, bi := range bad {
 		if _, err := ConvertPbTechCardInsertToEntity(bi); err == nil {
@@ -411,61 +332,124 @@ func TestConvertTechCardProductionAndCosting(t *testing.T) {
 	}
 }
 
-func TestConvertTechCardPomActualVerdict(t *testing.T) {
-	dec := func(s string) decimal.Decimal { return decimal.RequireFromString(s) }
-	nd := func(s string) decimal.NullDecimal { return decimal.NullDecimal{Decimal: dec(s), Valid: true} }
-	pt := entity.TechCardPomPoint{
-		Name:           "Chest",
-		BaseValue:      nd("50"),
-		TolerancePlus:  nd("1"),
-		ToleranceMinus: nd("1"),
-		Grades: []entity.TechCardPomGrade{
-			{SizeId: 4, Value: dec("54")},
-			{SizeId: 5, Value: dec("56")},
+// TestConvertTechCardPerSizeCosting checks a mixed colourway (one per-garment usage + one
+// per-size usage) folds the size-run cost against per-size order quantities.
+func TestConvertTechCardPerSizeCosting(t *testing.T) {
+	in := &pb_common.TechCardInsert{
+		StyleNumber:    "ST-021",
+		Name:           "Parka",
+		SizeIds:        []int32{4, 5},
+		SizeQuantities: []*pb_common.TechCardSizeQuantity{{SizeId: 4, OrderQty: 10}, {SizeId: 5, OrderQty: 20}},
+		BomItems: []*pb_common.TechCardBomItem{
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "shell", UnitPrice: dec("2"), Currency: "EUR"},
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_HARDWARE, Name: "zip", UnitPrice: dec("3"), Currency: "EUR"},
 		},
-		Actuals: []entity.TechCardPomActual{
-			{SizeId: nullInt32FromPb(4), Value: dec("54.5")}, // in tolerance (54 ± 1)
-			{SizeId: nullInt32FromPb(4), Value: dec("55.5")}, // over (> 55)
-			{SizeId: nullInt32FromPb(4), Value: dec("52.5")}, // under (< 53)
-			{Value: dec("50")}, // no size → base 50, in tolerance
-			{SizeId: nullInt32FromPb(99), Value: dec("70")}, // size set but ungraded → UNKNOWN (no cross-size fallback)
+		Colorways: []*pb_common.TechCardColorway{
+			{Name: "Black", Usages: []*pb_common.TechCardColorwayUsage{
+				// per-size: (1.5×10 + 1.8×20) × 2 = 51 × 2 = 102.
+				{BomItemIndex: i32(0), SizeConsumptions: []*pb_common.TechCardBomSizeConsumption{
+					{SizeId: 4, Consumption: dec("1.5")}, {SizeId: 5, Consumption: dec("1.8")}}},
+				// per-garment countable: 1 × 3 = 3.
+				{BomItemIndex: i32(1), Quantity: dec("1")},
+			}},
 		},
+		Costing: &pb_common.TechCardCosting{Currency: "EUR"},
 	}
-	tc := &entity.TechCard{
-		Id:             1,
-		TechCardInsert: entity.TechCardInsert{StyleNumber: "x", Name: "y", PomPoints: []entity.TechCardPomPoint{pt}},
-		CreatedAt:      time.Now(),
-		UpdatedAt:      time.Now(),
+	got, err := ConvertPbTechCardInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	acts := ConvertEntityTechCardToPb(tc).TechCard.PomPoints[0].Actuals
-	want := []pb_common.TechCardPomVerdict{
-		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_IN_TOLERANCE,
-		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_OVER,
-		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_UNDER,
-		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_IN_TOLERANCE,
-		pb_common.TechCardPomVerdict_TECH_CARD_POM_VERDICT_UNKNOWN,
+	pb := ConvertEntityTechCardToPb(&entity.TechCard{TechCardInsert: *got})
+	cost := pb.TechCard.Costing
+	cc := cost.ColorwayCosts[0]
+	// materials_cost = size-run 102 + per-garment 3 = 105.
+	if cc.MaterialsCost.Value != "105" {
+		t.Errorf("mixed-scale materials_cost mismatch: %+v", cc.MaterialsCost)
 	}
-	for i, w := range want {
-		if acts[i].Verdict != w {
-			t.Errorf("actual %d verdict = %v, want %v", i, acts[i].Verdict, w)
-		}
+	// size_run_total = just the per-size usage's run cost = 102.
+	if cc.SizeRunTotal == nil || cc.SizeRunTotal.Value != "102" {
+		t.Errorf("colorway size_run_total mismatch: %+v", cc.SizeRunTotal)
 	}
-	if acts[0].Deviation == nil || acts[0].Deviation.Value != "0.5" {
-		t.Errorf("actual 0 deviation = %+v, want 0.5", acts[0].Deviation)
+	// the per-size usage emits size_run_total and an absent line_total.
+	pus := pb.TechCard.Colorways[0].Usages
+	if pus[0].SizeRunTotal == nil || pus[0].SizeRunTotal.Value != "102" || pus[0].LineTotal != nil {
+		t.Errorf("per-size usage totals mismatch: line=%v run=%v", pus[0].LineTotal, pus[0].SizeRunTotal)
 	}
 }
 
-func TestConvertTechCardOperationsAndIssues(t *testing.T) {
-	dec := func(s string) *pb_decimal.Decimal { return &pb_decimal.Decimal{Value: s} }
+// TestConvertTechCardOperations covers server-assigned operation numbers ((i+1)*10, client
+// value ignored), placement normalisation, and the classification refs.
+func TestConvertTechCardOperations(t *testing.T) {
 	in := &pb_common.TechCardInsert{
-		StyleNumber:  "ST-030",
-		Name:         "Jacket",
-		Construction: &pb_common.TechCardConstruction{LabourRate: dec("0.5"), LabourRateCurrency: "EUR"},
-		Operations: []*pb_common.TechCardOperation{
-			{Node: "collar", OperationNumber: 10, Machine: "lockstitch", SeamAllowance: "1.0", Needle: "90/14", Attachment: "binder", TimeNorm: dec("2")},
-			{Node: "side", OperationNumber: 20, TimeNorm: dec("3")},
+		StyleNumber: "ST-030",
+		Name:        "Jacket",
+		Callouts:    []*pb_common.TechCardCallout{{Number: 1}, {Number: 2}},
+		BomItems: []*pb_common.TechCardBomItem{
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_THREAD, Name: "thread"},
+			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_TRIM, Name: "binding"},
 		},
-		Costing: &pb_common.TechCardCosting{Currency: "EUR"},
+		Operations: []*pb_common.TechCardOperation{
+			{Node: "bind hem", OperationNumber: 999, Placement: "  Outer Hem", // client number ignored
+				OperationType: pb_common.TechCardOperationType_TECH_CARD_OPERATION_TYPE_COVERSTITCH,
+				Zone:          pb_common.TechCardConstructionZone_TECH_CARD_CONSTRUCTION_ZONE_OUTER,
+				BomItemIndex:  i32(1), CalloutNumber: 2},
+			{Node: "lay thread", BomItemIndex: i32(0)}, // index 0 must survive as present
+		},
+	}
+	got, err := ConvertPbTechCardInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// server-assigned numbers: (0+1)*10=10, (1+1)*10=20, regardless of client value.
+	if got.Operations[0].OperationNumber.Int32 != 10 || got.Operations[1].OperationNumber.Int32 != 20 {
+		t.Errorf("operation numbers not server-assigned: %v, %v", got.Operations[0].OperationNumber, got.Operations[1].OperationNumber)
+	}
+	if got.Operations[0].Placement.String != "outer hem" {
+		t.Errorf("operation placement not normalised: %q", got.Operations[0].Placement.String)
+	}
+	if got.Operations[0].OperationType != entity.OpTypeCoverstitch || got.Operations[0].Zone != entity.ZoneOuter ||
+		got.Operations[0].BomItemIndex.Int32 != 1 || got.Operations[0].CalloutNumber.Int32 != 2 {
+		t.Errorf("operation classification mismatch: %+v", got.Operations[0])
+	}
+	if !got.Operations[1].BomItemIndex.Valid || got.Operations[1].BomItemIndex.Int32 != 0 {
+		t.Errorf("bom_item_index 0 should be present: %+v", got.Operations[1].BomItemIndex)
+	}
+
+	pb := ConvertEntityTechCardToPb(&entity.TechCard{TechCardInsert: *got})
+	if pb.TechCard.Operations[0].OperationNumber != 10 || pb.TechCard.Operations[0].Placement != "outer hem" {
+		t.Errorf("pb operation mismatch: %+v", pb.TechCard.Operations[0])
+	}
+	if pop := pb.TechCard.Operations[1]; pop.BomItemIndex == nil || *pop.BomItemIndex != 0 {
+		t.Errorf("pb op1 bom_item_index 0 should round-trip as present: %+v", pop.BomItemIndex)
+	}
+
+	// a placement that matches no usage is a soft case — drafts are incomplete, never rejected.
+	if _, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{StyleNumber: "x", Name: "y",
+		Operations: []*pb_common.TechCardOperation{{Node: "n", Placement: "nonexistent part"}}}); err != nil {
+		t.Errorf("placement mismatch must be accepted (soft): %v", err)
+	}
+
+	// hard errors: out-of-range bom_item_index and unmatched callout_number.
+	bad := map[string]*pb_common.TechCardInsert{
+		"op no node": {StyleNumber: "x", Name: "y", Operations: []*pb_common.TechCardOperation{{SeamType: "x"}}},
+		"bom idx range": {StyleNumber: "x", Name: "y",
+			BomItems:   []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_THREAD, Name: "t"}},
+			Operations: []*pb_common.TechCardOperation{{Node: "n", BomItemIndex: i32(3)}}},
+		"callout unmatched": {StyleNumber: "x", Name: "y",
+			Callouts:   []*pb_common.TechCardCallout{{Number: 1}},
+			Operations: []*pb_common.TechCardOperation{{Node: "n", CalloutNumber: 9}}},
+	}
+	for name, bi := range bad {
+		if _, err := ConvertPbTechCardInsertToEntity(bi); err == nil {
+			t.Errorf("case %q: expected error, got nil", name)
+		}
+	}
+}
+
+func TestConvertTechCardIssuesAndRelease(t *testing.T) {
+	in := &pb_common.TechCardInsert{
+		StyleNumber: "ST-035",
+		Name:        "Jacket",
 		Issues: []*pb_common.TechCardIssue{
 			{OperationNumber: 10, Severity: pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_HIGH, Description: "collar too tight to turn"},
 		},
@@ -474,31 +458,8 @@ func TestConvertTechCardOperationsAndIssues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(got.Operations) != 2 || !got.Operations[0].OperationNumber.Valid || got.Operations[0].OperationNumber.Int32 != 10 ||
-		got.Operations[0].Machine.String != "lockstitch" || got.Operations[0].Attachment.String != "binder" || !got.Operations[0].TimeNorm.Valid {
-		t.Errorf("operations mismatch: %+v", got.Operations)
-	}
 	if len(got.Issues) != 1 || got.Issues[0].Severity != entity.IssueSeverityHigh || got.Issues[0].Status != entity.IssueStatusOpen {
 		t.Errorf("issues mismatch: %+v", got.Issues)
-	}
-
-	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
-	cost := pb.TechCard.Costing
-	if cost == nil || cost.TotalSam == nil || cost.TotalSam.Value != "5" {
-		t.Errorf("total_sam mismatch: %+v", cost.GetTotalSam())
-	}
-	if cost.LabourCost == nil || cost.LabourCost.Value != "2.5" {
-		t.Errorf("labour_cost mismatch: %+v", cost.GetLabourCost())
-	}
-	// no cmt_cost + same currency → computed labour folds into total_cost as the make cost.
-	if cost.TotalCost == nil || cost.TotalCost.Value != "2.5" {
-		t.Errorf("total_cost should include folded labour: %+v", cost.GetTotalCost())
-	}
-	if len(pb.TechCard.Operations) != 2 || pb.TechCard.Operations[0].OperationNumber != 10 {
-		t.Errorf("pb operations mismatch: %+v", pb.TechCard.Operations)
-	}
-	if len(pb.TechCard.Issues) != 1 || pb.TechCard.Issues[0].Severity != pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_HIGH {
-		t.Errorf("pb issues mismatch: %+v", pb.TechCard.Issues)
 	}
 
 	// issue without a description is rejected.
@@ -506,170 +467,48 @@ func TestConvertTechCardOperationsAndIssues(t *testing.T) {
 		Issues: []*pb_common.TechCardIssue{{Severity: pb_common.TechCardIssueSeverity_TECH_CARD_ISSUE_SEVERITY_LOW}}}); err == nil {
 		t.Errorf("expected error for issue without description")
 	}
-
-	// releasing while a high-severity issue is still open is blocked.
+	// releasing while a high-severity issue is open is blocked.
 	in.ApprovalState = pb_common.TechCardApprovalState_TECH_CARD_APPROVAL_STATE_RELEASED
 	if _, err := ConvertPbTechCardInsertToEntity(in); err == nil {
 		t.Errorf("expected release to be blocked by an open high-severity issue")
 	}
 }
 
-func TestConvertTechCardOperationClassification(t *testing.T) {
-	i32 := func(v int32) *int32 { return &v }
+func TestConvertTechCardSignoffs(t *testing.T) {
 	in := &pb_common.TechCardInsert{
-		StyleNumber: "ST-031",
-		Name:        "Jacket",
-		Callouts: []*pb_common.TechCardCallout{
-			{Number: 1, Part: "hem"},
-			{Number: 2, Part: "side seam"},
-		},
-		BomItems: []*pb_common.TechCardBomItem{
-			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_THREAD, Name: "thread"},
-			{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_TRIM, Name: "binding"},
-		},
-		Operations: []*pb_common.TechCardOperation{
-			{
-				Node:          "bind hem",
-				OperationType: pb_common.TechCardOperationType_TECH_CARD_OPERATION_TYPE_COVERSTITCH,
-				Zone:          pb_common.TechCardConstructionZone_TECH_CARD_CONSTRUCTION_ZONE_OUTER,
-				BomItemIndex:  i32(1),
-				CalloutNumber: 2,
-			},
-			// bom_item_index 0 must survive as a real reference (not be read as "unset").
-			{Node: "lay thread", OperationType: pb_common.TechCardOperationType_TECH_CARD_OPERATION_TYPE_LOCKSTITCH, BomItemIndex: i32(0)},
+		StyleNumber: "ST-050", Name: "Tee",
+		Signoffs: []*pb_common.TechCardSignoff{
+			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COSTING, State: pb_common.TechCardSignoffState_TECH_CARD_SIGNOFF_STATE_APPROVED, SignedBy: "finance"},
+			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COLOUR},
 		},
 	}
 	got, err := ConvertPbTechCardInsertToEntity(in)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got.BomItems[1].Section != entity.BomSectionTrim {
-		t.Errorf("trim section mismatch: %v", got.BomItems[1].Section)
+	if len(got.Signoffs) != 2 || got.Signoffs[0].Section != entity.SignoffCosting || got.Signoffs[0].State != entity.SignoffStateApproved {
+		t.Errorf("signoffs mismatch: %+v", got.Signoffs)
 	}
-	op0 := got.Operations[0]
-	if op0.OperationType != entity.OpTypeCoverstitch || op0.Zone != entity.ZoneOuter {
-		t.Errorf("operation type/zone mismatch: %+v", op0)
+	if got.Signoffs[1].State != entity.SignoffStatePending {
+		t.Errorf("signoff default state mismatch: %+v", got.Signoffs[1])
 	}
-	if !op0.BomItemIndex.Valid || op0.BomItemIndex.Int32 != 1 {
-		t.Errorf("bom_item_index mismatch: %+v", op0.BomItemIndex)
-	}
-	if !op0.CalloutNumber.Valid || op0.CalloutNumber.Int32 != 2 {
-		t.Errorf("callout_number mismatch: %+v", op0.CalloutNumber)
-	}
-	op1 := got.Operations[1]
-	if !op1.BomItemIndex.Valid || op1.BomItemIndex.Int32 != 0 {
-		t.Errorf("bom_item_index 0 should be present, got: %+v", op1.BomItemIndex)
-	}
-	if op1.Zone != entity.ZoneUnknown || op1.OperationType != entity.OpTypeLockstitch {
-		t.Errorf("op1 type/zone defaults mismatch: %+v", op1)
+	pb := ConvertEntityTechCardToPb(&entity.TechCard{TechCardInsert: *got})
+	if len(pb.TechCard.Signoffs) != 2 || pb.TechCard.Signoffs[0].Section != pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COSTING {
+		t.Errorf("pb signoffs mismatch: %+v", pb.TechCard.Signoffs)
 	}
 
-	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
-	pop0 := pb.TechCard.Operations[0]
-	if pop0.OperationType != pb_common.TechCardOperationType_TECH_CARD_OPERATION_TYPE_COVERSTITCH ||
-		pop0.Zone != pb_common.TechCardConstructionZone_TECH_CARD_CONSTRUCTION_ZONE_OUTER {
-		t.Errorf("pb op type/zone mismatch: %+v", pop0)
-	}
-	if pop0.BomItemIndex == nil || *pop0.BomItemIndex != 1 || pop0.CalloutNumber != 2 {
-		t.Errorf("pb op refs mismatch: %+v", pop0)
-	}
-	if pop1 := pb.TechCard.Operations[1]; pop1.BomItemIndex == nil || *pop1.BomItemIndex != 0 {
-		t.Errorf("pb op1 bom_item_index 0 should round-trip as present: %+v", pop1.BomItemIndex)
-	}
-	if pb.TechCard.BomItems[1].Section != pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_TRIM {
-		t.Errorf("pb trim section mismatch: %v", pb.TechCard.BomItems[1].Section)
-	}
-
-	// bom_item_index out of range is rejected.
-	bad := &pb_common.TechCardInsert{StyleNumber: "x", Name: "y",
-		BomItems:   []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_THREAD, Name: "t"}},
-		Operations: []*pb_common.TechCardOperation{{Node: "n", BomItemIndex: i32(3)}}}
-	if _, err := ConvertPbTechCardInsertToEntity(bad); err == nil {
-		t.Errorf("expected error for out-of-range bom_item_index")
-	}
-
-	// callout_number with no matching callout is rejected.
-	bad2 := &pb_common.TechCardInsert{StyleNumber: "x", Name: "y",
-		Callouts:   []*pb_common.TechCardCallout{{Number: 1}},
-		Operations: []*pb_common.TechCardOperation{{Node: "n", CalloutNumber: 9}}}
-	if _, err := ConvertPbTechCardInsertToEntity(bad2); err == nil {
-		t.Errorf("expected error for callout_number with no matching callout")
+	// duplicate sign-off section is rejected (the POM section is gone from the enum).
+	if _, err := ConvertPbTechCardInsertToEntity(&pb_common.TechCardInsert{StyleNumber: "x", Name: "y",
+		Signoffs: []*pb_common.TechCardSignoff{
+			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COLOUR},
+			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COLOUR}}}); err == nil {
+		t.Errorf("expected error for duplicate signoff section")
 	}
 }
 
-func TestConvertTechCardMaterialsDepth(t *testing.T) {
-	dec := func(s string) *pb_decimal.Decimal { return &pb_decimal.Decimal{Value: s} }
-	ts := timestamppb.New(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
-	in := &pb_common.TechCardInsert{
-		StyleNumber: "ST-040",
-		Name:        "Parka",
-		SizeIds:     []int32{4, 5},
-		SizeQuantities: []*pb_common.TechCardSizeQuantity{
-			{SizeId: 4, OrderQty: 120}, {SizeId: 5, OrderQty: 80},
-		},
-		Media: []*pb_common.TechCardMediaItem{
-			{MediaId: 11, Kind: pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_MOODBOARD, Caption: "AW vibe"},
-		},
-		Callouts: []*pb_common.TechCardCallout{{Number: 1, PosX: dec("0.5"), PosY: dec("0.25")}},
-		Colorways: []*pb_common.TechCardColorway{
-			{Name: "Black", Pantone: "19-4005", PantoneSystem: "TCX", Hex: "#101010", LabDipRound: 2, SwatchMediaId: 11, LabDipDecidedBy: "colorist", LabDipDecidedAt: ts},
-		},
-		BomItems: []*pb_common.TechCardBomItem{
-			{
-				Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "shell",
-				Quantity: dec("2"), UnitPrice: dec("10"), Currency: "EUR", WastagePercent: dec("10"),
-				FabricWidth: dec("150"), FabricDirection: pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_ONE_WAY,
-			},
-		},
-	}
-	got, err := ConvertPbTechCardInsertToEntity(in)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(got.SizeQuantities) != 2 || got.SizeQuantities[0].OrderQty != 120 {
-		t.Errorf("size_quantities mismatch: %+v", got.SizeQuantities)
-	}
-	if got.Media[0].Caption.String != "AW vibe" || got.Media[0].Kind != entity.TechCardMediaMoodboard {
-		t.Errorf("media caption/kind mismatch: %+v", got.Media[0])
-	}
-	if !got.Callouts[0].PosX.Valid || got.BomItems[0].FabricDirection.String != string(entity.FabricDirectionOneWay) {
-		t.Errorf("callout/fabric mismatch: %+v %+v", got.Callouts[0], got.BomItems[0])
-	}
-	if got.Colorways[0].Pantone.String != "19-4005" || got.Colorways[0].LabDipRound.Int32 != 2 {
-		t.Errorf("colorway lab-dip mismatch: %+v", got.Colorways[0])
-	}
-	// line_total grossed up by 10% wastage: 2 * 10 * 1.1 = 22.
-	if lt := got.BomItems[0].LineTotal(); !lt.Valid || !lt.Decimal.Equal(decimal.RequireFromString("22")) {
-		t.Errorf("line_total with wastage mismatch: %+v", lt)
-	}
-
-	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
-	if pb.TechCard.BomItems[0].LineTotal.Value != "22" ||
-		pb.TechCard.BomItems[0].FabricDirection != pb_common.TechCardFabricDirection_TECH_CARD_FABRIC_DIRECTION_ONE_WAY {
-		t.Errorf("pb bom mismatch: %+v", pb.TechCard.BomItems[0])
-	}
-	if len(pb.TechCard.SizeQuantities) != 2 || pb.TechCard.Colorways[0].Pantone != "19-4005" || pb.TechCard.Media[0].Caption != "AW vibe" {
-		t.Errorf("pb depth fields mismatch")
-	}
-
-	bad := map[string]*pb_common.TechCardInsert{
-		"wastage over 100": {StyleNumber: "x", Name: "y", BomItems: []*pb_common.TechCardBomItem{{Section: pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC, Name: "m", WastagePercent: dec("150")}}},
-		"size qty not in range": {StyleNumber: "x", Name: "y", SizeIds: []int32{4},
-			SizeQuantities: []*pb_common.TechCardSizeQuantity{{SizeId: 9, OrderQty: 1}}},
-		"callout pos out of range": {StyleNumber: "x", Name: "y", Callouts: []*pb_common.TechCardCallout{{Number: 1, PosX: dec("2")}}},
-	}
-	for name, bi := range bad {
-		if _, err := ConvertPbTechCardInsertToEntity(bi); err == nil {
-			t.Errorf("case %q: expected error, got nil", name)
-		}
-	}
-}
-
-// TestConvertTechCardZeroTimestampsAreNull guards the grpc-gateway behaviour
-// where an unset Go time.Time is serialised as "0001-01-01T00:00:00Z" — a
-// non-nil timestamp at the zero instant. These must map to NULL, not be passed
-// through, or MySQL rejects the DATE/TIMESTAMP ("Incorrect date value:
-// '0000-00-00'", err 1292) and the whole tech card insert fails.
+// TestConvertTechCardZeroTimestampsAreNull guards the grpc-gateway behaviour where an unset
+// Go time.Time serialises as "0001-01-01T00:00:00Z" (a non-nil zero-instant timestamp); these
+// must map to NULL or MySQL rejects the DATE/TIMESTAMP (err 1292).
 func TestConvertTechCardZeroTimestampsAreNull(t *testing.T) {
 	zero := timestamppb.New(time.Time{})
 	in := &pb_common.TechCardInsert{
@@ -696,53 +535,12 @@ func TestConvertTechCardZeroTimestampsAreNull(t *testing.T) {
 	}
 }
 
-func TestConvertTechCardSignoffs(t *testing.T) {
-	in := &pb_common.TechCardInsert{
-		StyleNumber: "ST-050", Name: "Tee",
-		Signoffs: []*pb_common.TechCardSignoff{
-			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COSTING, State: pb_common.TechCardSignoffState_TECH_CARD_SIGNOFF_STATE_APPROVED, SignedBy: "finance"},
-			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COLOUR},
-		},
-	}
-	got, err := ConvertPbTechCardInsertToEntity(in)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(got.Signoffs) != 2 || got.Signoffs[0].Section != entity.SignoffCosting || got.Signoffs[0].State != entity.SignoffStateApproved {
-		t.Errorf("signoffs mismatch: %+v", got.Signoffs)
-	}
-	if got.Signoffs[1].State != entity.SignoffStatePending {
-		t.Errorf("signoff default state mismatch: %+v", got.Signoffs[1])
-	}
-	pb := ConvertEntityTechCardToPb(&entity.TechCard{Id: 1, TechCardInsert: *got, CreatedAt: time.Now(), UpdatedAt: time.Now()})
-	if len(pb.TechCard.Signoffs) != 2 || pb.TechCard.Signoffs[0].Section != pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_COSTING {
-		t.Errorf("pb signoffs mismatch: %+v", pb.TechCard.Signoffs)
-	}
-
-	bad := map[string]*pb_common.TechCardInsert{
-		"signoff no section": {StyleNumber: "x", Name: "y", Signoffs: []*pb_common.TechCardSignoff{{SignedBy: "x"}}},
-		"signoff dup section": {StyleNumber: "x", Name: "y", Signoffs: []*pb_common.TechCardSignoff{
-			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_POM},
-			{Section: pb_common.TechCardSignoffSection_TECH_CARD_SIGNOFF_SECTION_POM}}},
-	}
-	for name, bi := range bad {
-		if _, err := ConvertPbTechCardInsertToEntity(bi); err == nil {
-			t.Errorf("case %q: expected error, got nil", name)
-		}
-	}
-}
-
-// ListItem conversion produces a lightweight header.
 func TestConvertEntityTechCardToListItemPb(t *testing.T) {
 	tc := &entity.TechCard{
-		Id: 5,
-		TechCardInsert: entity.TechCardInsert{
-			StyleNumber: "ST-003",
-			Name:        "Pants",
-			Stage:       entity.TechCardStagePP,
-		},
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		Id:             5,
+		TechCardInsert: entity.TechCardInsert{StyleNumber: "ST-003", Name: "Pants", Stage: entity.TechCardStagePP},
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
 	}
 	li := ConvertEntityTechCardToListItemPb(tc)
 	if li.Id != 5 || li.StyleNumber != "ST-003" || li.Stage != pb_common.TechCardStage_TECH_CARD_STAGE_PP {

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -169,7 +169,9 @@ const (
 	BomSectionThread      TechCardBomSection = "thread"
 	BomSectionLabel       TechCardBomSection = "label"
 	BomSectionPackaging   TechCardBomSection = "packaging"
-	BomSectionTrim        TechCardBomSection = "trim" // soft trims (бейка / тесьма / резинка / кант / шнур / лента)
+	BomSectionTrim        TechCardBomSection = "trim"       // soft trims (бейка / тесьма / резинка / кант / шнур / лента)
+	BomSectionDecoration  TechCardBomSection = "decoration" // принт / вышивка / аппликация / патч / стразы
+	BomSectionOther       TechCardBomSection = "other"      // прочее (catch-all)
 )
 
 // ValidTechCardBomSections is the set of accepted BOM sections.
@@ -183,6 +185,8 @@ var ValidTechCardBomSections = map[TechCardBomSection]bool{
 	BomSectionLabel:       true,
 	BomSectionPackaging:   true,
 	BomSectionTrim:        true,
+	BomSectionDecoration:  true,
+	BomSectionOther:       true,
 }
 
 // IsValidTechCardBomSection reports whether s is an accepted BOM section.
@@ -231,45 +235,109 @@ type TechCardColorway struct {
 	LabDipDecidedAt    sql.NullTime         `db:"lab_dip_decided_at"`
 	LabDipDecidedBy    sql.NullString       `db:"lab_dip_decided_by"`
 	LabDipRejectReason sql.NullString       `db:"lab_dip_reject_reason"`
+	// Usages is the colour's material recipe (in-memory; persisted to
+	// tech_card_colorway_usage). Each entry binds a catalog BOM article to a garment
+	// part, the colour it takes in this colourway, and its consumption.
+	Usages []TechCardColorwayUsage `db:"-"`
 }
 
-// TechCardBomColorwayColor is the colour of a BOM material in a colourway. On
-// write, ColorwayIndex points into TechCardInsert.Colorways (full-replace has no
-// stable colourway ids yet); on read it is resolved from the stored colorway id.
-type TechCardBomColorwayColor struct {
-	ColorwayIndex int            `db:"-"`
-	Color         sql.NullString `db:"color"`
-	Pantone       sql.NullString `db:"pantone"`
+// TechCardColorwayUsage is one material use inside a colourway: which catalog article
+// (BomItemIndex) goes on which garment part (Placement), the colour it takes here, and
+// how much is consumed (per-garment Consumption/Quantity and/or per-size). The BOM is a
+// pure article catalog; per-colourway divergence lives here.
+type TechCardColorwayUsage struct {
+	Id           int                 `db:"id"`
+	BomItemIndex sql.NullInt32       `db:"bom_item_index"` // 0-based index into the submitted bom_items; NULL = unset
+	Placement    sql.NullString      `db:"placement"`
+	Color        sql.NullString      `db:"color"`
+	Pantone      sql.NullString      `db:"pantone"`
+	Consumption  decimal.NullDecimal `db:"consumption"` // per-garment rate (measured materials)
+	Quantity     decimal.NullDecimal `db:"quantity"`    // count (countable trims)
+	// SizeConsumptions is the per-size material rate (in-memory; persisted to
+	// tech_card_colorway_usage_consumption). When non-empty it grades usage per size.
+	SizeConsumptions []TechCardBomSizeConsumption `db:"-"`
 }
 
-// TechCardBomItem is one bill-of-materials line (Sheet «Спецификация»).
+// LineTotal is the usage's per-garment material cost, resolved against its catalog
+// article (bom). It is INVALID (the cost moves to SizeRunTotal) when the usage has
+// per-size consumption. A countable trim (Quantity, no Consumption) is Quantity ×
+// unit_price with no wastage; a measured material is Consumption × unit_price grossed
+// up by the article's wastage_percent.
+func (u *TechCardColorwayUsage) LineTotal(bom *TechCardBomItem) decimal.NullDecimal {
+	if len(u.SizeConsumptions) > 0 || bom == nil || !bom.UnitPrice.Valid {
+		return decimal.NullDecimal{}
+	}
+	if u.Quantity.Valid {
+		return decimal.NullDecimal{Decimal: u.Quantity.Decimal.Mul(bom.UnitPrice.Decimal), Valid: true}
+	}
+	if !u.Consumption.Valid {
+		return decimal.NullDecimal{}
+	}
+	return decimal.NullDecimal{Decimal: applyWastage(u.Consumption.Decimal.Mul(bom.UnitPrice.Decimal), bom.WastagePercent), Valid: true}
+}
+
+// SizeRunTotal is the usage's whole-run material cost when it has per-size consumption:
+// Σ(consumption_size × order_qty_size) × unit_price, grossed up by the article's
+// wastage_percent. orderQtyBySize maps size_id → order quantity (a size with no order
+// quantity contributes nothing). INVALID when there is no per-size consumption, no
+// unit_price, or no order quantities yet (the cost is then 0, per the costing rule).
+func (u *TechCardColorwayUsage) SizeRunTotal(bom *TechCardBomItem, orderQtyBySize map[int]int) decimal.NullDecimal {
+	if len(u.SizeConsumptions) == 0 || bom == nil || !bom.UnitPrice.Valid {
+		return decimal.NullDecimal{}
+	}
+	totalQty := decimal.Zero
+	for _, sc := range u.SizeConsumptions {
+		qty, ok := orderQtyBySize[sc.SizeId]
+		if !ok || qty <= 0 {
+			continue
+		}
+		totalQty = totalQty.Add(sc.Consumption.Mul(decimal.NewFromInt(int64(qty))))
+	}
+	if totalQty.IsZero() {
+		return decimal.NullDecimal{}
+	}
+	return decimal.NullDecimal{Decimal: applyWastage(totalQty.Mul(bom.UnitPrice.Decimal), bom.WastagePercent), Valid: true}
+}
+
+// EffectiveTotal is the usage's contribution to the materials rollup: its whole-run
+// SizeRunTotal when it has per-size consumption (order-scale), otherwise its per-garment
+// LineTotal. Mirrors the «per-size if present, else per-garment» rule applied per usage.
+func (u *TechCardColorwayUsage) EffectiveTotal(bom *TechCardBomItem, orderQtyBySize map[int]int) decimal.NullDecimal {
+	if rt := u.SizeRunTotal(bom, orderQtyBySize); rt.Valid {
+		return rt
+	}
+	return u.LineTotal(bom)
+}
+
+// applyWastage grosses a base cost up by wastage_percent when set (× (1 + pct/100)).
+func applyWastage(base decimal.Decimal, wastagePercent decimal.NullDecimal) decimal.Decimal {
+	if !wastagePercent.Valid {
+		return base
+	}
+	return base.Mul(decimal.NewFromInt(1).Add(wastagePercent.Decimal.Div(decimal.NewFromInt(100))))
+}
+
+// TechCardBomItem is one bill-of-materials line — a catalog article (Sheet
+// «Спецификация»). The per-colourway colour, placement and consumption live on
+// TechCardColorwayUsage; the BOM line is a pure material-article catalog entry.
 type TechCardBomItem struct {
-	Id          int                 `db:"id"`
-	Section     TechCardBomSection  `db:"section"`
-	Name        string              `db:"name"`
-	Placement   sql.NullString      `db:"placement"`
-	Supplier    sql.NullString      `db:"supplier"`
-	SupplierRef sql.NullString      `db:"supplier_ref"`
-	Color       sql.NullString      `db:"color"`
-	Composition sql.NullString      `db:"composition"`
-	Spec        sql.NullString      `db:"spec"`
-	Consumption decimal.NullDecimal `db:"consumption"`
-	Unit        sql.NullString      `db:"unit"`
-	Quantity    decimal.NullDecimal `db:"quantity"`
+	Id          int                `db:"id"`
+	Section     TechCardBomSection `db:"section"`
+	Name        string             `db:"name"`
+	Supplier    sql.NullString     `db:"supplier"`
+	SupplierRef sql.NullString     `db:"supplier_ref"`
+	Color       sql.NullString     `db:"color"` // base/reference colour (per-colourway colour is on the usage)
+	Composition sql.NullString     `db:"composition"`
+	Spec        sql.NullString     `db:"spec"`
+	Unit        sql.NullString     `db:"unit"`
 	UnitPrice   decimal.NullDecimal `db:"unit_price"`
-	Currency    sql.NullString      `db:"currency"`
-	Comment     sql.NullString      `db:"comment"`
+	Currency    sql.NullString     `db:"currency"`
+	Comment     sql.NullString     `db:"comment"`
 	// fabric data for the cutter / marker (Phase 3.5c)
 	FabricWidth     decimal.NullDecimal `db:"fabric_width"`
 	FabricWeightGsm decimal.NullDecimal `db:"fabric_weight_gsm"`
 	FabricDirection sql.NullString      `db:"fabric_direction"`
 	WastagePercent  decimal.NullDecimal `db:"wastage_percent"`
-	// ColorwayColors are the per-colourway colours (in-memory; persisted to
-	// tech_card_bom_colorway).
-	ColorwayColors []TechCardBomColorwayColor `db:"-"`
-	// SizeConsumptions is the per-size material rate (in-memory; persisted to
-	// tech_card_bom_consumption). When non-empty it grades fabric usage per size.
-	SizeConsumptions []TechCardBomSizeConsumption `db:"-"`
 }
 
 // TechCardBomSizeConsumption is the per-size consumption (норма расхода) of a BOM
@@ -292,58 +360,6 @@ var ValidTechCardFabricDirections = map[TechCardFabricDirection]bool{
 	FabricDirectionAny: true, FabricDirectionOneWay: true, FabricDirectionTwoWay: true,
 }
 
-// LineTotal returns quantity*unit_price (falling back to consumption*unit_price
-// when quantity is unset), grossed up by wastage_percent when set. Invalid (no
-// price) yields an invalid NullDecimal.
-func (b *TechCardBomItem) LineTotal() decimal.NullDecimal {
-	if !b.UnitPrice.Valid {
-		return decimal.NullDecimal{}
-	}
-	qty := b.Quantity
-	if !qty.Valid {
-		qty = b.Consumption
-	}
-	if !qty.Valid {
-		return decimal.NullDecimal{}
-	}
-	total := qty.Decimal.Mul(b.UnitPrice.Decimal)
-	if b.WastagePercent.Valid {
-		total = total.Mul(decimal.NewFromInt(1).Add(b.WastagePercent.Decimal.Div(decimal.NewFromInt(100))))
-	}
-	return decimal.NullDecimal{Decimal: total, Valid: true}
-}
-
-// SizeRunTotal returns the total material cost over the whole size run when this line has
-// per-size consumption: Σ(consumption_size × order_qty_size) × unit_price, grossed up by
-// wastage_percent. orderQtyBySize maps size_id → order quantity (a size with no order
-// quantity contributes nothing). It returns an INVALID NullDecimal when there is no
-// per-size consumption, no unit_price, or no order quantities at all — so the costing
-// rollup can fall back to the per-garment LineTotal (the user's "if per-size empty → old
-// formula" rule, extended to "no quantities yet → old formula"). NOTE: a per-size line's
-// run total is order-scale, whereas LineTotal is per-garment; a costing that mixes both
-// (some lines per-size, some not) mixes scales — kept per-line by explicit choice.
-func (b *TechCardBomItem) SizeRunTotal(orderQtyBySize map[int]int) decimal.NullDecimal {
-	if len(b.SizeConsumptions) == 0 || !b.UnitPrice.Valid {
-		return decimal.NullDecimal{}
-	}
-	totalQty := decimal.Zero
-	for _, sc := range b.SizeConsumptions {
-		qty, ok := orderQtyBySize[sc.SizeId]
-		if !ok || qty <= 0 {
-			continue
-		}
-		totalQty = totalQty.Add(sc.Consumption.Mul(decimal.NewFromInt(int64(qty))))
-	}
-	if totalQty.IsZero() {
-		return decimal.NullDecimal{}
-	}
-	total := totalQty.Mul(b.UnitPrice.Decimal)
-	if b.WastagePercent.Valid {
-		total = total.Mul(decimal.NewFromInt(1).Add(b.WastagePercent.Decimal.Div(decimal.NewFromInt(100))))
-	}
-	return decimal.NullDecimal{Decimal: total, Valid: true}
-}
-
 // TechCardSizeQuantity is the production order quantity for a size (size run).
 type TechCardSizeQuantity struct {
 	SizeId   int `db:"size_id"`
@@ -358,33 +374,14 @@ type TechCardSizePattern struct {
 	SizeBytes sql.NullInt64  `db:"size_bytes"`
 }
 
-// TechCardPomGrade is the graded value of a POM point for a size.
-type TechCardPomGrade struct {
-	SizeId int             `db:"size_id"`
-	Value  decimal.Decimal `db:"value"`
-}
-
-// TechCardPomActual is an actual measured value, optionally from a fitting and at
-// a specific size (so it can be compared to that size's grade ± tolerance).
-type TechCardPomActual struct {
-	FittingId sql.NullInt32   `db:"fitting_id"`
-	SizeId    sql.NullInt32   `db:"size_id"`
-	Label     sql.NullString  `db:"label"`
-	Value     decimal.Decimal `db:"value"`
-}
-
-// TechCardPomPoint is a point of measure with its grade and actuals (Sheet «Измерения»).
-type TechCardPomPoint struct {
-	Id             int                 `db:"id"`
-	Section        sql.NullString      `db:"section"`
-	Code           sql.NullString      `db:"code"`
-	Name           string              `db:"name"`
-	HowToMeasure   sql.NullString      `db:"how_to_measure"`
-	BaseValue      decimal.NullDecimal `db:"base_value"`
-	TolerancePlus  decimal.NullDecimal `db:"tolerance_plus"`
-	ToleranceMinus decimal.NullDecimal `db:"tolerance_minus"`
-	Grades         []TechCardPomGrade  `db:"-"`
-	Actuals        []TechCardPomActual `db:"-"`
+// TechCardDetail is one aspect of the construction description (Sheet «Титул», lower
+// block) with optional reference images. Replaces the flat construction-description
+// strings (silhouette/collar/fastening/…); Key is freeform.
+type TechCardDetail struct {
+	Id       int            `db:"id"`
+	Key      sql.NullString `db:"detail_key"`  // aspect name (silhouette/collar/…); freeform
+	Text     sql.NullString `db:"detail_text"` // the description for this aspect
+	MediaIds []int          `db:"-"`           // FK media(id); persisted to tech_card_detail_media
 }
 
 // TechCardLabelType classifies a label/tag. Mirrors the common.TechCardLabelType
@@ -429,9 +426,6 @@ type TechCardConstruction struct {
 	Pressing        sql.NullString `db:"pressing"`
 	MachineClass    sql.NullString `db:"machine_class"`
 	Notes           sql.NullString `db:"notes"`
-	// labour rate (Phase 3.5b): per-minute cost; × Σ(operation SAM) = labour cost.
-	LabourRate         decimal.NullDecimal `db:"labour_rate"`
-	LabourRateCurrency sql.NullString      `db:"labour_rate_currency"`
 }
 
 // TechCardOperationType is the machine / stitch class of an operation. Mirrors the
@@ -502,10 +496,15 @@ type TechCardOperation struct {
 	OperationType TechCardOperationType    `db:"operation_type"` // machine/stitch class; "unknown" = unset
 	Zone          TechCardConstructionZone `db:"zone"`           // display-grouping band; "unknown" = unset
 	// BomItemIndex is the 0-based index into the submitted bom_items of the material
-	// this operation applies; NULL = no reference (index 0 is a valid reference).
+	// this operation applies; NULL = no reference (index 0 is a valid reference). When
+	// set it wins; otherwise the material resolves via Placement against the selected
+	// colourway's usages.
 	BomItemIndex sql.NullInt32 `db:"bom_item_index"`
 	// CalloutNumber links the operation to a TechCardCallout.number; NULL/0 = none.
 	CalloutNumber sql.NullInt32 `db:"callout_number"`
+	// Placement is the garment part this operation works on; resolves the real material
+	// via the selected colourway's usages (normalized trim+lower match). NULL = unset.
+	Placement sql.NullString `db:"placement"`
 }
 
 // TechCardIssueSeverity / TechCardIssueStatus classify a maker-flagged issue.
@@ -550,7 +549,6 @@ type TechCardSignoffSection string
 const (
 	SignoffDesign       TechCardSignoffSection = "design"
 	SignoffConstruction TechCardSignoffSection = "construction"
-	SignoffPom          TechCardSignoffSection = "pom"
 	SignoffMaterials    TechCardSignoffSection = "materials"
 	SignoffColour       TechCardSignoffSection = "colour"
 	SignoffLabels       TechCardSignoffSection = "labels"
@@ -559,7 +557,7 @@ const (
 )
 
 var ValidTechCardSignoffSections = map[TechCardSignoffSection]bool{
-	SignoffDesign: true, SignoffConstruction: true, SignoffPom: true, SignoffMaterials: true,
+	SignoffDesign: true, SignoffConstruction: true, SignoffMaterials: true,
 	SignoffColour: true, SignoffLabels: true, SignoffPackaging: true, SignoffCosting: true,
 }
 
@@ -624,55 +622,43 @@ type TechCardCosting struct {
 	Notes            sql.NullString      `db:"notes"`
 }
 
-// TechCardInsert is the writable payload for a tech card (header + construction
-// description + child sections). Child slices are full replacements on update.
+// TechCardInsert is the writable payload for a tech card (header + child sections).
+// Child slices are full replacements on update. The construction description lives in
+// Details; the header carries no cost targets (pricing is on Costing).
 type TechCardInsert struct {
-	StyleNumber       string                  `db:"style_number"`
-	Name              string                  `db:"name"`
-	Brand             sql.NullString          `db:"brand"`
-	Season            sql.NullString          `db:"season"`
-	Collection        sql.NullString          `db:"collection"`
-	CategoryId        sql.NullInt32           `db:"category_id"`
-	TargetGender      sql.NullString          `db:"target_gender"`
-	Stage             TechCardStage           `db:"stage"`
-	Status            sql.NullString          `db:"status"`
-	ApprovalState     TechCardApprovalState   `db:"approval_state"`
-	ApprovedBy        sql.NullString          `db:"approved_by"`
-	ApprovedAt        sql.NullTime            `db:"approved_at"`
-	ReleasedAt        sql.NullTime            `db:"released_at"`
-	Version           sql.NullString          `db:"version"`
-	RevisionDate      sql.NullTime            `db:"revision_date"`
-	BaseModelId       sql.NullInt32           `db:"base_model_id"`
-	BaseSampleSizeId  sql.NullInt32           `db:"base_sample_size_id"`
-	Designer          sql.NullString          `db:"designer"`
-	Constructor       sql.NullString          `db:"constructor"`
-	Technologist      sql.NullString          `db:"technologist"`
-	TargetCost        decimal.NullDecimal     `db:"target_cost"`
-	TargetRetailPrice decimal.NullDecimal     `db:"target_retail_price"`
-	Currency          sql.NullString          `db:"currency"`
-	MeasurementUnit   TechCardMeasurementUnit `db:"measurement_unit"`
-	// construction description
-	Description  sql.NullString `db:"description"`
-	Concept      sql.NullString `db:"concept"`
-	Silhouette   sql.NullString `db:"silhouette"`
-	Collar       sql.NullString `db:"collar"`
-	Fastening    sql.NullString `db:"fastening"`
-	Pockets      sql.NullString `db:"pockets"`
-	SleeveCuff   sql.NullString `db:"sleeve_cuff"`
-	ExtraDetails sql.NullString `db:"extra_details"`
-	Topstitching sql.NullString `db:"topstitching"`
-	AuxMaterials sql.NullString `db:"aux_materials"`
-	Notes        sql.NullString `db:"notes"`
+	StyleNumber      string                  `db:"style_number"`
+	Name             string                  `db:"name"`
+	Brand            sql.NullString          `db:"brand"`
+	Season           sql.NullString          `db:"season"`
+	Collection       sql.NullString          `db:"collection"`
+	CategoryId       sql.NullInt32           `db:"category_id"`
+	TargetGender     sql.NullString          `db:"target_gender"`
+	Stage            TechCardStage           `db:"stage"`
+	Status           sql.NullString          `db:"status"`
+	ApprovalState    TechCardApprovalState   `db:"approval_state"`
+	ApprovedBy       sql.NullString          `db:"approved_by"`
+	ApprovedAt       sql.NullTime            `db:"approved_at"`
+	ReleasedAt       sql.NullTime            `db:"released_at"`
+	Version          sql.NullString          `db:"version"`
+	RevisionDate     sql.NullTime            `db:"revision_date"`
+	BaseModelId      sql.NullInt32           `db:"base_model_id"`
+	BaseSampleSizeId sql.NullInt32           `db:"base_sample_size_id"`
+	Designer         sql.NullString          `db:"designer"`
+	Constructor      sql.NullString          `db:"constructor"`
+	Technologist     sql.NullString          `db:"technologist"`
+	MeasurementUnit  TechCardMeasurementUnit `db:"measurement_unit"`
+	Concept          sql.NullString          `db:"concept"` // design concept / intent (designer)
+	Notes            sql.NullString          `db:"notes"`
 	// child sections (in-memory only; persisted to their own tables)
 	SizeIds    []int               `db:"-"`
 	ProductIds []int               `db:"-"`
 	Media      []TechCardMediaItem `db:"-"`
 	Callouts   []TechCardCallout   `db:"-"`
 	Revisions  []TechCardRevision  `db:"-"`
+	Details    []TechCardDetail    `db:"-"` // construction-description aspects (+ media)
 	// materials (Phase 2)
-	BomItems  []TechCardBomItem  `db:"-"`
-	Colorways []TechCardColorway `db:"-"`
-	PomPoints []TechCardPomPoint `db:"-"`
+	BomItems  []TechCardBomItem  `db:"-"` // article catalog
+	Colorways []TechCardColorway `db:"-"` // colourways carry the usage recipe
 	// production (Phase 3); 1:1 sections are nil when unset
 	Construction   *TechCardConstruction  `db:"-"`
 	Operations     []TechCardOperation    `db:"-"`

--- a/internal/store/sql/0079_tech_card_overhaul.sql
+++ b/internal/store/sql/0079_tech_card_overhaul.sql
@@ -1,0 +1,257 @@
+-- +migrate Up
+-- Tech card overhaul. The model shifts so the BOM becomes a pure material-article catalog
+-- and the colourway becomes the "recipe": tech_card_colorway_usage binds a BOM article to a
+-- garment part (placement), the colour it takes in that colourway, and its consumption
+-- (per-garment and/or per-size). Construction description moves from flat header strings to
+-- tech_card_detail (+ reference media). POM, header cost targets and labour pricing are
+-- removed. Clean break (new feature, ~no production data); the BOM colour matrix is migrated
+-- into usages BEFORE it is dropped, so existing per-colourway colours are preserved.
+--
+-- Auto-named CHECK drops below follow the established idiom (see 0073/0076): MySQL names an
+-- inline column CHECK <table>_chk_<n> in column order at CREATE TABLE time, and a column that
+-- a CHECK references cannot be dropped until the CHECK is dropped.
+
+-- 1. Colourway material recipe.
+CREATE TABLE tech_card_colorway_usage (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  colorway_id INT NOT NULL,
+  bom_item_index INT NULL COMMENT '0-based index into the submitted bom_items; NULL = unset'
+    CHECK (bom_item_index IS NULL OR bom_item_index >= 0),
+  placement VARCHAR(255) NULL COMMENT 'garment part (normalised trim+lower); matched to operation.placement',
+  color VARCHAR(255) NULL COMMENT 'material colour in this colourway',
+  pantone VARCHAR(64) NULL COMMENT 'material Pantone / code in this colourway',
+  consumption DECIMAL(10, 3) NULL COMMENT 'per-garment rate (measured materials)'
+    CHECK (consumption IS NULL OR consumption >= 0),
+  quantity DECIMAL(10, 3) NULL COMMENT 'count (countable trims)'
+    CHECK (quantity IS NULL OR quantity >= 0),
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_colorway_usage_colorway (colorway_id),
+  FOREIGN KEY (colorway_id) REFERENCES tech_card_colorway(id) ON DELETE CASCADE
+) COMMENT 'Per-colourway material recipe: which BOM article on which part, colour, consumption';
+
+-- 2. Per-size consumption of a usage (graded fabric usage).
+CREATE TABLE tech_card_colorway_usage_consumption (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  usage_id INT NOT NULL,
+  size_id INT NOT NULL COMMENT 'FK size(id); one of the tech card size range',
+  consumption DECIMAL(10, 3) NOT NULL COMMENT 'per-garment rate at this size'
+    CHECK (consumption >= 0),
+  display_order INT NOT NULL DEFAULT 0,
+  UNIQUE KEY uniq_tech_card_colorway_usage_consumption (usage_id, size_id),
+  FOREIGN KEY (usage_id) REFERENCES tech_card_colorway_usage(id) ON DELETE CASCADE,
+  FOREIGN KEY (size_id) REFERENCES size(id)
+) COMMENT 'Per-size consumption (норма расхода) of a colourway usage';
+
+-- 3. Construction-description aspects (replaces the flat «Титул» strings).
+CREATE TABLE tech_card_detail (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  detail_key VARCHAR(64) NULL COMMENT 'aspect name (silhouette/collar/…); freeform',
+  detail_text TEXT NULL COMMENT 'the description for this aspect',
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_detail_card (tech_card_id),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+) COMMENT 'Construction-description aspects (Sheet «Титул», lower block)';
+
+-- 4. Reference media for a construction-description aspect.
+CREATE TABLE tech_card_detail_media (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  detail_id INT NOT NULL,
+  media_id INT NOT NULL COMMENT 'FK media(id)',
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_detail_media_detail (detail_id),
+  FOREIGN KEY (detail_id) REFERENCES tech_card_detail(id) ON DELETE CASCADE,
+  FOREIGN KEY (media_id) REFERENCES media(id)
+) COMMENT 'Reference media for a tech_card_detail aspect';
+
+-- 5. Operations attach to a garment part; the real material resolves via the colourway usages.
+ALTER TABLE tech_card_operation
+  ADD COLUMN placement VARCHAR(255) NULL
+    COMMENT 'garment part this operation works on (normalised); resolves material via the colourway usages';
+
+-- 6. Migrate the BOM colour matrix into colourway usages BEFORE dropping it. Each matrix cell
+--    becomes a usage under its colourway, carrying the BOM line's placement/consumption/quantity
+--    and the cell's colour/pantone. bom_item_index is the BOM line's 0-based position within its
+--    card (the same order the read path emits, display_order then id). Safe on empty source.
+INSERT INTO tech_card_colorway_usage
+    (colorway_id, bom_item_index, placement, color, pantone, consumption, quantity, display_order)
+SELECT bc.colorway_id, idx.bom_item_index, bi.placement, bc.color, bc.pantone,
+       bi.consumption, bi.quantity, bc.display_order
+FROM tech_card_bom_colorway bc
+JOIN tech_card_bom_item bi ON bi.id = bc.bom_item_id
+JOIN (
+  SELECT id, ROW_NUMBER() OVER (PARTITION BY tech_card_id ORDER BY display_order, id) - 1 AS bom_item_index
+  FROM tech_card_bom_item
+) idx ON idx.id = bi.id;
+
+-- 7. BOM articles with no colour cell at all → one usage per colourway (no colour), so a fabric
+--    used across all colourways without a per-colourway colour is still represented.
+INSERT INTO tech_card_colorway_usage
+    (colorway_id, bom_item_index, placement, color, pantone, consumption, quantity, display_order)
+SELECT cw.id, idx.bom_item_index, bi.placement, NULL, NULL, bi.consumption, bi.quantity, 0
+FROM tech_card_bom_item bi
+JOIN tech_card_colorway cw ON cw.tech_card_id = bi.tech_card_id
+JOIN (
+  SELECT id, ROW_NUMBER() OVER (PARTITION BY tech_card_id ORDER BY display_order, id) - 1 AS bom_item_index
+  FROM tech_card_bom_item
+) idx ON idx.id = bi.id
+WHERE NOT EXISTS (SELECT 1 FROM tech_card_bom_colorway bc WHERE bc.bom_item_id = bi.id);
+-- NOTE: per-size BOM consumption (tech_card_bom_consumption) is NOT backfilled onto the new
+-- usages, and the flat construction-description strings are NOT migrated into tech_card_detail
+-- (trivial volume, clean cutover; details start empty — plan §5).
+
+-- 8. Drop the obsolete child tables (colour matrix, per-size BOM consumption, POM).
+DROP TABLE IF EXISTS tech_card_bom_consumption;
+DROP TABLE IF EXISTS tech_card_bom_colorway;
+DROP TABLE IF EXISTS tech_card_pom_actual;
+DROP TABLE IF EXISTS tech_card_pom_grade;
+DROP TABLE IF EXISTS tech_card_pom_point;
+
+-- 9. BOM line → catalog article: drop placement/consumption/quantity (moved onto the usage).
+--    consumption = tech_card_bom_item_chk_2, quantity = tech_card_bom_item_chk_3 (column order
+--    in 0068; section was chk_1, renamed in 0076). placement has no CHECK.
+ALTER TABLE tech_card_bom_item
+  DROP CHECK tech_card_bom_item_chk_2,
+  DROP CHECK tech_card_bom_item_chk_3;
+ALTER TABLE tech_card_bom_item
+  DROP COLUMN placement,
+  DROP COLUMN consumption,
+  DROP COLUMN quantity;
+
+-- 10. Construction: drop labour pricing (labour_rate = tech_card_construction_chk_1; the only
+--     CHECK on the table, added in 0072. labour_rate_currency has no CHECK).
+ALTER TABLE tech_card_construction
+  DROP CHECK tech_card_construction_chk_1;
+ALTER TABLE tech_card_construction
+  DROP COLUMN labour_rate,
+  DROP COLUMN labour_rate_currency;
+
+-- 11. Header: drop cost targets and the flat construction-description strings (now in
+--     tech_card_detail). target_cost = tech_card_chk_4, target_retail_price = tech_card_chk_5
+--     (column order in 0067: target_gender chk_1, stage chk_2, approval_state chk_3,
+--     target_cost chk_4, target_retail_price chk_5, measurement_unit chk_6). The remaining
+--     columns (currency + the description strings) have no CHECK.
+ALTER TABLE tech_card
+  DROP CHECK tech_card_chk_4,
+  DROP CHECK tech_card_chk_5;
+ALTER TABLE tech_card
+  DROP COLUMN target_cost,
+  DROP COLUMN target_retail_price,
+  DROP COLUMN currency,
+  DROP COLUMN description,
+  DROP COLUMN silhouette,
+  DROP COLUMN collar,
+  DROP COLUMN fastening,
+  DROP COLUMN pockets,
+  DROP COLUMN sleeve_cuff,
+  DROP COLUMN extra_details,
+  DROP COLUMN topstitching,
+  DROP COLUMN aux_materials;
+
+-- 12. Sign-off: drop the POM section value (POM removed). Remove any POM rows first, then
+--     narrow the section CHECK (tech_card_signoff_chk_1, the first CHECK on the table in 0074).
+DELETE FROM tech_card_signoff WHERE section = 'pom';
+ALTER TABLE tech_card_signoff
+  DROP CHECK tech_card_signoff_chk_1,
+  ADD CONSTRAINT chk_tech_card_signoff_section
+    CHECK (section REGEXP '^(design|construction|materials|colour|labels|packaging|costing)$');
+
+-- +migrate Down
+-- Structural rollback only (the Up is a destructive clean break — dropped POM / matrix /
+-- per-size consumption / construction-description data cannot be restored).
+
+ALTER TABLE tech_card_signoff
+  DROP CHECK chk_tech_card_signoff_section,
+  ADD CONSTRAINT tech_card_signoff_chk_1
+    CHECK (section REGEXP '^(design|construction|pom|materials|colour|labels|packaging|costing)$');
+
+ALTER TABLE tech_card
+  ADD COLUMN target_cost DECIMAL(10, 2) NULL CHECK (target_cost IS NULL OR target_cost >= 0),
+  ADD COLUMN target_retail_price DECIMAL(10, 2) NULL CHECK (target_retail_price IS NULL OR target_retail_price >= 0),
+  ADD COLUMN currency VARCHAR(3) NULL,
+  ADD COLUMN description TEXT NULL,
+  ADD COLUMN silhouette TEXT NULL,
+  ADD COLUMN collar TEXT NULL,
+  ADD COLUMN fastening TEXT NULL,
+  ADD COLUMN pockets TEXT NULL,
+  ADD COLUMN sleeve_cuff TEXT NULL,
+  ADD COLUMN extra_details TEXT NULL,
+  ADD COLUMN topstitching TEXT NULL,
+  ADD COLUMN aux_materials TEXT NULL;
+
+ALTER TABLE tech_card_construction
+  ADD COLUMN labour_rate DECIMAL(10, 4) NULL CHECK (labour_rate IS NULL OR labour_rate >= 0),
+  ADD COLUMN labour_rate_currency VARCHAR(3) NULL;
+
+ALTER TABLE tech_card_bom_item
+  ADD COLUMN placement VARCHAR(255) NULL,
+  ADD COLUMN consumption DECIMAL(10, 3) NULL CHECK (consumption IS NULL OR consumption >= 0),
+  ADD COLUMN quantity DECIMAL(10, 3) NULL CHECK (quantity IS NULL OR quantity >= 0);
+
+CREATE TABLE tech_card_pom_point (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  tech_card_id INT NOT NULL,
+  section VARCHAR(255) NULL,
+  code VARCHAR(32) NULL,
+  name VARCHAR(255) NOT NULL,
+  how_to_measure TEXT NULL,
+  base_value DECIMAL(8, 2) NULL CHECK (base_value IS NULL OR base_value >= 0),
+  tolerance_plus DECIMAL(8, 2) NULL CHECK (tolerance_plus IS NULL OR tolerance_plus >= 0),
+  tolerance_minus DECIMAL(8, 2) NULL CHECK (tolerance_minus IS NULL OR tolerance_minus >= 0),
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_pom_card (tech_card_id),
+  UNIQUE KEY uniq_tech_card_pom_code (tech_card_id, code),
+  FOREIGN KEY (tech_card_id) REFERENCES tech_card(id) ON DELETE CASCADE
+);
+CREATE TABLE tech_card_pom_grade (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  pom_point_id INT NOT NULL,
+  size_id INT NOT NULL,
+  value DECIMAL(8, 2) NOT NULL CHECK (value >= 0),
+  UNIQUE KEY uniq_tech_card_pom_grade (pom_point_id, size_id),
+  INDEX idx_tech_card_pom_grade_size (size_id),
+  FOREIGN KEY (pom_point_id) REFERENCES tech_card_pom_point(id) ON DELETE CASCADE,
+  FOREIGN KEY (size_id) REFERENCES size(id)
+);
+CREATE TABLE tech_card_pom_actual (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  pom_point_id INT NOT NULL,
+  size_id INT NULL,
+  fitting_id INT NULL,
+  label VARCHAR(64) NULL,
+  value DECIMAL(8, 2) NOT NULL CHECK (value >= 0),
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_tech_card_pom_actual_fitting (fitting_id),
+  INDEX idx_tech_card_pom_actual_size (size_id),
+  FOREIGN KEY (pom_point_id) REFERENCES tech_card_pom_point(id) ON DELETE CASCADE,
+  FOREIGN KEY (fitting_id) REFERENCES fitting(id) ON DELETE SET NULL,
+  FOREIGN KEY (size_id) REFERENCES size(id)
+);
+CREATE TABLE tech_card_bom_colorway (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  bom_item_id INT NOT NULL,
+  colorway_id INT NOT NULL,
+  color VARCHAR(255) NULL,
+  pantone VARCHAR(64) NULL,
+  display_order INT NOT NULL DEFAULT 0,
+  UNIQUE KEY uniq_tech_card_bom_colorway (bom_item_id, colorway_id),
+  INDEX idx_tech_card_bom_colorway_colorway (colorway_id),
+  FOREIGN KEY (bom_item_id) REFERENCES tech_card_bom_item(id) ON DELETE CASCADE,
+  FOREIGN KEY (colorway_id) REFERENCES tech_card_colorway(id) ON DELETE CASCADE
+);
+CREATE TABLE tech_card_bom_consumption (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  bom_item_id INT NOT NULL,
+  size_id INT NOT NULL,
+  consumption DECIMAL(10, 3) NOT NULL CHECK (consumption >= 0),
+  display_order INT NOT NULL DEFAULT 0,
+  UNIQUE KEY uniq_tech_card_bom_consumption (bom_item_id, size_id),
+  FOREIGN KEY (bom_item_id) REFERENCES tech_card_bom_item(id) ON DELETE CASCADE,
+  FOREIGN KEY (size_id) REFERENCES size(id)
+);
+
+ALTER TABLE tech_card_operation DROP COLUMN placement;
+DROP TABLE IF EXISTS tech_card_detail_media;
+DROP TABLE IF EXISTS tech_card_detail;
+DROP TABLE IF EXISTS tech_card_colorway_usage_consumption;
+DROP TABLE IF EXISTS tech_card_colorway_usage;

--- a/internal/store/techcard/materials.go
+++ b/internal/store/techcard/materials.go
@@ -2,9 +2,7 @@ package techcard
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
-	"sort"
 
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
@@ -13,13 +11,13 @@ import (
 
 // --- inserts (called within the AddTechCard / UpdateTechCard transaction) ---
 
-// insertTechCardColorways inserts the colourways and returns their new ids in the
-// same order, so BOM colorway_index can be resolved to a colourway id.
-func insertTechCardColorways(ctx context.Context, db dependency.DB, tcID int, cws []entity.TechCardColorway) ([]int, error) {
-	ids := make([]int, len(cws))
+// insertTechCardColorways inserts the colourways and, for each, its material recipe
+// (usages + per-size usage consumption). Colourways are the "recipe"; the BOM is a pure
+// article catalog the usage's bom_item_index points into.
+func insertTechCardColorways(ctx context.Context, db dependency.DB, tcID int, cws []entity.TechCardColorway) error {
 	for i := range cws {
 		c := &cws[i]
-		id, err := storeutil.ExecNamedLastId(ctx, db, `
+		cwID, err := storeutil.ExecNamedLastId(ctx, db, `
 			INSERT INTO tech_card_colorway
 				(tech_card_id, code, name, lab_dip_status, product_id, comment, display_order,
 				 pantone, pantone_system, hex, swatch_media_id, lab_dip_round,
@@ -46,137 +44,118 @@ func insertTechCardColorways(ctx context.Context, db dependency.DB, tcID int, cw
 				"lab_dip_reject_reason": c.LabDipRejectReason,
 			})
 		if err != nil {
-			return nil, fmt.Errorf("failed to insert tech card colorway: %w", err)
+			return fmt.Errorf("failed to insert tech card colorway: %w", err)
 		}
-		ids[i] = id
+		if err := insertTechCardColorwayUsages(ctx, db, cwID, c.Usages); err != nil {
+			return err
+		}
 	}
-	return ids, nil
+	return nil
 }
 
-// insertTechCardBom inserts the BOM lines and, for each, the per-colourway colour
-// cells (resolving ColorwayIndex against colorwayIds).
-func insertTechCardBom(ctx context.Context, db dependency.DB, tcID int, items []entity.TechCardBomItem, colorwayIds []int) error {
-	for i := range items {
-		b := &items[i]
-		bomID, err := storeutil.ExecNamedLastId(ctx, db, `
-			INSERT INTO tech_card_bom_item
-				(tech_card_id, section, name, placement, supplier, supplier_ref, color, composition, spec,
-				 consumption, unit, quantity, unit_price, currency, comment, display_order,
-				 fabric_width, fabric_weight_gsm, fabric_direction, wastage_percent)
-			VALUES (:tech_card_id, :section, :name, :placement, :supplier, :supplier_ref, :color, :composition, :spec,
-				 :consumption, :unit, :quantity, :unit_price, :currency, :comment, :display_order,
-				 :fabric_width, :fabric_weight_gsm, :fabric_direction, :wastage_percent)`,
+// insertTechCardColorwayUsages inserts one colourway's usages and, for each, its per-size
+// consumption rows.
+func insertTechCardColorwayUsages(ctx context.Context, db dependency.DB, cwID int, usages []entity.TechCardColorwayUsage) error {
+	for j := range usages {
+		u := &usages[j]
+		usageID, err := storeutil.ExecNamedLastId(ctx, db, `
+			INSERT INTO tech_card_colorway_usage
+				(colorway_id, bom_item_index, placement, color, pantone, consumption, quantity, display_order)
+			VALUES (:colorway_id, :bom_item_index, :placement, :color, :pantone, :consumption, :quantity, :display_order)`,
 			map[string]any{
-				"tech_card_id":      tcID,
-				"section":           string(b.Section),
-				"name":              b.Name,
-				"placement":         b.Placement,
-				"supplier":          b.Supplier,
-				"supplier_ref":      b.SupplierRef,
-				"color":             b.Color,
-				"composition":       b.Composition,
-				"spec":              b.Spec,
-				"consumption":       b.Consumption,
-				"unit":              b.Unit,
-				"quantity":          b.Quantity,
-				"unit_price":        b.UnitPrice,
-				"currency":          b.Currency,
-				"comment":           b.Comment,
-				"display_order":     i,
-				"fabric_width":      b.FabricWidth,
-				"fabric_weight_gsm": b.FabricWeightGsm,
-				"fabric_direction":  b.FabricDirection,
-				"wastage_percent":   b.WastagePercent,
+				"colorway_id":    cwID,
+				"bom_item_index": u.BomItemIndex,
+				"placement":      u.Placement,
+				"color":          u.Color,
+				"pantone":        u.Pantone,
+				"consumption":    u.Consumption,
+				"quantity":       u.Quantity,
+				"display_order":  j,
 			})
 		if err != nil {
-			return fmt.Errorf("failed to insert tech card bom item: %w", err)
+			return fmt.Errorf("failed to insert tech card colorway usage: %w", err)
 		}
-		if len(b.ColorwayColors) > 0 {
-			rows := make([]map[string]any, 0, len(b.ColorwayColors))
-			for j, cc := range b.ColorwayColors {
-				if cc.ColorwayIndex < 0 || cc.ColorwayIndex >= len(colorwayIds) {
-					return fmt.Errorf("bom colorway_index %d out of range", cc.ColorwayIndex)
-				}
+		if len(u.SizeConsumptions) > 0 {
+			rows := make([]map[string]any, 0, len(u.SizeConsumptions))
+			for k, sc := range u.SizeConsumptions {
 				rows = append(rows, map[string]any{
-					"bom_item_id":   bomID,
-					"colorway_id":   colorwayIds[cc.ColorwayIndex],
-					"color":         cc.Color,
-					"pantone":       cc.Pantone,
-					"display_order": j,
-				})
-			}
-			if err := storeutil.BulkInsert(ctx, db, "tech_card_bom_colorway", rows); err != nil {
-				return fmt.Errorf("failed to insert tech card bom colorway: %w", err)
-			}
-		}
-		if len(b.SizeConsumptions) > 0 {
-			scRows := make([]map[string]any, 0, len(b.SizeConsumptions))
-			for j, sc := range b.SizeConsumptions {
-				scRows = append(scRows, map[string]any{
-					"bom_item_id":   bomID,
+					"usage_id":      usageID,
 					"size_id":       sc.SizeId,
 					"consumption":   sc.Consumption,
-					"display_order": j,
+					"display_order": k,
 				})
 			}
-			if err := storeutil.BulkInsert(ctx, db, "tech_card_bom_consumption", scRows); err != nil {
-				return fmt.Errorf("failed to insert tech card bom consumption: %w", err)
+			if err := storeutil.BulkInsert(ctx, db, "tech_card_colorway_usage_consumption", rows); err != nil {
+				return fmt.Errorf("failed to insert tech card colorway usage consumption: %w", err)
 			}
 		}
 	}
 	return nil
 }
 
-// insertTechCardPom inserts the POM points and, for each, its graded values and
-// actual measurements.
-func insertTechCardPom(ctx context.Context, db dependency.DB, tcID int, points []entity.TechCardPomPoint) error {
-	for i := range points {
-		p := &points[i]
-		pomID, err := storeutil.ExecNamedLastId(ctx, db, `
-			INSERT INTO tech_card_pom_point
-				(tech_card_id, section, code, name, how_to_measure, base_value, tolerance_plus, tolerance_minus, display_order)
-			VALUES (:tech_card_id, :section, :code, :name, :how_to_measure, :base_value, :tolerance_plus, :tolerance_minus, :display_order)`,
+// insertTechCardBom inserts the BOM lines (material-article catalog). Per-colourway colour,
+// placement and consumption now live on the colourway usages, not here.
+func insertTechCardBom(ctx context.Context, db dependency.DB, tcID int, items []entity.TechCardBomItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(items))
+	for i := range items {
+		b := &items[i]
+		rows = append(rows, map[string]any{
+			"tech_card_id":      tcID,
+			"section":           string(b.Section),
+			"name":              b.Name,
+			"supplier":          b.Supplier,
+			"supplier_ref":      b.SupplierRef,
+			"color":             b.Color,
+			"composition":       b.Composition,
+			"spec":              b.Spec,
+			"unit":              b.Unit,
+			"unit_price":        b.UnitPrice,
+			"currency":          b.Currency,
+			"comment":           b.Comment,
+			"display_order":     i,
+			"fabric_width":      b.FabricWidth,
+			"fabric_weight_gsm": b.FabricWeightGsm,
+			"fabric_direction":  b.FabricDirection,
+			"wastage_percent":   b.WastagePercent,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "tech_card_bom_item", rows); err != nil {
+		return fmt.Errorf("failed to insert tech card bom item: %w", err)
+	}
+	return nil
+}
+
+// insertTechCardDetails inserts the construction-description aspects and, for each, its
+// reference media.
+func insertTechCardDetails(ctx context.Context, db dependency.DB, tcID int, details []entity.TechCardDetail) error {
+	for i := range details {
+		d := &details[i]
+		detailID, err := storeutil.ExecNamedLastId(ctx, db, `
+			INSERT INTO tech_card_detail (tech_card_id, detail_key, detail_text, display_order)
+			VALUES (:tech_card_id, :detail_key, :detail_text, :display_order)`,
 			map[string]any{
-				"tech_card_id":    tcID,
-				"section":         p.Section,
-				"code":            p.Code,
-				"name":            p.Name,
-				"how_to_measure":  p.HowToMeasure,
-				"base_value":      p.BaseValue,
-				"tolerance_plus":  p.TolerancePlus,
-				"tolerance_minus": p.ToleranceMinus,
-				"display_order":   i,
+				"tech_card_id":  tcID,
+				"detail_key":    d.Key,
+				"detail_text":   d.Text,
+				"display_order": i,
 			})
 		if err != nil {
-			return fmt.Errorf("failed to insert tech card pom point: %w", err)
+			return fmt.Errorf("failed to insert tech card detail: %w", err)
 		}
-		if len(p.Grades) > 0 {
-			rows := make([]map[string]any, 0, len(p.Grades))
-			for _, g := range p.Grades {
+		if len(d.MediaIds) > 0 {
+			rows := make([]map[string]any, 0, len(d.MediaIds))
+			for j, mid := range d.MediaIds {
 				rows = append(rows, map[string]any{
-					"pom_point_id": pomID,
-					"size_id":      g.SizeId,
-					"value":        g.Value,
-				})
-			}
-			if err := storeutil.BulkInsert(ctx, db, "tech_card_pom_grade", rows); err != nil {
-				return fmt.Errorf("failed to insert tech card pom grades: %w", err)
-			}
-		}
-		if len(p.Actuals) > 0 {
-			rows := make([]map[string]any, 0, len(p.Actuals))
-			for j, a := range p.Actuals {
-				rows = append(rows, map[string]any{
-					"pom_point_id":  pomID,
-					"fitting_id":    a.FittingId,
-					"size_id":       a.SizeId,
-					"label":         a.Label,
-					"value":         a.Value,
+					"detail_id":     detailID,
+					"media_id":      mid,
 					"display_order": j,
 				})
 			}
-			if err := storeutil.BulkInsert(ctx, db, "tech_card_pom_actual", rows); err != nil {
-				return fmt.Errorf("failed to insert tech card pom actuals: %w", err)
+			if err := storeutil.BulkInsert(ctx, db, "tech_card_detail_media", rows); err != nil {
+				return fmt.Errorf("failed to insert tech card detail media: %w", err)
 			}
 		}
 	}
@@ -195,35 +174,28 @@ type techCardBomItemRow struct {
 	entity.TechCardBomItem
 }
 
-type techCardBomColorwayRow struct {
-	BomItemID  int            `db:"bom_item_id"`
-	ColorwayID int            `db:"colorway_id"`
-	Color      sql.NullString `db:"color"`
-	Pantone    sql.NullString `db:"pantone"`
+type techCardColorwayUsageRow struct {
+	ColorwayID int `db:"colorway_id"`
+	entity.TechCardColorwayUsage
 }
 
-type techCardBomConsumptionRow struct {
-	BomItemID int `db:"bom_item_id"`
+type techCardUsageConsumptionRow struct {
+	UsageID int `db:"usage_id"`
 	entity.TechCardBomSizeConsumption
 }
 
-type techCardPomPointRow struct {
+type techCardDetailRow struct {
 	TechCardID int `db:"tech_card_id"`
-	entity.TechCardPomPoint
+	entity.TechCardDetail
 }
 
-type techCardPomGradeRow struct {
-	PomPointID int `db:"pom_point_id"`
-	entity.TechCardPomGrade
+type techCardDetailMediaRow struct {
+	DetailID int `db:"detail_id"`
+	MediaID  int `db:"media_id"`
 }
 
-type techCardPomActualRow struct {
-	PomPointID int `db:"pom_point_id"`
-	entity.TechCardPomActual
-}
-
-// enrichMaterials loads colourways, BOM lines (+ the per-colourway colour matrix)
-// and POM points (+ grades and actuals) for each card and attaches them.
+// enrichMaterials loads colourways (+ their usages and per-size usage consumption), BOM
+// lines (the article catalog) and construction-description details (+ media) for each card.
 func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) error {
 	if len(cards) == 0 {
 		return nil
@@ -233,11 +205,8 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 		ids = append(ids, cards[i].Id)
 	}
 
-	// Colourways: grouped per card (in display order), plus a colourway id -> index
-	// map so the BOM colour matrix can be emitted by index.
-	// product_id resolves through a LEFT JOIN that excludes soft-deleted products
-	// (products are soft-deleted, so the ON DELETE SET NULL never fires) — a dead
-	// SKU surfaces as NULL instead of a dangling id, mirroring productIdsByTechCardIds.
+	// Colourways grouped per card (in display order). product_id resolves through a LEFT
+	// JOIN that excludes soft-deleted products (a dead SKU surfaces as NULL).
 	cwRows, err := storeutil.QueryListNamed[techCardColorwayRow](ctx, s.DB, `
 		SELECT c.id, c.tech_card_id, c.code, c.name, c.lab_dip_status, p.id AS product_id, c.comment,
 		       c.pantone, c.pantone_system, c.hex, c.swatch_media_id, c.lab_dip_round,
@@ -250,20 +219,70 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 		return fmt.Errorf("can't load tech card colorways: %w", err)
 	}
 	colorwaysByCard := make(map[int][]entity.TechCardColorway, len(ids))
-	colorwayIndexByID := make(map[int]int, len(cwRows))
 	for _, r := range cwRows {
-		colorwayIndexByID[r.Id] = len(colorwaysByCard[r.TechCardID])
 		colorwaysByCard[r.TechCardID] = append(colorwaysByCard[r.TechCardID], r.TechCardColorway)
 	}
+	// Index colourways by id to attach usages; collect ids for the usage query.
+	colorwayByID := make(map[int]*entity.TechCardColorway, len(cwRows))
+	colorwayIDs := make([]int, 0, len(cwRows))
+	for card := range colorwaysByCard {
+		cws := colorwaysByCard[card]
+		for i := range cws {
+			colorwayByID[cws[i].Id] = &cws[i]
+			colorwayIDs = append(colorwayIDs, cws[i].Id)
+		}
+	}
+	if len(colorwayIDs) > 0 {
+		usageRows, err := storeutil.QueryListNamed[techCardColorwayUsageRow](ctx, s.DB, `
+			SELECT id, colorway_id, bom_item_index, placement, color, pantone, consumption, quantity
+			FROM tech_card_colorway_usage
+			WHERE colorway_id IN (:ids)
+			ORDER BY colorway_id, display_order`, map[string]any{"ids": colorwayIDs})
+		if err != nil {
+			return fmt.Errorf("can't load tech card colorway usages: %w", err)
+		}
+		usageByID := make(map[int]*entity.TechCardColorwayUsage, len(usageRows))
+		usageIDs := make([]int, 0, len(usageRows))
+		for _, r := range usageRows {
+			cw, ok := colorwayByID[r.ColorwayID]
+			if !ok {
+				continue
+			}
+			cw.Usages = append(cw.Usages, r.TechCardColorwayUsage)
+		}
+		// Slices are final now; index usages by id to attach per-size consumption.
+		for cwID := range colorwayByID {
+			us := colorwayByID[cwID].Usages
+			for i := range us {
+				usageByID[us[i].Id] = &us[i]
+				usageIDs = append(usageIDs, us[i].Id)
+			}
+		}
+		if len(usageIDs) > 0 {
+			consRows, err := storeutil.QueryListNamed[techCardUsageConsumptionRow](ctx, s.DB, `
+				SELECT usage_id, size_id, consumption
+				FROM tech_card_colorway_usage_consumption
+				WHERE usage_id IN (:ids)
+				ORDER BY usage_id, display_order`, map[string]any{"ids": usageIDs})
+			if err != nil {
+				return fmt.Errorf("can't load tech card usage consumptions: %w", err)
+			}
+			for _, c := range consRows {
+				if u, ok := usageByID[c.UsageID]; ok {
+					u.SizeConsumptions = append(u.SizeConsumptions, c.TechCardBomSizeConsumption)
+				}
+			}
+		}
+	}
 
-	// BOM lines per card.
+	// BOM lines per card (the article catalog).
 	bomRows, err := storeutil.QueryListNamed[techCardBomItemRow](ctx, s.DB, `
-		SELECT id, tech_card_id, section, name, placement, supplier, supplier_ref, color, composition, spec,
-		       consumption, unit, quantity, unit_price, currency, comment,
+		SELECT id, tech_card_id, section, name, supplier, supplier_ref, color, composition, spec,
+		       unit, unit_price, currency, comment,
 		       fabric_width, fabric_weight_gsm, fabric_direction, wastage_percent
 		FROM tech_card_bom_item
 		WHERE tech_card_id IN (:ids)
-		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
+		ORDER BY tech_card_id, display_order, id`, map[string]any{"ids": ids})
 	if err != nil {
 		return fmt.Errorf("can't load tech card bom items: %w", err)
 	}
@@ -271,104 +290,41 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 	for _, r := range bomRows {
 		bomByCard[r.TechCardID] = append(bomByCard[r.TechCardID], r.TechCardBomItem)
 	}
-	// Slices are final now; index BOM items by id to attach the colour matrix.
-	bomItemByID := make(map[int]*entity.TechCardBomItem, len(bomRows))
-	bomItemIDs := make([]int, 0, len(bomRows))
-	for card := range bomByCard {
-		items := bomByCard[card]
-		for i := range items {
-			bomItemByID[items[i].Id] = &items[i]
-			bomItemIDs = append(bomItemIDs, items[i].Id)
-		}
-	}
-	if len(bomItemIDs) > 0 {
-		cells, err := storeutil.QueryListNamed[techCardBomColorwayRow](ctx, s.DB, `
-			SELECT bom_item_id, colorway_id, color, pantone
-			FROM tech_card_bom_colorway
-			WHERE bom_item_id IN (:ids)
-			ORDER BY bom_item_id, display_order`, map[string]any{"ids": bomItemIDs})
-		if err != nil {
-			return fmt.Errorf("can't load tech card bom colorways: %w", err)
-		}
-		for _, c := range cells {
-			item, ok := bomItemByID[c.BomItemID]
-			if !ok {
-				continue
-			}
-			idx, ok := colorwayIndexByID[c.ColorwayID]
-			if !ok {
-				continue
-			}
-			item.ColorwayColors = append(item.ColorwayColors, entity.TechCardBomColorwayColor{
-				ColorwayIndex: idx,
-				Color:         c.Color,
-				Pantone:       c.Pantone,
-			})
-		}
 
-		// Per-size consumption matrix, attached to each BOM line by id.
-		consRows, err := storeutil.QueryListNamed[techCardBomConsumptionRow](ctx, s.DB, `
-			SELECT bom_item_id, size_id, consumption
-			FROM tech_card_bom_consumption
-			WHERE bom_item_id IN (:ids)
-			ORDER BY bom_item_id, display_order`, map[string]any{"ids": bomItemIDs})
-		if err != nil {
-			return fmt.Errorf("can't load tech card bom consumptions: %w", err)
-		}
-		for _, c := range consRows {
-			if item, ok := bomItemByID[c.BomItemID]; ok {
-				item.SizeConsumptions = append(item.SizeConsumptions, c.TechCardBomSizeConsumption)
-			}
-		}
-	}
-
-	// POM points per card, then grades and actuals per point.
-	pomRows, err := storeutil.QueryListNamed[techCardPomPointRow](ctx, s.DB, `
-		SELECT id, tech_card_id, section, code, name, how_to_measure, base_value, tolerance_plus, tolerance_minus
-		FROM tech_card_pom_point
+	// Construction-description details per card, then media per detail.
+	detailRows, err := storeutil.QueryListNamed[techCardDetailRow](ctx, s.DB, `
+		SELECT id, tech_card_id, detail_key, detail_text
+		FROM tech_card_detail
 		WHERE tech_card_id IN (:ids)
 		ORDER BY tech_card_id, display_order`, map[string]any{"ids": ids})
 	if err != nil {
-		return fmt.Errorf("can't load tech card pom points: %w", err)
+		return fmt.Errorf("can't load tech card details: %w", err)
 	}
-	pomByCard := make(map[int][]entity.TechCardPomPoint, len(ids))
-	for _, r := range pomRows {
-		pomByCard[r.TechCardID] = append(pomByCard[r.TechCardID], r.TechCardPomPoint)
+	detailsByCard := make(map[int][]entity.TechCardDetail, len(ids))
+	for _, r := range detailRows {
+		detailsByCard[r.TechCardID] = append(detailsByCard[r.TechCardID], r.TechCardDetail)
 	}
-	pomPointByID := make(map[int]*entity.TechCardPomPoint, len(pomRows))
-	pomPointIDs := make([]int, 0, len(pomRows))
-	for card := range pomByCard {
-		points := pomByCard[card]
-		for i := range points {
-			pomPointByID[points[i].Id] = &points[i]
-			pomPointIDs = append(pomPointIDs, points[i].Id)
+	detailByID := make(map[int]*entity.TechCardDetail, len(detailRows))
+	detailIDs := make([]int, 0, len(detailRows))
+	for card := range detailsByCard {
+		ds := detailsByCard[card]
+		for i := range ds {
+			detailByID[ds[i].Id] = &ds[i]
+			detailIDs = append(detailIDs, ds[i].Id)
 		}
 	}
-	if len(pomPointIDs) > 0 {
-		gradeRows, err := storeutil.QueryListNamed[techCardPomGradeRow](ctx, s.DB, `
-			SELECT pom_point_id, size_id, value
-			FROM tech_card_pom_grade
-			WHERE pom_point_id IN (:ids)
-			ORDER BY pom_point_id, id`, map[string]any{"ids": pomPointIDs})
+	if len(detailIDs) > 0 {
+		dmRows, err := storeutil.QueryListNamed[techCardDetailMediaRow](ctx, s.DB, `
+			SELECT detail_id, media_id
+			FROM tech_card_detail_media
+			WHERE detail_id IN (:ids)
+			ORDER BY detail_id, display_order`, map[string]any{"ids": detailIDs})
 		if err != nil {
-			return fmt.Errorf("can't load tech card pom grades: %w", err)
+			return fmt.Errorf("can't load tech card detail media: %w", err)
 		}
-		for _, g := range gradeRows {
-			if p, ok := pomPointByID[g.PomPointID]; ok {
-				p.Grades = append(p.Grades, g.TechCardPomGrade)
-			}
-		}
-		actualRows, err := storeutil.QueryListNamed[techCardPomActualRow](ctx, s.DB, `
-			SELECT pom_point_id, fitting_id, size_id, label, value
-			FROM tech_card_pom_actual
-			WHERE pom_point_id IN (:ids)
-			ORDER BY pom_point_id, display_order`, map[string]any{"ids": pomPointIDs})
-		if err != nil {
-			return fmt.Errorf("can't load tech card pom actuals: %w", err)
-		}
-		for _, a := range actualRows {
-			if p, ok := pomPointByID[a.PomPointID]; ok {
-				p.Actuals = append(p.Actuals, a.TechCardPomActual)
+		for _, m := range dmRows {
+			if d, ok := detailByID[m.DetailID]; ok {
+				d.MediaIds = append(d.MediaIds, m.MediaID)
 			}
 		}
 	}
@@ -377,33 +333,7 @@ func (s *Store) enrichMaterials(ctx context.Context, cards []entity.TechCard) er
 		id := cards[i].Id
 		cards[i].Colorways = colorwaysByCard[id]
 		cards[i].BomItems = bomByCard[id]
-		points := pomByCard[id]
-		sortPomGradesBySizeOrder(points, cards[i].SizeIds)
-		cards[i].PomPoints = points
+		cards[i].Details = detailsByCard[id]
 	}
 	return nil
-}
-
-// sortPomGradesBySizeOrder orders each point's grades by the card's declared size
-// range (tech_card_size order), so the graded chart renders its size columns in a
-// stable, meaningful order instead of insertion order. cards[i].SizeIds is already
-// populated by enrich before enrichMaterials runs.
-func sortPomGradesBySizeOrder(points []entity.TechCardPomPoint, sizeIds []int) {
-	if len(sizeIds) == 0 {
-		return
-	}
-	rank := make(map[int]int, len(sizeIds))
-	for i, sid := range sizeIds {
-		rank[sid] = i
-	}
-	order := func(sid int) int {
-		if r, ok := rank[sid]; ok {
-			return r
-		}
-		return len(sizeIds) // sizes outside the range (shouldn't happen) sort last
-	}
-	for i := range points {
-		g := points[i].Grades
-		sort.SliceStable(g, func(a, b int) bool { return order(g[a].SizeId) < order(g[b].SizeId) })
-	}
 }

--- a/internal/store/techcard/production.go
+++ b/internal/store/techcard/production.go
@@ -18,21 +18,19 @@ func insertTechCardConstruction(ctx context.Context, db dependency.DB, tcID int,
 	if err := storeutil.ExecNamed(ctx, db, `
 		INSERT INTO tech_card_construction
 			(tech_card_id, main_stitch_type, stitch_density, overlock_threads, seam_allowances,
-			 hem_finish, pressing, machine_class, notes, labour_rate, labour_rate_currency)
+			 hem_finish, pressing, machine_class, notes)
 		VALUES (:tech_card_id, :main_stitch_type, :stitch_density, :overlock_threads, :seam_allowances,
-			 :hem_finish, :pressing, :machine_class, :notes, :labour_rate, :labour_rate_currency)`,
+			 :hem_finish, :pressing, :machine_class, :notes)`,
 		map[string]any{
-			"tech_card_id":         tcID,
-			"main_stitch_type":     c.MainStitchType,
-			"stitch_density":       c.StitchDensity,
-			"overlock_threads":     c.OverlockThreads,
-			"seam_allowances":      c.SeamAllowances,
-			"hem_finish":           c.HemFinish,
-			"pressing":             c.Pressing,
-			"machine_class":        c.MachineClass,
-			"notes":                c.Notes,
-			"labour_rate":          c.LabourRate,
-			"labour_rate_currency": c.LabourRateCurrency,
+			"tech_card_id":     tcID,
+			"main_stitch_type": c.MainStitchType,
+			"stitch_density":   c.StitchDensity,
+			"overlock_threads": c.OverlockThreads,
+			"seam_allowances":  c.SeamAllowances,
+			"hem_finish":       c.HemFinish,
+			"pressing":         c.Pressing,
+			"machine_class":    c.MachineClass,
+			"notes":            c.Notes,
 		}); err != nil {
 		return fmt.Errorf("failed to insert tech card construction: %w", err)
 	}
@@ -64,6 +62,7 @@ func insertTechCardOperations(ctx context.Context, db dependency.DB, tcID int, o
 			"zone":             string(o.Zone),
 			"bom_item_index":   o.BomItemIndex,
 			"callout_number":   o.CalloutNumber,
+			"placement":        o.Placement,
 			"display_order":    i,
 		})
 	}
@@ -264,7 +263,7 @@ func (s *Store) enrichProduction(ctx context.Context, cards []entity.TechCard) e
 	opRows, err := storeutil.QueryListNamed[techCardOperationRow](ctx, s.DB, `
 		SELECT tech_card_id, operation_number, node, description, seam_type, machine, stitches_per_cm,
 		       topstitch_width, seam_allowance, thread, needle, attachment, time_norm, note,
-		       operation_type, zone, bom_item_index, callout_number
+		       operation_type, zone, bom_item_index, callout_number, placement
 		FROM tech_card_operation
 		WHERE tech_card_id IN (:ids)
 		ORDER BY tech_card_id, operation_number IS NULL, operation_number, display_order`, map[string]any{"ids": ids})

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -33,20 +33,18 @@ func New(base storeutil.Base, txFunc TxFunc) *Store {
 	return &Store{Base: base, txFunc: txFunc}
 }
 
-// header columns shared by INSERT (AddTechCard) and UPDATE (UpdateTechCard).
+// header columns shared by INSERT (AddTechCard) and UPDATE (UpdateTechCard). Cost
+// targets and the flat construction-description strings are gone (description → details[];
+// pricing is on costing).
 const techCardHeaderColumns = `style_number, name, brand, season, collection, category_id,
 	target_gender, stage, status, approval_state, approved_by, approved_at, released_at, version, revision_date,
 	base_model_id, base_sample_size_id, designer, constructor, technologist,
-	target_cost, target_retail_price, currency, measurement_unit,
-	description, concept, silhouette, fastening, pockets, sleeve_cuff, extra_details, collar,
-	topstitching, aux_materials, notes`
+	measurement_unit, concept, notes`
 
 const techCardHeaderValues = `:style_number, :name, :brand, :season, :collection, :category_id,
 	:target_gender, :stage, :status, :approval_state, :approved_by, :approved_at, :released_at, :version, :revision_date,
 	:base_model_id, :base_sample_size_id, :designer, :constructor, :technologist,
-	:target_cost, :target_retail_price, :currency, :measurement_unit,
-	:description, :concept, :silhouette, :fastening, :pockets, :sleeve_cuff, :extra_details, :collar,
-	:topstitching, :aux_materials, :notes`
+	:measurement_unit, :concept, :notes`
 
 func techCardHeaderParams(tc *entity.TechCardInsert) map[string]any {
 	return map[string]any{
@@ -70,21 +68,9 @@ func techCardHeaderParams(tc *entity.TechCardInsert) map[string]any {
 		"designer":            tc.Designer,
 		"constructor":         tc.Constructor,
 		"technologist":        tc.Technologist,
-		"target_cost":         tc.TargetCost,
-		"target_retail_price": tc.TargetRetailPrice,
-		"currency":            tc.Currency,
 		"measurement_unit":    string(tc.MeasurementUnit),
-		"description":         tc.Description,
-		"silhouette":          tc.Silhouette,
-		"collar":              tc.Collar,
-		"fastening":           tc.Fastening,
-		"pockets":             tc.Pockets,
-		"sleeve_cuff":         tc.SleeveCuff,
-		"extra_details":       tc.ExtraDetails,
-		"topstitching":        tc.Topstitching,
-		"aux_materials":       tc.AuxMaterials,
-		"notes":               tc.Notes,
 		"concept":             tc.Concept,
+		"notes":               tc.Notes,
 	}
 }
 
@@ -156,14 +142,17 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 			}
 			return fmt.Errorf("failed to load tech card for update: %w", err)
 		}
-		if cur.LockVersion != expectedLockVersion {
-			return entity.ErrTechCardConflict
-		}
-		// A released card is frozen for the factory: only a re-open to draft is
-		// allowed; any other edit while still released is rejected.
+		// Freeze check BEFORE the version check (plan §4): a released card is frozen for
+		// the factory — only a re-open to draft is allowed; any other edit while still
+		// released is rejected. Checking this first means a stale-version edit of a
+		// released card gets the actionable "re-open to draft" (FailedPrecondition) rather
+		// than a misleading "modified concurrently" (Aborted).
 		if cur.ApprovalState == string(entity.TechCardApprovalReleased) &&
 			tc.ApprovalState != entity.TechCardApprovalDraft {
 			return entity.ErrTechCardReleased
+		}
+		if cur.LockVersion != expectedLockVersion {
+			return entity.ErrTechCardConflict
 		}
 		// Server owns the lifecycle stamps (set on enter, cleared on re-open).
 		s.stampApprovalTimes(tc, entity.TechCardApprovalState(cur.ApprovalState), cur.ApprovedAt, cur.ReleasedAt)
@@ -181,11 +170,7 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 				version = :version, revision_date = :revision_date,
 				base_model_id = :base_model_id, base_sample_size_id = :base_sample_size_id,
 				designer = :designer, constructor = :constructor, technologist = :technologist,
-				target_cost = :target_cost, target_retail_price = :target_retail_price, currency = :currency,
-				measurement_unit = :measurement_unit,
-				description = :description, concept = :concept, silhouette = :silhouette, collar = :collar,
-				fastening = :fastening, pockets = :pockets, sleeve_cuff = :sleeve_cuff, extra_details = :extra_details,
-				topstitching = :topstitching, aux_materials = :aux_materials, notes = :notes
+				measurement_unit = :measurement_unit, concept = :concept, notes = :notes
 			WHERE id = :id AND lock_version = :expected_lock_version`, params)
 		if err != nil {
 			return fmt.Errorf("failed to update tech card: %w", err)
@@ -196,13 +181,13 @@ func (s *Store) UpdateTechCard(ctx context.Context, id int, tc *entity.TechCardI
 			return entity.ErrTechCardConflict
 		}
 
-		// Delete tech_card_bom_item before tech_card_colorway so the bom-colourway
-		// matrix cascades out via the BOM line; pom grades/actuals and bom-colourway
-		// cells cascade from their parents.
+		// Full-replace: clear all child rows by tech_card_id. Grandchildren cascade
+		// from their parents — colourway usages (+ their per-size consumption) via
+		// tech_card_colorway, and detail media via tech_card_detail.
 		for _, table := range []string{
 			"tech_card_size", "tech_card_product", "tech_card_media",
-			"tech_card_callout", "tech_card_revision",
-			"tech_card_bom_item", "tech_card_colorway", "tech_card_pom_point",
+			"tech_card_callout", "tech_card_revision", "tech_card_detail",
+			"tech_card_bom_item", "tech_card_colorway",
 			"tech_card_construction", "tech_card_operation", "tech_card_label",
 			"tech_card_packaging", "tech_card_costing", "tech_card_issue", "tech_card_signoff",
 			"tech_card_size_pattern",
@@ -317,16 +302,16 @@ func insertTechCardChildren(ctx context.Context, db dependency.DB, id int, tc *e
 	if err := insertTechCardRevisions(ctx, db, id, tc.Revisions); err != nil {
 		return err
 	}
-	// Materials (Phase 2): colourways first so the BOM colour matrix can resolve
-	// each colorway_index to a freshly-inserted colourway id.
-	colorwayIds, err := insertTechCardColorways(ctx, db, id, tc.Colorways)
-	if err != nil {
+	if err := insertTechCardDetails(ctx, db, id, tc.Details); err != nil {
 		return err
 	}
-	if err := insertTechCardBom(ctx, db, id, tc.BomItems, colorwayIds); err != nil {
+	// Materials (Phase 2): colourways (each with its usage recipe) and the BOM article
+	// catalog. A usage's bom_item_index points into the BOM by position, so order is
+	// not load-bearing between the two inserts.
+	if err := insertTechCardColorways(ctx, db, id, tc.Colorways); err != nil {
 		return err
 	}
-	if err := insertTechCardPom(ctx, db, id, tc.PomPoints); err != nil {
+	if err := insertTechCardBom(ctx, db, id, tc.BomItems); err != nil {
 		return err
 	}
 	// production (Phase 3)

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -32,8 +32,8 @@ enum TechCardApprovalState {
   TECH_CARD_APPROVAL_STATE_OBSOLETE = 5;
 }
 
-// TechCardMeasurementUnit is the unit for the card's geometry (callout dimensions
-// and the POM chart). Metric only — the brand works in cm and mm, never inches.
+// TechCardMeasurementUnit is the unit for the card's geometry (callout dimensions).
+// Metric only — the brand works in cm and mm, never inches.
 enum TechCardMeasurementUnit {
   TECH_CARD_MEASUREMENT_UNIT_UNKNOWN = 0; // defaults to MM on write (the brand works in mm)
   TECH_CARD_MEASUREMENT_UNIT_CM = 1; // back-compat; clients should stop sending CM
@@ -100,6 +100,8 @@ enum TechCardBomSection {
   TECH_CARD_BOM_SECTION_LABEL = 7; // этикетки и маркировка
   TECH_CARD_BOM_SECTION_PACKAGING = 8; // упаковка
   TECH_CARD_BOM_SECTION_TRIM = 9; // soft trims: бейка / тесьма / резинка / кант / шнур / лента (not hardware fittings)
+  TECH_CARD_BOM_SECTION_DECORATION = 10; // принт / вышивка / аппликация / патч / стразы
+  TECH_CARD_BOM_SECTION_OTHER = 11; // прочее (catch-all)
 }
 
 // TechCardLabDipStatus is the lab-dip approval lifecycle of a colourway.
@@ -129,69 +131,64 @@ message TechCardColorway {
   google.protobuf.Timestamp lab_dip_decided_at = 12;
   string lab_dip_decided_by = 13;
   string lab_dip_reject_reason = 14;
-  // OUTPUT-ONLY (read paths only): the BOM materials used in this colourway, with the
-  // colour each takes here. Built by inverting the BOM colour matrix
-  // (tech_card_bom_colorway) so the frontend can show «which fabrics in which colourway»
-  // without re-joining. Ignored on write — the source of truth is bom_items[].colorway_colors.
-  repeated TechCardColorwayMaterial materials = 15;
+  // the colour's material recipe: which catalog article (bom_item_index) goes on which
+  // garment part, in what colour, at what consumption. Per-colourway divergence lives here.
+  repeated TechCardColorwayUsage usages = 16;
+  reserved 15; // was `materials` (OUTPUT-ONLY); usages + bom_items resolve it now
 }
 
-// TechCardColorwayMaterial is one entry of a colourway's resolved material list: a BOM
-// material used in the colourway and the colour it takes there. OUTPUT-ONLY (derived).
-message TechCardColorwayMaterial {
-  int32 bom_item_index = 1; // 0-based index into TechCardInsert.bom_items
-  string material_name = 2; // BOM line name
-  TechCardBomSection section = 3; // material family
-  string color = 4; // colour of this material in this colourway
-  string pantone = 5; // Pantone / code for this colourway
+// TechCardColorwayUsage is one material use inside a colourway: which catalog article
+// (bom_item_index) goes on which garment part (placement), the colour it takes HERE, and
+// how much is consumed (per-garment and/or per-size). The BOM is a pure article catalog;
+// per-colourway divergence lives here.
+message TechCardColorwayUsage {
+  // explicit presence: index 0 is a real BOM line, distinct from "unset"
+  // (mirrors TechCardOperation.bom_item_index).
+  optional int32 bom_item_index = 1; // FK → TechCardInsert.bom_items
+  string placement = 2; // garment part: outer / inner collar / lining / sleeve …
+  // matched (trim+lower) against TechCardOperation.placement
+  string color = 3; // material colour in THIS colourway — material-specific,
+  // independent of TechCardColorway.pantone (the swatch colour)
+  string pantone = 4; // material Pantone / code in this colourway
+  google.type.Decimal consumption = 5; // per-garment rate (measured materials); fallback when size_consumptions empty
+  google.type.Decimal quantity = 6; // count (countable trims)
+  repeated TechCardBomSizeConsumption size_consumptions = 7; // per-size rate; size_id ∈ TechCardInsert.size_ids
+  google.type.Decimal line_total = 8; // OUTPUT-ONLY (per-garment)
+  google.type.Decimal size_run_total = 9; // OUTPUT-ONLY (whole run)
 }
 
-// TechCardBomColorwayColor is one «Колористика» matrix cell: the colour of a BOM
-// material in a colourway. colorway_index points into TechCardInsert.colorways — a
-// full-replace upsert has no stable colourway ids to reference on write.
-message TechCardBomColorwayColor {
-  int32 colorway_index = 1; // 0-based index into TechCardInsert.colorways
-  string color = 2; // colour name / code
-  string pantone = 3; // Pantone / code
+// TechCardDetail is one aspect of the construction description (Sheet «Титул», lower block)
+// with optional reference images. key is freeform (silhouette/collar/fastening/pockets/
+// sleeve_cuff/topstitching/extra_details … or a custom aspect).
+message TechCardDetail {
+  string key = 1;
+  string text = 2;
+  repeated int32 media_ids = 3; // FK media(id)
 }
 
-// TechCardBomItem is one bill-of-materials line (Sheet «Спецификация»).
+// TechCardBomItem is one bill-of-materials line — a catalog article (Sheet «Спецификация»).
+// The per-colourway colour, placement and consumption live on TechCardColorwayUsage; the
+// BOM line is now a pure material-article catalog entry.
 message TechCardBomItem {
   TechCardBomSection section = 1; // required
   string name = 2; // required
-  string placement = 3; // размещение / назначение
   string supplier = 4;
   string supplier_ref = 5; // артикул поставщика
-  string color = 6; // base/default colour
-  string composition = 7; // состав
+  string color = 6; // base/default reference colour (the per-colourway colour is on the usage)
+  string composition = 7; // состав (the frontend may store structured-JSON here, like product style)
   string spec = 8; // ширина / плотность
-  // consumption vs quantity: fill ONE per line. consumption = per-garment rate of
-  // a measured material (fabric/lining/interlining/insulation/thread) in `unit`
-  // (м/см/г); quantity = discrete count of a countable trim (hardware/label/
-  // packaging), `unit` then = pcs. line_total uses quantity when set, else consumption.
-  google.type.Decimal consumption = 9; // норма расхода (measured materials)
-  string unit = 10; // ед. (м/см/г for consumption; pcs for quantity)
-  google.type.Decimal quantity = 11; // кол-во (countable trims)
+  string unit = 10; // ед. (м/см/г for measured materials; pcs for countable trims)
   google.type.Decimal unit_price = 12; // цена/ед.
   string currency = 13; // ISO 4217 for unit_price
   string comment = 14;
-  repeated TechCardBomColorwayColor colorway_colors = 15; // per-colourway colours
-  google.type.Decimal line_total = 16; // OUTPUT-ONLY: gross of wastage_percent; quantity*unit_price else consumption*unit_price
   // fabric data for the cutter / marker (Phase 3.5c)
   google.type.Decimal fabric_width = 17; // usable width, cm
   google.type.Decimal fabric_weight_gsm = 18; // weight, g/m²
   TechCardFabricDirection fabric_direction = 19; // nap / layout
-  google.type.Decimal wastage_percent = 20; // cutting wastage %, folded into line_total
-  // per-size consumption (Sheet «Спецификация» grading): the measured material rate for
-  // each size, since different sizes consume different amounts of fabric. When set, the
-  // size-run cost folds per-size consumption against the per-size order quantities
-  // (TechCardInsert.size_quantities); `consumption` above is the fallback single rate used
-  // only when this is empty. Each size_id must be one of TechCardInsert.size_ids.
-  repeated TechCardBomSizeConsumption size_consumptions = 21;
-  // OUTPUT-ONLY: total material cost over the whole size run when size_consumptions is set —
-  // Σ(consumption_size × order_qty_size) × unit_price, gross of wastage_percent. Empty when
-  // no per-size consumption is given (line_total then carries the cost).
-  google.type.Decimal size_run_total = 22;
+  google.type.Decimal wastage_percent = 20; // cutting wastage %, folded into the usage line totals
+  // → TechCardColorwayUsage: placement, consumption, quantity, colorway_colors, line_total,
+  //   size_consumptions, size_run_total all moved onto the per-colourway usage.
+  reserved 3, 9, 11, 15, 16, 21, 22;
 }
 
 // TechCardBomSizeConsumption is the per-size consumption (норма расхода) of one BOM
@@ -226,47 +223,6 @@ message TechCardSizePattern {
   int64 size_bytes = 4; // file size in bytes (0 = unknown)
 }
 
-// TechCardPomGrade is the graded value of a POM point for one size.
-message TechCardPomGrade {
-  int32 size_id = 1; // FK size(id); must be one of TechCardInsert.size_ids
-  google.type.Decimal value = 2;
-}
-
-// TechCardPomVerdict is the computed in/out-of-tolerance result of an actual.
-enum TechCardPomVerdict {
-  TECH_CARD_POM_VERDICT_UNKNOWN = 0; // no target (no grade for the size and no base value)
-  TECH_CARD_POM_VERDICT_IN_TOLERANCE = 1;
-  TECH_CARD_POM_VERDICT_OVER = 2; // above target + tolerance_plus
-  TECH_CARD_POM_VERDICT_UNDER = 3; // below target - tolerance_minus
-}
-
-// TechCardPomActual is an actual measured value, optionally taken in a fitting and
-// at a specific size (so QC can compare it to that size's grade ± tolerance).
-message TechCardPomActual {
-  int32 fitting_id = 1; // FK fitting(id); 0 = none
-  string label = 2; // free label when no fitting linked (e.g. примерка 1)
-  google.type.Decimal value = 3;
-  int32 size_id = 4; // FK size(id); 0 = unset. Must be one of size_ids when set.
-  // OUTPUT-ONLY: deviation = value - target (grade at size_id, else base_value);
-  // verdict compares the deviation against tolerance_plus / tolerance_minus.
-  google.type.Decimal deviation = 5;
-  TechCardPomVerdict verdict = 6;
-}
-
-// TechCardPomPoint is a point of measure with its grade and actuals (Sheet «Измерения»).
-// Values are in TechCardInsert.measurement_unit.
-message TechCardPomPoint {
-  string section = 1; // group label, e.g. ВЕРХ / КОРПУС
-  string code = 2; // код
-  string name = 3; // required
-  string how_to_measure = 4; // HTM
-  google.type.Decimal base_value = 5; // базовый образец
-  google.type.Decimal tolerance_plus = 6; // допуск + (Допуск +); mirrored to minus if minus unset
-  google.type.Decimal tolerance_minus = 9; // допуск - (Допуск -); mirrored to plus if plus unset
-  repeated TechCardPomGrade grades = 7;
-  repeated TechCardPomActual actuals = 8;
-}
-
 // TechCardLabelType classifies a label / tag (Sheet «Этикетки и упаковка»).
 enum TechCardLabelType {
   TECH_CARD_LABEL_TYPE_UNKNOWN = 0;
@@ -290,8 +246,7 @@ message TechCardConstruction {
   string pressing = 6; // ВТО / финишная отделка
   string machine_class = 7; // класс / группа машин
   string notes = 8;
-  google.type.Decimal labour_rate = 9; // cost per minute; × Σ(operation SAM) = labour cost
-  string labour_rate_currency = 10; // ISO 4217 for labour_rate
+  reserved 9, 10; // labour pricing removed (was labour_rate, labour_rate_currency)
 }
 
 // TechCardOperationType classifies an operation by its machine / stitch class
@@ -340,13 +295,15 @@ message TechCardOperation {
   string attachment = 13; // folder / binder / guide / hemmer / presser-foot (приспособление)
   TechCardOperationType operation_type = 14; // machine / stitch class; UNKNOWN = unset
   // 0-based index into TechCardInsert.bom_items of the material this operation
-  // applies (thread / binding (бейка) / interlining / zipper). Uses proto3 explicit
-  // presence so index 0 (the first BOM line) is distinguishable from "no material":
-  // unset = no reference. Mirrors TechCardBomColorwayColor.colorway_index, which —
-  // being always present — needs no presence flag.
+  // applies (thread / binding (бейка) / interlining / zipper) when it is NOT resolved
+  // through a part. Uses proto3 explicit presence so index 0 (the first BOM line) is
+  // distinguishable from "no material": unset = no reference. When set, it wins; the
+  // colour resolves via the selected colourway's usage with the same bom_item_index.
   optional int32 bom_item_index = 15;
   int32 callout_number = 16; // links to a TechCardCallout.number (assembly point on the sketch); 0 = none
   TechCardConstructionZone zone = 17; // display-grouping band; UNKNOWN = unset
+  string placement = 18; // garment part this operation works on; resolves the real material
+  // via the selected colourway's usages (match trim+lower; bom_item_index wins if set)
 }
 
 // TechCardIssueSeverity ranks a flagged construction issue.
@@ -403,8 +360,18 @@ message TechCardPackaging {
 
 // TechCardCostLine is one currency bucket of the materials rollup.
 message TechCardCostLine {
-  string currency = 1; // empty = BOM lines without a currency
+  string currency = 1; // empty = usage lines without a currency
   google.type.Decimal amount = 2;
+}
+
+// TechCardColorwayCost is the computed material cost of ONE colourway (Sheet «Калькуляция»).
+// OUTPUT-ONLY (ignored on write). Per-currency buckets; no FX conversion.
+message TechCardColorwayCost {
+  int32 colorway_index = 1; // 0-based index into TechCardInsert.colorways
+  repeated TechCardCostLine materials_total = 2; // Σ usage cost grouped by article currency
+  google.type.Decimal materials_cost = 3; // Σ in costing.currency (and currency-less)
+  google.type.Decimal size_run_total = 4; // whole-run material spend for this colourway
+  bool has_unconverted_currencies = 5; // a usage currency ≠ costing.currency → excluded from materials_cost
 }
 
 // TechCardCosting holds the manually-entered cost articles (Sheet «Калькуляция»).
@@ -417,23 +384,26 @@ message TechCardCosting {
   google.type.Decimal logistics_cost = 4; // логистика / доставка
   google.type.Decimal overhead_cost = 5; // накладные расходы
   google.type.Decimal defect_percent = 6; // брак / запас (%), 0..100
+  // Pricing is single (brand policy): markup_multiplier, wholesale_price, retail_price
+  // and currency are the SAME across colourways. Per-SKU pricing, if ever needed, lives
+  // on the published product, not here.
   google.type.Decimal markup_multiplier = 7; // наценка (×)
   google.type.Decimal wholesale_price = 8; // оптовая цена
   google.type.Decimal retail_price = 9; // розничная цена
   string currency = 10; // ISO 4217 for the articles above
   string notes = 11;
 
-  // OUTPUT-ONLY computed rollup (ignored on write; no currency conversion).
-  // OUTPUT-ONLY. A BOM line with per-size consumption (size_consumptions) contributes its
-  // whole-run size_run_total (order-scale); a line without contributes its per-garment
-  // line_total. A card that mixes both mixes scales — so when size_consumptions is used,
-  // read materials_total/materials_cost as the size-run material spend, not per-garment.
-  repeated TechCardCostLine materials_total = 12; // Σ BOM line cost grouped by BOM currency
-  google.type.Decimal materials_cost = 13; // Σ BOM line cost in `currency` (and currency-less lines)
-  google.type.Decimal total_cost = 14; // (materials_cost + make + hardware+packaging+logistics+overhead) × (1 + defect/100); make = cmt_cost, or computed labour_cost when cmt_cost is unset and same currency
-  bool has_unconverted_currencies = 15; // OUTPUT-ONLY: a BOM line (or computed labour) is in a currency other than `currency`, so it is excluded from total_cost
-  google.type.Decimal total_sam = 16; // OUTPUT-ONLY: Σ of operation time_norm (minutes)
-  google.type.Decimal labour_cost = 17; // OUTPUT-ONLY: total_sam × construction.labour_rate (in labour_rate_currency); folded into total_cost as the make cost when cmt_cost is unset and currencies match
+  // OUTPUT-ONLY computed rollup (ignored on write; no currency conversion). The root
+  // rollup is the PRIMARY colourway (colorways index 0); per-colourway figures are in
+  // colorway_costs. A usage with per-size consumption contributes its whole-run
+  // size_run_total (order-scale); a usage without contributes its per-garment line_total.
+  repeated TechCardCostLine materials_total = 12; // Σ usage cost (colourway 0) grouped by article currency
+  google.type.Decimal materials_cost = 13; // Σ usage cost (colourway 0) in `currency` (and currency-less)
+  google.type.Decimal total_cost = 14; // (materials_cost + cmt_cost + hardware + packaging + logistics + overhead) × (1 + defect/100). No labour fallback.
+  bool has_unconverted_currencies = 15; // OUTPUT-ONLY: a usage line (colourway 0) is in a currency other than `currency`, so it is excluded from total_cost
+  google.type.Decimal total_sam = 16; // OUTPUT-ONLY: Σ of operation time_norm (minutes), informative
+  repeated TechCardColorwayCost colorway_costs = 18; // OUTPUT-ONLY, per colourway
+  reserved 17; // was labour_cost (OUTPUT); labour pricing removed
 }
 
 // TechCardInsert is the writable payload for a tech card. Nested lists are full
@@ -443,7 +413,7 @@ enum TechCardSignoffSection {
   TECH_CARD_SIGNOFF_SECTION_UNKNOWN = 0;
   TECH_CARD_SIGNOFF_SECTION_DESIGN = 1;
   TECH_CARD_SIGNOFF_SECTION_CONSTRUCTION = 2;
-  TECH_CARD_SIGNOFF_SECTION_POM = 3;
+  reserved 3; // was TECH_CARD_SIGNOFF_SECTION_POM (POM removed)
   TECH_CARD_SIGNOFF_SECTION_MATERIALS = 4;
   TECH_CARD_SIGNOFF_SECTION_COLOUR = 5;
   TECH_CARD_SIGNOFF_SECTION_LABELS = 6;
@@ -491,20 +461,9 @@ message TechCardInsert {
   string designer = 14;
   string constructor = 15;
   string technologist = 16;
-  google.type.Decimal target_cost = 17;
-  google.type.Decimal target_retail_price = 18;
-  string currency = 19; // ISO 4217 for target cost/price
 
-  // construction description (lower block of Sheet «Титул»)
-  string description = 20;
-  string silhouette = 21;
-  string collar = 22;
-  string fastening = 23;
-  string pockets = 24;
-  string sleeve_cuff = 25;
-  string extra_details = 26;
-  string topstitching = 27;
-  string aux_materials = 28;
+  // construction description (lower block of Sheet «Титул») now lives in details[]; the
+  // header targets / currency were removed (pricing is on costing, single brand policy).
   string notes = 29;
 
   // children (full-replace on update)
@@ -514,10 +473,9 @@ message TechCardInsert {
   repeated TechCardCallout callouts = 33; // sketch callouts
   repeated TechCardRevision revisions = 34; // revision log
 
-  // materials (Phase 2): bill of materials, colourways, points of measure.
+  // materials (Phase 2): bill of materials (article catalog) and colourways (recipes).
   repeated TechCardBomItem bom_items = 40;
   repeated TechCardColorway colorways = 41;
-  repeated TechCardPomPoint pom_points = 42;
 
   // production (Phase 3): construction, operations, labels, packaging, costing.
   TechCardConstruction construction = 43; // 1:1; null = unset
@@ -534,8 +492,12 @@ message TechCardInsert {
   repeated TechCardSignoff signoffs = 52; // per-section sign-off
   repeated TechCardSizePattern patterns = 53; // per-size PDF выкройки (cut patterns)
 
-  // Reserved so a future field can never collide with a removed one.
-  reserved 39, 54 to 99;
+  // construction-description aspects with reference images (replaces the flat strings).
+  repeated TechCardDetail details = 54;
+
+  // Reserved so a future field can never collide with a removed one. 17-19 targets+currency;
+  // 20-28 construction-desc strings → details[]; 42 pom_points; 39 prior.
+  reserved 17 to 28, 39, 42, 55 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.


### PR DESCRIPTION
## Tech Card overhaul — backend

Implements `tmp/backend-plan` in full. The model shifts so the **BOM becomes a pure material-article catalog** and the **colourway carries the "recipe"** (`tech_card_colorway_usage` — which article on which garment part, in what colour, at what consumption, per-garment and/or per-size).

### Highlights
- New: `TechCardColorwayUsage`, `TechCardDetail`, `TechCardColorwayCost`; `Operation.placement`; `Costing.colorway_costs`.
- Removed (reserved): POM, header cost targets, labour pricing, the BOM colour matrix, flat construction-description strings → `details[]`.
- Per-colourway costing; root rollup = primary colourway (index 0); no labour fallback; banker's rounding.
- `operation_number` is server-assigned `(i+1)*10`; placement normalized (trim+lower); category must be a leaf (Q5).
- Lock/freeze: RELEASED-freeze checked before the version check (plan §4).

### Migration `0079`
Creates the new tables, backfills the colour matrix → colourway usages, drops the obsolete tables/columns. **Validated end-to-end against MySQL 8** (all migrations 0001→0079) and the backfill checked with a fixture.

### Verification
Full build + `go vet` clean; dto/entity/apisrv unit tests pass (test files rewritten for the new model); no new lint. Adversarial multi-agent review run — verdict **ship**, both low-severity findings fixed.

> ⚠️ Breaking proto change — the **admin frontend** needs `make proto` + redeploy for the tech-card screens. Blast radius is the admin tech-card feature only (new feature, ~no data); the customer storefront is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)