### PR TITLE
Promote beta → master: hero v2 + per-media tint/stroke

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -48,6 +48,11 @@ envs:
 - key: HTTP_ALLOWED_ORIGINS
   scope: RUN_TIME
   value: '["https://backend.grbpwr.com","https://mikevelko.github.io","https://jekabolt.github.io","https://0101oak.github.io","https://grbpwr.com","https://admin.grbpwr.com"]'
+# Comma-separated allowlist of hosts permitted as hero EMBED iframe sources.
+# Empty accepts any https host (scheme/format validation still applies).
+- key: HERO_EMBED_ALLOWED_HOSTS
+  scope: RUN_TIME
+  value: ""
 - key: AUTH_JWT_SECRET
   scope: RUN_TIME
   type: SECRET

--- a/app/app.go
+++ b/app/app.go
@@ -256,7 +256,7 @@ func (a *App) Start(ctx context.Context) error {
 		p.SetGA4MP(ga4mpClient)
 	}
 
-	adminS := admin.New(a.db, a.b, a.ma, stripeMain, stripeTest, a.re, reservationMgr, ga4mpClient)
+	adminS := admin.New(a.db, a.b, a.ma, stripeMain, stripeTest, a.re, reservationMgr, ga4mpClient, a.c.Security.HeroEmbedAllowedHosts)
 
 	var frontendS *frontend.Server
 	frontendS, err = frontend.New(a.db, a.ma, stripeMain, stripeTest, a.re, reservationMgr, &a.c.StorefrontAuth)

--- a/config/cfg.go
+++ b/config/cfg.go
@@ -41,6 +41,10 @@ type SecurityConfig struct {
 	// non-positive value falls back to the secure default of one hop, which
 	// matches DigitalOcean App Platform's single edge proxy.
 	TrustProxyHops int `mapstructure:"trust_proxy_hops"`
+	// HeroEmbedAllowedHosts is a comma-separated allowlist of hosts permitted as
+	// hero EMBED iframe sources (e.g. "www.youtube.com,player.vimeo.com"). Empty
+	// means any https host is accepted (scheme/format validation still applies).
+	HeroEmbedAllowedHosts string `mapstructure:"hero_embed_allowed_hosts"`
 }
 
 // defaultTrustProxyHops is the secure default applied when trust_proxy_hops is
@@ -225,6 +229,10 @@ const (
 // bindEnvVars binds environment variables to config keys
 // This allows using both nested keys (MYSQL__DSN) and flat keys (MYSQL_DSN)
 func bindEnvVars() {
+	// Security
+	viper.BindEnv("security.trust_proxy_hops", "SECURITY_TRUST_PROXY_HOPS")
+	viper.BindEnv("security.hero_embed_allowed_hosts", "SECURITY_HERO_EMBED_ALLOWED_HOSTS", "HERO_EMBED_ALLOWED_HOSTS")
+
 	// MySQL
 	viper.BindEnv("mysql.dsn", "MYSQL_DSN")
 	viper.BindEnv("mysql.automigrate", "MYSQL_AUTOMIGRATE")

--- a/internal/apisrv/admin/hero.go
+++ b/internal/apisrv/admin/hero.go
@@ -2,15 +2,23 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net/url"
+	"strings"
 
 	"github.com/jekabolt/grbpwr-manager/internal/dto"
 	pb_admin "github.com/jekabolt/grbpwr-manager/proto/gen/admin"
+	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func (s *Server) AddHero(ctx context.Context, req *pb_admin.AddHeroRequest) (*pb_admin.AddHeroResponse, error) {
+	if err := s.validateHeroEmbeds(req.Hero); err != nil {
+		slog.Default().WarnContext(ctx, "rejected hero with invalid embed", slog.String("err", err.Error()))
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
 
 	heroFull := dto.ConvertCommonHeroFullInsertToEntity(req.Hero)
 
@@ -26,4 +34,53 @@ func (s *Server) AddHero(ctx context.Context, req *pb_admin.AddHeroRequest) (*pb
 		Hero: true,
 	})
 	return &pb_admin.AddHeroResponse{}, nil
+}
+
+// validateHeroEmbeds ensures every EMBED block references a safe iframe source:
+// an absolute https URL, and — when an allowlist is configured — a permitted host.
+func (s *Server) validateHeroEmbeds(h *pb_common.HeroFullInsert) error {
+	if h == nil {
+		return nil
+	}
+	for i, e := range h.Entities {
+		if e.Type != pb_common.HeroType_HERO_TYPE_EMBED || e.Embed == nil {
+			continue
+		}
+		u, err := url.Parse(e.Embed.EmbedUrl)
+		if err != nil || u.Scheme != "https" || u.Hostname() == "" {
+			return fmt.Errorf("hero entity %d: embed_url must be an absolute https URL", i)
+		}
+		if len(s.embedAllowedHosts) > 0 && !hostAllowed(u.Hostname(), s.embedAllowedHosts) {
+			return fmt.Errorf("hero entity %d: embed host %q is not in the allowlist", i, u.Hostname())
+		}
+	}
+	return nil
+}
+
+// parseEmbedAllowedHosts splits a comma-separated host allowlist into a
+// normalized (trimmed, lowercased, non-empty) slice.
+func parseEmbedAllowedHosts(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	hosts := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if h := strings.ToLower(strings.TrimSpace(p)); h != "" {
+			hosts = append(hosts, h)
+		}
+	}
+	return hosts
+}
+
+// hostAllowed reports whether host exactly matches, or is a subdomain of, any
+// allowed host.
+func hostAllowed(host string, allowed []string) bool {
+	host = strings.ToLower(host)
+	for _, a := range allowed {
+		if host == a || strings.HasSuffix(host, "."+a) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/apisrv/admin/server.go
+++ b/internal/apisrv/admin/server.go
@@ -33,6 +33,9 @@ type Server struct {
 	// revalidateSem is a counting semaphore bounding concurrent async revalidations
 	// spawned by revalidateAsync. Buffered to maxConcurrentRevalidations.
 	revalidateSem chan struct{}
+	// embedAllowedHosts restricts the hosts allowed as hero EMBED iframe sources.
+	// Empty means any https host is accepted (scheme/format validation still applies).
+	embedAllowedHosts []string
 }
 
 // New creates a new server with admin handlers.
@@ -45,6 +48,7 @@ func New(
 	re dependency.RevalidationService,
 	reservationMgr dependency.StockReservationManager,
 	ga4mpClient *ga4mp.Client,
+	embedAllowedHosts string,
 ) *Server {
 	return &Server{
 		repo:              r,
@@ -56,6 +60,7 @@ func New(
 		reservationMgr:    reservationMgr,
 		ga4mp:             ga4mpClient,
 		revalidateSem:     make(chan struct{}, maxConcurrentRevalidations),
+		embedAllowedHosts: parseEmbedAllowedHosts(embedAllowedHosts),
 	}
 }
 

--- a/internal/apisrv/frontend/hero.go
+++ b/internal/apisrv/frontend/hero.go
@@ -6,14 +6,16 @@ import (
 
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
 	"github.com/jekabolt/grbpwr-manager/internal/dto"
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
 	pb_frontend "github.com/jekabolt/grbpwr-manager/proto/gen/frontend"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func (s *Server) GetHero(ctx context.Context, req *pb_frontend.GetHeroRequest) (*pb_frontend.GetHeroResponse, error) {
-	// Use cached hero for default language since GetHeroRequest doesn't have language field
-	heroFull := cache.GetHero()
+	// Cached hero is the shared, resolved default-language hero. Filter a copy of
+	// it for the requesting viewer (TARGETING modifier); never mutate the cache.
+	heroFull := s.filterHeroForViewer(ctx, cache.GetHero())
 
 	h, err := dto.ConvertEntityHeroFullToCommonWithTranslations(heroFull)
 	if err != nil {
@@ -48,4 +50,44 @@ func (s *Server) GetHero(ctx context.Context, req *pb_frontend.GetHeroRequest) (
 			BackgroundHeroColor:         cache.GetBackgroundHeroColor(),
 		}),
 	}, nil
+}
+
+// filterHeroForViewer returns a copy of the hero containing only the entities
+// the requesting viewer is allowed to see, per each entity's HeroAudience.
+func (s *Server) filterHeroForViewer(ctx context.Context, hero *entity.HeroFullWithTranslations) *entity.HeroFullWithTranslations {
+	if hero == nil {
+		return nil
+	}
+
+	email, err := s.storefrontEmailFromAccess(ctx)
+	authenticated := err == nil && email != ""
+	var tier int16 = entity.TierCodeMember
+	if authenticated {
+		tier = s.viewerTier(ctx)
+	}
+
+	out := &entity.HeroFullWithTranslations{
+		NavFeatured: hero.NavFeatured,
+		Entities:    make([]entity.HeroEntityWithTranslations, 0, len(hero.Entities)),
+	}
+	for _, e := range hero.Entities {
+		if heroEntityVisibleTo(e, authenticated, tier) {
+			out.Entities = append(out.Entities, e)
+		}
+	}
+	return out
+}
+
+// heroEntityVisibleTo applies the TARGETING modifier for a single entity.
+func heroEntityVisibleTo(e entity.HeroEntityWithTranslations, authenticated bool, tier int16) bool {
+	switch e.Audience {
+	case entity.HeroAudienceGuests:
+		return !authenticated
+	case entity.HeroAudienceMembers:
+		return authenticated
+	case entity.HeroAudienceTier:
+		return authenticated && int(tier) >= e.MinTierId
+	default: // HeroAudienceUnknown / HeroAudienceAll
+		return true
+	}
 }

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -35,6 +35,8 @@ type (
 		GetProductsByIds(ctx context.Context, ids []int) ([]entity.Product, error)
 		// GetProductsByTag returns a list of products by their tag.
 		GetProductsByTag(ctx context.Context, tag string) ([]entity.Product, error)
+		// GetLowStockProducts returns visible products with total stock in (0, threshold], ordered by ascending stock.
+		GetLowStockProducts(ctx context.Context, threshold int, limit int) ([]entity.Product, error)
 		// GetProductByIdShowHidden returns a product by its ID no matter hidden they or not.
 		GetProductByIdShowHidden(ctx context.Context, id int) (*entity.ProductFull, error)
 		// GetProductByIdNoHidden returns a product by its ID, excluding hidden products.

--- a/internal/dto/hero.go
+++ b/internal/dto/hero.go
@@ -85,6 +85,8 @@ func convertCommonHeroMediaToEntity(m *pb_common.HeroMedia) entity.HeroMedia {
 		PortraitId:     int(m.PortraitId),
 		LandscapeId:    int(m.LandscapeId),
 		DisableOverlay: m.DisableOverlay,
+		DisableTint:    m.DisableTint,
+		Stroke:         m.Stroke,
 	}
 }
 
@@ -96,6 +98,8 @@ func convertEntityHeroMediaFullToCommon(m *entity.HeroMediaFull) *pb_common.Hero
 		Portrait:       ConvertEntityToCommonMedia(&m.Portrait),
 		Landscape:      ConvertEntityToCommonMedia(&m.Landscape),
 		DisableOverlay: m.DisableOverlay,
+		DisableTint:    m.DisableTint,
+		Stroke:         m.Stroke,
 	}
 }
 

--- a/internal/dto/hero.go
+++ b/internal/dto/hero.go
@@ -2,38 +2,126 @@ package dto
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
 	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func convertCommonHeroSingleSliceToEntity(in []*pb_common.HeroSingleInsert) []entity.HeroSingleInsert {
+	out := make([]entity.HeroSingleInsert, len(in))
+	for i, s := range in {
+		out[i] = convertCommonHeroSingleInsertToEntity(s)
+	}
+	return out
+}
+
+func convertEntityHeroSingleSliceToCommon(in []entity.HeroSingleWithTranslations) []*pb_common.HeroSingleWithTranslations {
+	out := make([]*pb_common.HeroSingleWithTranslations, len(in))
+	for i := range in {
+		out[i] = convertEntityHeroSingleToCommon(&in[i])
+	}
+	return out
+}
+
+func convertEntityProductsToCommon(products []entity.Product) ([]*pb_common.Product, error) {
+	out := make([]*pb_common.Product, len(products))
+	for i := range products {
+		cp, err := ConvertEntityProductToCommon(&products[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert product at index %d: %w", i, err)
+		}
+		out[i] = cp
+	}
+	return out, nil
+}
+
+// ─── fragment helpers ───────────────────────────────────────────────────────
+
+func convertCommonHeroCopyTranslationsToEntity(in []*pb_common.HeroCopyTranslation) []entity.HeroCopyTranslation {
+	out := make([]entity.HeroCopyTranslation, len(in))
+	for i, t := range in {
+		out[i] = entity.HeroCopyTranslation{
+			LanguageId:  int(t.LanguageId),
+			Tag:         t.Tag,
+			Headline:    t.Headline,
+			Subhead:     t.Subhead,
+			Body:        t.Body,
+			CtaText:     t.CtaText,
+			ExploreText: t.ExploreText,
+			Caption:     t.Caption,
+			Placeholder: t.Placeholder,
+			SuccessText: t.SuccessText,
+		}
+	}
+	return out
+}
+
+func convertEntityHeroCopyTranslationsToCommon(in []entity.HeroCopyTranslation) []*pb_common.HeroCopyTranslation {
+	out := make([]*pb_common.HeroCopyTranslation, len(in))
+	for i, t := range in {
+		out[i] = &pb_common.HeroCopyTranslation{
+			LanguageId:  int32(t.LanguageId),
+			Tag:         t.Tag,
+			Headline:    t.Headline,
+			Subhead:     t.Subhead,
+			Body:        t.Body,
+			CtaText:     t.CtaText,
+			ExploreText: t.ExploreText,
+			Caption:     t.Caption,
+			Placeholder: t.Placeholder,
+			SuccessText: t.SuccessText,
+		}
+	}
+	return out
+}
+
+func convertCommonHeroMediaToEntity(m *pb_common.HeroMedia) entity.HeroMedia {
+	if m == nil {
+		return entity.HeroMedia{}
+	}
+	return entity.HeroMedia{
+		PortraitId:     int(m.PortraitId),
+		LandscapeId:    int(m.LandscapeId),
+		DisableOverlay: m.DisableOverlay,
+	}
+}
+
+func convertEntityHeroMediaFullToCommon(m *entity.HeroMediaFull) *pb_common.HeroMediaFull {
+	if m == nil {
+		return nil
+	}
+	return &pb_common.HeroMediaFull{
+		Portrait:       ConvertEntityToCommonMedia(&m.Portrait),
+		Landscape:      ConvertEntityToCommonMedia(&m.Landscape),
+		DisableOverlay: m.DisableOverlay,
+	}
+}
+
+// ─── insert: proto → entity ─────────────────────────────────────────────────
 
 func ConvertCommonHeroFullInsertToEntity(hi *pb_common.HeroFullInsert) entity.HeroFullInsert {
 	result := entity.HeroFullInsert{
 		Entities: make([]entity.HeroEntityInsert, len(hi.Entities)),
 	}
-
-	for i, entity := range hi.Entities {
-		result.Entities[i] = ConvertCommonHeroEntityInsertToEntity(entity)
+	for i, e := range hi.Entities {
+		result.Entities[i] = ConvertCommonHeroEntityInsertToEntity(e)
 	}
-
 	if hi.NavFeatured != nil {
 		result.NavFeatured = ConvertCommonNavFeaturedInsertToEntity(hi.NavFeatured)
 	}
-
 	return result
 }
 
 func ConvertCommonNavFeaturedInsertToEntity(hi *pb_common.NavFeaturedInsert) entity.NavFeaturedInsert {
 	result := entity.NavFeaturedInsert{}
-
 	if hi.Men != nil {
 		result.Men = ConvertCommonNavFeaturedEntityInsertToEntity(hi.Men)
 	}
-
 	if hi.Women != nil {
 		result.Women = ConvertCommonNavFeaturedEntityInsertToEntity(hi.Women)
 	}
-
 	return result
 }
 
@@ -44,146 +132,196 @@ func ConvertCommonNavFeaturedEntityInsertToEntity(hi *pb_common.NavFeaturedEntit
 		FeaturedArchiveId: int(hi.FeaturedArchiveId),
 		Translations:      make([]entity.NavFeaturedEntityInsertTranslation, len(hi.Translations)),
 	}
-
 	for i, trans := range hi.Translations {
 		result.Translations[i] = entity.NavFeaturedEntityInsertTranslation{
 			LanguageId:  int(trans.LanguageId),
 			ExploreText: trans.ExploreText,
 		}
 	}
-
 	return result
+}
+
+func convertCommonHeroSingleInsertToEntity(s *pb_common.HeroSingleInsert) entity.HeroSingleInsert {
+	if s == nil {
+		return entity.HeroSingleInsert{}
+	}
+	return entity.HeroSingleInsert{
+		Media:        convertCommonHeroMediaToEntity(s.Media),
+		ExploreLink:  s.ExploreLink,
+		Translations: convertCommonHeroCopyTranslationsToEntity(s.Translations),
+	}
 }
 
 func ConvertCommonHeroEntityInsertToEntity(hi *pb_common.HeroEntityInsert) entity.HeroEntityInsert {
 	result := entity.HeroEntityInsert{
-		Type: entity.HeroType(hi.Type),
+		Type:      entity.HeroType(hi.Type),
+		Audience:  entity.HeroAudience(hi.Audience),
+		MinTierId: int(hi.MinTierId),
 	}
 
 	switch hi.Type {
 	case pb_common.HeroType_HERO_TYPE_SINGLE:
 		if hi.Single != nil {
-			result.Single = entity.HeroSingleInsert{
-				MediaPortraitId:  int(hi.Single.MediaPortraitId),
-				MediaLandscapeId: int(hi.Single.MediaLandscapeId),
-				ExploreLink:      hi.Single.ExploreLink,
-				Translations:     make([]entity.HeroSingleInsertTranslation, len(hi.Single.Translations)),
-			}
-
-			for i, trans := range hi.Single.Translations {
-				result.Single.Translations[i] = entity.HeroSingleInsertTranslation{
-					LanguageId:  int(trans.LanguageId),
-					Headline:    trans.Headline,
-					ExploreText: trans.ExploreText,
-				}
-			}
+			result.Single = convertCommonHeroSingleInsertToEntity(hi.Single)
 		}
 	case pb_common.HeroType_HERO_TYPE_DOUBLE:
-		if hi.Double != nil && hi.Double.Left != nil && hi.Double.Right != nil {
-			leftTranslations := make([]entity.HeroSingleInsertTranslation, len(hi.Double.Left.Translations))
-			for i, trans := range hi.Double.Left.Translations {
-				leftTranslations[i] = entity.HeroSingleInsertTranslation{
-					LanguageId:  int(trans.LanguageId),
-					Headline:    trans.Headline,
-					ExploreText: trans.ExploreText,
-				}
-			}
-
-			rightTranslations := make([]entity.HeroSingleInsertTranslation, len(hi.Double.Right.Translations))
-			for i, trans := range hi.Double.Right.Translations {
-				rightTranslations[i] = entity.HeroSingleInsertTranslation{
-					LanguageId:  int(trans.LanguageId),
-					Headline:    trans.Headline,
-					ExploreText: trans.ExploreText,
-				}
-			}
-
+		if hi.Double != nil {
 			result.Double = entity.HeroDoubleInsert{
-				Left: entity.HeroSingleInsert{
-					MediaPortraitId:  int(hi.Double.Left.MediaPortraitId),
-					MediaLandscapeId: int(hi.Double.Left.MediaLandscapeId),
-					ExploreLink:      hi.Double.Left.ExploreLink,
-					Translations:     leftTranslations,
-				},
-				Right: entity.HeroSingleInsert{
-					MediaPortraitId:  int(hi.Double.Right.MediaPortraitId),
-					MediaLandscapeId: int(hi.Double.Right.MediaLandscapeId),
-					ExploreLink:      hi.Double.Right.ExploreLink,
-					Translations:     rightTranslations,
-				},
+				Left:  convertCommonHeroSingleInsertToEntity(hi.Double.Left),
+				Right: convertCommonHeroSingleInsertToEntity(hi.Double.Right),
 			}
 		}
 	case pb_common.HeroType_HERO_TYPE_MAIN:
 		if hi.Main != nil {
-			translations := make([]entity.HeroMainInsertTranslation, len(hi.Main.Translations))
-			for i, trans := range hi.Main.Translations {
-				translations[i] = entity.HeroMainInsertTranslation{
-					LanguageId:  int(trans.LanguageId),
-					Tag:         trans.Tag,
-					Description: trans.Description,
-					Headline:    trans.Headline,
-					ExploreText: trans.ExploreText,
-				}
-			}
-
 			result.Main = entity.HeroMainInsert{
-				MediaPortraitId:  int(hi.Main.MediaPortraitId),
-				MediaLandscapeId: int(hi.Main.MediaLandscapeId),
-				ExploreLink:      hi.Main.ExploreLink,
-				Translations:     translations,
+				Media:        convertCommonHeroMediaToEntity(hi.Main.Media),
+				ExploreLink:  hi.Main.ExploreLink,
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.Main.Translations),
 			}
 		}
 	case pb_common.HeroType_HERO_TYPE_FEATURED_PRODUCTS:
 		if hi.FeaturedProducts != nil {
-			translations := make([]entity.HeroFeaturedProductsInsertTranslation, len(hi.FeaturedProducts.Translations))
-			for i, trans := range hi.FeaturedProducts.Translations {
-				translations[i] = entity.HeroFeaturedProductsInsertTranslation{
-					LanguageId:  int(trans.LanguageId),
-					Headline:    trans.Headline,
-					ExploreText: trans.ExploreText,
-				}
-			}
-
-			result.FeaturedProducts = entity.HeroFeaturedProductsInsert{
-				ProductIDs:   make([]int, len(hi.FeaturedProducts.ProductIds)),
-				ExploreLink:  hi.FeaturedProducts.ExploreLink,
-				Translations: translations,
-			}
+			ids := make([]int, len(hi.FeaturedProducts.ProductIds))
 			for i, id := range hi.FeaturedProducts.ProductIds {
-				result.FeaturedProducts.ProductIDs[i] = int(id)
+				ids[i] = int(id)
+			}
+			result.FeaturedProducts = entity.HeroFeaturedProductsInsert{
+				ProductIDs:   ids,
+				ExploreLink:  hi.FeaturedProducts.ExploreLink,
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.FeaturedProducts.Translations),
 			}
 		}
 	case pb_common.HeroType_HERO_TYPE_FEATURED_PRODUCTS_TAG:
 		if hi.FeaturedProductsTag != nil {
-			translations := make([]entity.HeroFeaturedProductsTagInsertTranslation, len(hi.FeaturedProductsTag.Translations))
-			for i, trans := range hi.FeaturedProductsTag.Translations {
-				translations[i] = entity.HeroFeaturedProductsTagInsertTranslation{
-					LanguageId:  int(trans.LanguageId),
-					Headline:    trans.Headline,
-					ExploreText: trans.ExploreText,
-				}
-			}
-
 			result.FeaturedProductsTag = entity.HeroFeaturedProductsTagInsert{
 				Tag:          hi.FeaturedProductsTag.Tag,
-				Translations: translations,
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.FeaturedProductsTag.Translations),
 			}
 		}
 	case pb_common.HeroType_HERO_TYPE_FEATURED_ARCHIVE:
 		if hi.FeaturedArchive != nil {
-			translations := make([]entity.HeroFeaturedArchiveInsertTranslation, len(hi.FeaturedArchive.Translations))
-			for i, trans := range hi.FeaturedArchive.Translations {
-				translations[i] = entity.HeroFeaturedArchiveInsertTranslation{
-					LanguageId:  int(trans.LanguageId),
-					Headline:    trans.Headline,
-					ExploreText: trans.ExploreText,
-				}
-			}
-
 			result.FeaturedArchive = entity.HeroFeaturedArchiveInsert{
 				ArchiveId:    int(hi.FeaturedArchive.ArchiveId),
 				Tag:          hi.FeaturedArchive.Tag,
-				Translations: translations,
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.FeaturedArchive.Translations),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_EMBED:
+		if hi.Embed != nil {
+			result.Embed = entity.HeroEmbedInsert{
+				EmbedUrl:     hi.Embed.EmbedUrl,
+				Fallback:     convertCommonHeroMediaToEntity(hi.Embed.Fallback),
+				CtaLink:      hi.Embed.CtaLink,
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.Embed.Translations),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_DROP:
+		if hi.Drop != nil {
+			var releaseAt time.Time
+			if hi.Drop.ReleaseAt != nil {
+				releaseAt = hi.Drop.ReleaseAt.AsTime()
+			}
+			result.Drop = entity.HeroDropInsert{
+				Media:        convertCommonHeroMediaToEntity(hi.Drop.Media),
+				ReleaseAt:    releaseAt,
+				ExploreLink:  hi.Drop.ExploreLink,
+				Tag:          hi.Drop.Tag,
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.Drop.Translations),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_LAST_CHANCE:
+		if hi.LastChance != nil {
+			result.LastChance = entity.HeroLastChanceInsert{
+				StockThreshold: int(hi.LastChance.StockThreshold),
+				Limit:          int(hi.LastChance.Limit),
+				ExploreLink:    hi.LastChance.ExploreLink,
+				Translations:   convertCommonHeroCopyTranslationsToEntity(hi.LastChance.Translations),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_MARQUEE:
+		if hi.Marquee != nil {
+			result.Marquee = entity.HeroMarqueeInsert{
+				Link:         hi.Marquee.Link,
+				Speed:        int(hi.Marquee.Speed),
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.Marquee.Translations),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_NEW_ARRIVALS:
+		if hi.NewArrivals != nil {
+			result.NewArrivals = entity.HeroNewArrivalsInsert{
+				Limit:        int(hi.NewArrivals.Limit),
+				ExploreLink:  hi.NewArrivals.ExploreLink,
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.NewArrivals.Translations),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_SLIDESHOW:
+		if hi.Slideshow != nil {
+			result.Slideshow = entity.HeroSlideshowInsert{
+				Slides:     convertCommonHeroSingleSliceToEntity(hi.Slideshow.Slides),
+				IntervalMs: int(hi.Slideshow.IntervalMs),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_MOSAIC:
+		if hi.Mosaic != nil {
+			result.Mosaic = entity.HeroMosaicInsert{
+				Tiles:   convertCommonHeroSingleSliceToEntity(hi.Mosaic.Tiles),
+				Columns: int(hi.Mosaic.Columns),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_SPLIT:
+		if hi.Split != nil {
+			ids := make([]int, len(hi.Split.ProductIds))
+			for i, id := range hi.Split.ProductIds {
+				ids[i] = int(id)
+			}
+			result.Split = entity.HeroSplitInsert{
+				Media:      convertCommonHeroSingleInsertToEntity(hi.Split.Media),
+				ProductIDs: ids,
+				MediaLeft:  hi.Split.MediaLeft,
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_VIDEO:
+		if hi.Video != nil {
+			result.Video = entity.HeroVideoInsert{
+				MediaId:       int(hi.Video.MediaId),
+				PosterMediaId: int(hi.Video.PosterMediaId),
+				Autoplay:      hi.Video.Autoplay,
+				Loop:          hi.Video.Loop,
+				Muted:         hi.Video.Muted,
+				CtaLink:       hi.Video.CtaLink,
+				Translations:  convertCommonHeroCopyTranslationsToEntity(hi.Video.Translations),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_PRODUCT_SPOTLIGHT:
+		if hi.ProductSpotlight != nil {
+			result.ProductSpotlight = entity.HeroProductSpotlightInsert{
+				ProductId:    int(hi.ProductSpotlight.ProductId),
+				Media:        convertCommonHeroMediaToEntity(hi.ProductSpotlight.Media),
+				ExploreLink:  hi.ProductSpotlight.ExploreLink,
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.ProductSpotlight.Translations),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_NEWSLETTER:
+		if hi.Newsletter != nil {
+			result.Newsletter = entity.HeroNewsletterInsert{
+				Media:        convertCommonHeroMediaToEntity(hi.Newsletter.Media),
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.Newsletter.Translations),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_STATEMENT:
+		if hi.Statement != nil {
+			result.Statement = entity.HeroStatementInsert{
+				Media:        convertCommonHeroMediaToEntity(hi.Statement.Media),
+				ExploreLink:  hi.Statement.ExploreLink,
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.Statement.Translations),
+			}
+		}
+	case pb_common.HeroType_HERO_TYPE_LOOKBOOK:
+		if hi.Lookbook != nil {
+			result.Lookbook = entity.HeroLookbookInsert{
+				Frames:       convertCommonHeroSingleSliceToEntity(hi.Lookbook.Frames),
+				ExploreLink:  hi.Lookbook.ExploreLink,
+				Translations: convertCommonHeroCopyTranslationsToEntity(hi.Lookbook.Translations),
 			}
 		}
 	}
@@ -191,7 +329,8 @@ func ConvertCommonHeroEntityInsertToEntity(hi *pb_common.HeroEntityInsert) entit
 	return result
 }
 
-// ConvertEntityHeroFullToCommonWithTranslations converts entity.HeroFull to pb_common.HeroFullWithTranslations
+// ─── read: entity → proto (WithTranslations) ────────────────────────────────
+
 func ConvertEntityHeroFullToCommonWithTranslations(hf *entity.HeroFullWithTranslations) (*pb_common.HeroFullWithTranslations, error) {
 	if hf == nil {
 		return nil, nil
@@ -202,8 +341,8 @@ func ConvertEntityHeroFullToCommonWithTranslations(hf *entity.HeroFullWithTransl
 		NavFeatured: ConvertEntityNavFeaturedToCommonWithTranslations(&hf.NavFeatured),
 	}
 
-	for i, entity := range hf.Entities {
-		commonEntity, err := ConvertEntityHeroEntityToCommonWithTranslations(&entity)
+	for i := range hf.Entities {
+		commonEntity, err := ConvertEntityHeroEntityToCommonWithTranslations(&hf.Entities[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert entity at index %d: %w", i, err)
 		}
@@ -244,128 +383,28 @@ func ConvertEntityNavFeaturedEntityToCommonWithTranslations(ne *entity.NavFeatur
 	}
 }
 
-func ConvertEntityHeroEntityToCommonWithTranslations(he *entity.HeroEntityWithTranslations) (*pb_common.HeroEntityWithTranslations, error) {
-	if he == nil {
-		return nil, nil
-	}
-
-	result := &pb_common.HeroEntityWithTranslations{
-		Type: pb_common.HeroType(he.Type),
-	}
-
-	switch he.Type {
-	case entity.HeroTypeSingle:
-		if he.Single != nil {
-			result.Single = ConvertEntityHeroSingleToCommonWithTranslations(he.Single)
-		}
-	case entity.HeroTypeDouble:
-		if he.Double != nil {
-			result.Double = ConvertEntityHeroDoubleToCommonWithTranslations(he.Double)
-		}
-	case entity.HeroTypeMain:
-		if he.Main != nil {
-			result.Main = ConvertEntityHeroMainToCommonWithTranslations(he.Main)
-		}
-	case entity.HeroTypeFeaturedProducts:
-		if he.FeaturedProducts != nil {
-			featuredProducts, err := ConvertEntityHeroFeaturedProductsToCommonWithTranslations(he.FeaturedProducts)
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert featured products: %w", err)
-			}
-			result.FeaturedProducts = featuredProducts
-		}
-	case entity.HeroTypeFeaturedProductsTag:
-		if he.FeaturedProductsTag != nil {
-			featuredProductsTag, err := ConvertEntityHeroFeaturedProductsTagToCommonWithTranslations(he.FeaturedProductsTag)
-			if err != nil {
-				return nil, err
-			}
-			result.FeaturedProductsTag = featuredProductsTag
-		}
-	case entity.HeroTypeFeaturedArchive:
-		if he.FeaturedArchive != nil {
-			result.FeaturedArchive = ConvertEntityHeroFeaturedArchiveToCommonWithTranslations(he.FeaturedArchive)
-		}
-	}
-
-	return result, nil
-}
-
-func ConvertEntityHeroSingleToCommonWithTranslations(hsa *entity.HeroSingleWithTranslations) *pb_common.HeroSingleWithTranslations {
-	if hsa == nil {
+func convertEntityHeroSingleToCommon(s *entity.HeroSingleWithTranslations) *pb_common.HeroSingleWithTranslations {
+	if s == nil {
 		return nil
 	}
-
-	translations := make([]*pb_common.HeroSingleInsertTranslation, len(hsa.Translations))
-	for i, trans := range hsa.Translations {
-		translations[i] = &pb_common.HeroSingleInsertTranslation{
-			LanguageId:  int32(trans.LanguageId),
-			Headline:    trans.Headline,
-			ExploreText: trans.ExploreText,
-		}
-	}
-
 	return &pb_common.HeroSingleWithTranslations{
-		MediaPortrait:  ConvertEntityToCommonMedia(&hsa.MediaPortrait),
-		MediaLandscape: ConvertEntityToCommonMedia(&hsa.MediaLandscape),
-		ExploreLink:    hsa.ExploreLink,
-		Translations:   translations,
+		Media:        convertEntityHeroMediaFullToCommon(&s.Media),
+		ExploreLink:  s.ExploreLink,
+		Translations: convertEntityHeroCopyTranslationsToCommon(s.Translations),
 	}
 }
 
-func ConvertEntityHeroDoubleToCommonWithTranslations(hda *entity.HeroDoubleWithTranslations) *pb_common.HeroDoubleWithTranslations {
-	if hda == nil {
-		return nil
-	}
-	return &pb_common.HeroDoubleWithTranslations{
-		Left:  ConvertEntityHeroSingleToCommonWithTranslations(&hda.Left),
-		Right: ConvertEntityHeroSingleToCommonWithTranslations(&hda.Right),
-	}
-}
-
-func ConvertEntityHeroMainToCommonWithTranslations(hma *entity.HeroMainWithTranslations) *pb_common.HeroMainWithTranslations {
-	if hma == nil {
-		return nil
-	}
-
-	translations := make([]*pb_common.HeroMainInsertTranslation, len(hma.Translations))
-	for i, trans := range hma.Translations {
-		translations[i] = &pb_common.HeroMainInsertTranslation{
-			LanguageId:  int32(trans.LanguageId),
-			Tag:         trans.Tag,
-			Description: trans.Description,
-			Headline:    trans.Headline,
-			ExploreText: trans.ExploreText,
-		}
-	}
-
-	return &pb_common.HeroMainWithTranslations{
-		Single:       ConvertEntityHeroSingleToCommonWithTranslations(&hma.Single),
-		Translations: translations,
-	}
-}
-
-func ConvertEntityHeroFeaturedProductsToCommonWithTranslations(hfp *entity.HeroFeaturedProductsWithTranslations) (*pb_common.HeroFeaturedProductsWithTranslations, error) {
-	if hfp == nil {
+func convertEntityHeroFeaturedProductsToCommon(fp *entity.HeroFeaturedProductsWithTranslations) (*pb_common.HeroFeaturedProductsWithTranslations, error) {
+	if fp == nil {
 		return nil, nil
 	}
-
-	translations := make([]*pb_common.HeroFeaturedProductsInsertTranslation, len(hfp.Translations))
-	for i, trans := range hfp.Translations {
-		translations[i] = &pb_common.HeroFeaturedProductsInsertTranslation{
-			LanguageId:  int32(trans.LanguageId),
-			Headline:    trans.Headline,
-			ExploreText: trans.ExploreText,
-		}
-	}
-
 	result := &pb_common.HeroFeaturedProductsWithTranslations{
-		Products:     make([]*pb_common.Product, len(hfp.Products)),
-		ExploreLink:  hfp.ExploreLink,
-		Translations: translations,
+		Products:     make([]*pb_common.Product, len(fp.Products)),
+		ExploreLink:  fp.ExploreLink,
+		Translations: convertEntityHeroCopyTranslationsToCommon(fp.Translations),
 	}
-	for i, product := range hfp.Products {
-		commonProduct, err := ConvertEntityProductToCommon(&product)
+	for i := range fp.Products {
+		commonProduct, err := ConvertEntityProductToCommon(&fp.Products[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert product at index %d: %w", i, err)
 		}
@@ -374,50 +413,206 @@ func ConvertEntityHeroFeaturedProductsToCommonWithTranslations(hfp *entity.HeroF
 	return result, nil
 }
 
-func ConvertEntityHeroFeaturedProductsTagToCommonWithTranslations(hfp *entity.HeroFeaturedProductsTagWithTranslations) (*pb_common.HeroFeaturedProductsTagWithTranslations, error) {
-	if hfp == nil {
+func convertEntityHeroFeaturedProductsTagToCommon(fp *entity.HeroFeaturedProductsTagWithTranslations) (*pb_common.HeroFeaturedProductsTagWithTranslations, error) {
+	if fp == nil {
 		return nil, nil
 	}
-	commonProducts, err := ConvertEntityHeroFeaturedProductsToCommonWithTranslations(&hfp.Products)
+	products, err := convertEntityHeroFeaturedProductsToCommon(&fp.Products)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert featured products: %w", err)
 	}
-
-	translations := make([]*pb_common.HeroFeaturedProductsTagInsertTranslation, len(hfp.Translations))
-	for i, trans := range hfp.Translations {
-		translations[i] = &pb_common.HeroFeaturedProductsTagInsertTranslation{
-			LanguageId:  int32(trans.LanguageId),
-			Headline:    trans.Headline,
-			ExploreText: trans.ExploreText,
-		}
-	}
-
 	return &pb_common.HeroFeaturedProductsTagWithTranslations{
-		Tag:          hfp.Tag,
-		Products:     commonProducts,
-		Translations: translations,
+		Tag:          fp.Tag,
+		Products:     products,
+		Translations: convertEntityHeroCopyTranslationsToCommon(fp.Translations),
 	}, nil
 }
 
-func ConvertEntityHeroFeaturedArchiveToCommonWithTranslations(he *entity.HeroFeaturedArchiveWithTranslations) *pb_common.HeroFeaturedArchiveWithTranslations {
+func ConvertEntityHeroEntityToCommonWithTranslations(he *entity.HeroEntityWithTranslations) (*pb_common.HeroEntityWithTranslations, error) {
 	if he == nil {
-		return nil
+		return nil, nil
 	}
 
-	translations := make([]*pb_common.HeroFeaturedArchiveInsertTranslation, len(he.Translations))
-	for i, trans := range he.Translations {
-		translations[i] = &pb_common.HeroFeaturedArchiveInsertTranslation{
-			LanguageId:  int32(trans.LanguageId),
-			Headline:    trans.Headline,
-			ExploreText: trans.ExploreText,
+	result := &pb_common.HeroEntityWithTranslations{
+		Type:      pb_common.HeroType(he.Type),
+		Audience:  pb_common.HeroAudience(he.Audience),
+		MinTierId: int32(he.MinTierId),
+	}
+
+	switch he.Type {
+	case entity.HeroTypeSingle:
+		if he.Single != nil {
+			result.Single = convertEntityHeroSingleToCommon(he.Single)
+		}
+	case entity.HeroTypeDouble:
+		if he.Double != nil {
+			result.Double = &pb_common.HeroDoubleWithTranslations{
+				Left:  convertEntityHeroSingleToCommon(&he.Double.Left),
+				Right: convertEntityHeroSingleToCommon(&he.Double.Right),
+			}
+		}
+	case entity.HeroTypeMain:
+		if he.Main != nil {
+			result.Main = &pb_common.HeroMainWithTranslations{
+				Media:        convertEntityHeroMediaFullToCommon(&he.Main.Media),
+				ExploreLink:  he.Main.ExploreLink,
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.Main.Translations),
+			}
+		}
+	case entity.HeroTypeFeaturedProducts:
+		if he.FeaturedProducts != nil {
+			featuredProducts, err := convertEntityHeroFeaturedProductsToCommon(he.FeaturedProducts)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert featured products: %w", err)
+			}
+			result.FeaturedProducts = featuredProducts
+		}
+	case entity.HeroTypeFeaturedProductsTag:
+		if he.FeaturedProductsTag != nil {
+			featuredProductsTag, err := convertEntityHeroFeaturedProductsTagToCommon(he.FeaturedProductsTag)
+			if err != nil {
+				return nil, err
+			}
+			result.FeaturedProductsTag = featuredProductsTag
+		}
+	case entity.HeroTypeFeaturedArchive:
+		if he.FeaturedArchive != nil {
+			result.FeaturedArchive = &pb_common.HeroFeaturedArchiveWithTranslations{
+				Archive:      ConvertArchiveFullEntityToPb(&he.FeaturedArchive.Archive),
+				Tag:          he.FeaturedArchive.Tag,
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.FeaturedArchive.Translations),
+			}
+		}
+	case entity.HeroTypeEmbed:
+		if he.Embed != nil {
+			result.Embed = &pb_common.HeroEmbedWithTranslations{
+				EmbedUrl:     he.Embed.EmbedUrl,
+				Fallback:     convertEntityHeroMediaFullToCommon(&he.Embed.Fallback),
+				CtaLink:      he.Embed.CtaLink,
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.Embed.Translations),
+			}
+		}
+	case entity.HeroTypeDrop:
+		if he.Drop != nil {
+			var releaseAt *timestamppb.Timestamp
+			if !he.Drop.ReleaseAt.IsZero() {
+				releaseAt = timestamppb.New(he.Drop.ReleaseAt)
+			}
+			result.Drop = &pb_common.HeroDropWithTranslations{
+				Media:        convertEntityHeroMediaFullToCommon(&he.Drop.Media),
+				ReleaseAt:    releaseAt,
+				ExploreLink:  he.Drop.ExploreLink,
+				Tag:          he.Drop.Tag,
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.Drop.Translations),
+			}
+		}
+	case entity.HeroTypeLastChance:
+		if he.LastChance != nil {
+			products, err := convertEntityProductsToCommon(he.LastChance.Products)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert last chance products: %w", err)
+			}
+			result.LastChance = &pb_common.HeroLastChanceWithTranslations{
+				Products:     products,
+				ExploreLink:  he.LastChance.ExploreLink,
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.LastChance.Translations),
+			}
+		}
+	case entity.HeroTypeMarquee:
+		if he.Marquee != nil {
+			result.Marquee = &pb_common.HeroMarqueeWithTranslations{
+				Link:         he.Marquee.Link,
+				Speed:        int32(he.Marquee.Speed),
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.Marquee.Translations),
+			}
+		}
+	case entity.HeroTypeNewArrivals:
+		if he.NewArrivals != nil {
+			products, err := convertEntityProductsToCommon(he.NewArrivals.Products)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert new arrivals products: %w", err)
+			}
+			result.NewArrivals = &pb_common.HeroNewArrivalsWithTranslations{
+				Products:     products,
+				ExploreLink:  he.NewArrivals.ExploreLink,
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.NewArrivals.Translations),
+			}
+		}
+	case entity.HeroTypeSlideshow:
+		if he.Slideshow != nil {
+			result.Slideshow = &pb_common.HeroSlideshowWithTranslations{
+				Slides:     convertEntityHeroSingleSliceToCommon(he.Slideshow.Slides),
+				IntervalMs: int32(he.Slideshow.IntervalMs),
+			}
+		}
+	case entity.HeroTypeMosaic:
+		if he.Mosaic != nil {
+			result.Mosaic = &pb_common.HeroMosaicWithTranslations{
+				Tiles:   convertEntityHeroSingleSliceToCommon(he.Mosaic.Tiles),
+				Columns: int32(he.Mosaic.Columns),
+			}
+		}
+	case entity.HeroTypeSplit:
+		if he.Split != nil {
+			products, err := convertEntityProductsToCommon(he.Split.Products)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert split products: %w", err)
+			}
+			result.Split = &pb_common.HeroSplitWithTranslations{
+				Media:     convertEntityHeroSingleToCommon(&he.Split.Media),
+				Products:  products,
+				MediaLeft: he.Split.MediaLeft,
+			}
+		}
+	case entity.HeroTypeVideo:
+		if he.Video != nil {
+			result.Video = &pb_common.HeroVideoWithTranslations{
+				Media:        ConvertEntityToCommonMedia(&he.Video.Media),
+				PosterMedia:  ConvertEntityToCommonMedia(&he.Video.PosterMedia),
+				Autoplay:     he.Video.Autoplay,
+				Loop:         he.Video.Loop,
+				Muted:        he.Video.Muted,
+				CtaLink:      he.Video.CtaLink,
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.Video.Translations),
+			}
+		}
+	case entity.HeroTypeProductSpotlight:
+		if he.ProductSpotlight != nil {
+			product, err := ConvertEntityProductToCommon(&he.ProductSpotlight.Product)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert spotlight product: %w", err)
+			}
+			result.ProductSpotlight = &pb_common.HeroProductSpotlightWithTranslations{
+				Product:      product,
+				Media:        convertEntityHeroMediaFullToCommon(&he.ProductSpotlight.Media),
+				ExploreLink:  he.ProductSpotlight.ExploreLink,
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.ProductSpotlight.Translations),
+			}
+		}
+	case entity.HeroTypeNewsletter:
+		if he.Newsletter != nil {
+			result.Newsletter = &pb_common.HeroNewsletterWithTranslations{
+				Media:        convertEntityHeroMediaFullToCommon(&he.Newsletter.Media),
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.Newsletter.Translations),
+			}
+		}
+	case entity.HeroTypeStatement:
+		if he.Statement != nil {
+			result.Statement = &pb_common.HeroStatementWithTranslations{
+				Media:        convertEntityHeroMediaFullToCommon(&he.Statement.Media),
+				ExploreLink:  he.Statement.ExploreLink,
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.Statement.Translations),
+			}
+		}
+	case entity.HeroTypeLookbook:
+		if he.Lookbook != nil {
+			result.Lookbook = &pb_common.HeroLookbookWithTranslations{
+				Frames:       convertEntityHeroSingleSliceToCommon(he.Lookbook.Frames),
+				ExploreLink:  he.Lookbook.ExploreLink,
+				Translations: convertEntityHeroCopyTranslationsToCommon(he.Lookbook.Translations),
+			}
 		}
 	}
 
-	return &pb_common.HeroFeaturedArchiveWithTranslations{
-		Archive:      ConvertArchiveFullEntityToPb(&he.Archive),
-		Tag:          he.Tag,
-		Headline:     he.Headline,
-		ExploreText:  he.ExploreText,
-		Translations: translations,
-	}
+	return result, nil
 }

--- a/internal/entity/hero.go
+++ b/internal/entity/hero.go
@@ -1,6 +1,78 @@
 package entity
 
-// WithTranslations structs to match proto definitions
+import "time"
+
+// ─── shared fragments ───────────────────────────────────────────────────────
+
+// HeroMedia is a portrait/landscape media pair addressed by id (write side).
+// DisableOverlay lives here so the scrim can be toggled per media slot.
+type HeroMedia struct {
+	PortraitId     int  `json:"portrait_id"`
+	LandscapeId    int  `json:"landscape_id"`
+	DisableOverlay bool `json:"disable_overlay"`
+}
+
+// HeroMediaFull is the resolved form of HeroMedia (read side).
+type HeroMediaFull struct {
+	Portrait       MediaFull `json:"portrait"`
+	Landscape      MediaFull `json:"landscape"`
+	DisableOverlay bool      `json:"disable_overlay"`
+}
+
+// HeroCopyTranslation is the single, shared translation for every hero block.
+// Each block type uses only the subset of fields it needs.
+type HeroCopyTranslation struct {
+	LanguageId  int    `json:"language_id"`
+	Tag         string `json:"tag"`
+	Headline    string `json:"headline"`
+	Subhead     string `json:"subhead"`
+	Body        string `json:"body"`
+	CtaText     string `json:"cta_text"`
+	ExploreText string `json:"explore_text"`
+	Caption     string `json:"caption"`
+	Placeholder string `json:"placeholder"`
+	SuccessText string `json:"success_text"`
+}
+
+type HeroType int32
+
+const (
+	HeroTypeUnknown             HeroType = 0
+	HeroTypeSingle              HeroType = 1
+	HeroTypeDouble              HeroType = 2
+	HeroTypeMain                HeroType = 3
+	HeroTypeFeaturedProducts    HeroType = 4
+	HeroTypeFeaturedProductsTag HeroType = 5
+	HeroTypeFeaturedArchive     HeroType = 6
+	HeroTypeEmbed               HeroType = 7
+	HeroTypeDrop                HeroType = 8
+	HeroTypeLastChance          HeroType = 9
+	HeroTypeMarquee             HeroType = 10
+	HeroTypeNewArrivals         HeroType = 11
+	HeroTypeSlideshow           HeroType = 12
+	HeroTypeMosaic              HeroType = 13
+	HeroTypeSplit               HeroType = 14
+	HeroTypeVideo               HeroType = 15
+	HeroTypeProductSpotlight    HeroType = 16
+	HeroTypeNewsletter          HeroType = 17
+	HeroTypeStatement           HeroType = 18
+	HeroTypeLookbook            HeroType = 19
+)
+
+// HeroAudience is the TARGETING modifier (carried through; enforcement pending
+// the frontend GetHero learning the viewer's tier).
+type HeroAudience int32
+
+const (
+	HeroAudienceUnknown HeroAudience = 0
+	HeroAudienceAll     HeroAudience = 1
+	HeroAudienceGuests  HeroAudience = 2
+	HeroAudienceMembers HeroAudience = 3
+	HeroAudienceTier    HeroAudience = 4
+)
+
+// ─── read side (resolved) ───────────────────────────────────────────────────
+
 type HeroFullWithTranslations struct {
 	Entities    []HeroEntityWithTranslations `json:"entities"`
 	NavFeatured NavFeaturedWithTranslations  `json:"nav_featured"`
@@ -14,7 +86,7 @@ type NavFeaturedWithTranslations struct {
 type NavFeaturedEntityWithTranslations struct {
 	Media             MediaFull                            `json:"media"`
 	FeaturedTag       string                               `json:"featured_tag"`
-	FeaturedArchiveId string                               `json:"featured_archive_id"` // Changed to string to match proto
+	FeaturedArchiveId string                               `json:"featured_archive_id"` // string to match proto
 	Translations      []NavFeaturedEntityInsertTranslation `json:"translations"`
 }
 
@@ -26,13 +98,27 @@ type HeroEntityWithTranslations struct {
 	FeaturedProducts    *HeroFeaturedProductsWithTranslations    `json:"featured_products"`
 	FeaturedProductsTag *HeroFeaturedProductsTagWithTranslations `json:"featured_products_tag"`
 	FeaturedArchive     *HeroFeaturedArchiveWithTranslations     `json:"featured_archive"`
+	Embed               *HeroEmbedWithTranslations               `json:"embed"`
+	Drop                *HeroDropWithTranslations                `json:"drop"`
+	LastChance          *HeroLastChanceWithTranslations          `json:"last_chance"`
+	Marquee             *HeroMarqueeWithTranslations             `json:"marquee"`
+	NewArrivals         *HeroNewArrivalsWithTranslations         `json:"new_arrivals"`
+	Slideshow           *HeroSlideshowWithTranslations           `json:"slideshow"`
+	Mosaic              *HeroMosaicWithTranslations              `json:"mosaic"`
+	Split               *HeroSplitWithTranslations               `json:"split"`
+	Video               *HeroVideoWithTranslations               `json:"video"`
+	ProductSpotlight    *HeroProductSpotlightWithTranslations    `json:"product_spotlight"`
+	Newsletter          *HeroNewsletterWithTranslations          `json:"newsletter"`
+	Statement           *HeroStatementWithTranslations           `json:"statement"`
+	Lookbook            *HeroLookbookWithTranslations            `json:"lookbook"`
+	Audience            HeroAudience                             `json:"audience"`
+	MinTierId           int                                      `json:"min_tier_id"`
 }
 
 type HeroSingleWithTranslations struct {
-	MediaPortrait  MediaFull                     `json:"media_portrait"`
-	MediaLandscape MediaFull                     `json:"media_landscape"`
-	ExploreLink    string                        `json:"explore_link"`
-	Translations   []HeroSingleInsertTranslation `json:"translations"`
+	Media        HeroMediaFull         `json:"media"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
 type HeroDoubleWithTranslations struct {
@@ -41,83 +127,125 @@ type HeroDoubleWithTranslations struct {
 }
 
 type HeroMainWithTranslations struct {
-	Single       HeroSingleWithTranslations  `json:"single"`
-	Translations []HeroMainInsertTranslation `json:"translations"`
+	Media        HeroMediaFull         `json:"media"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
 type HeroFeaturedProductsWithTranslations struct {
-	Products     []Product                               `json:"products"`
-	ExploreLink  string                                  `json:"explore_link"`
-	Translations []HeroFeaturedProductsInsertTranslation `json:"translations"`
+	Products     []Product             `json:"products"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
 type HeroFeaturedProductsTagWithTranslations struct {
-	Tag          string                                     `json:"tag"`
-	Products     HeroFeaturedProductsWithTranslations       `json:"products"`
-	Translations []HeroFeaturedProductsTagInsertTranslation `json:"translations"`
+	Tag          string                               `json:"tag"`
+	Products     HeroFeaturedProductsWithTranslations `json:"products"`
+	Translations []HeroCopyTranslation                `json:"translations"`
 }
 
 type HeroFeaturedArchiveWithTranslations struct {
-	Archive      ArchiveFull                            `json:"archive"`
-	Tag          string                                 `json:"tag"`
-	Headline     string                                 `json:"headline"`
-	ExploreText  string                                 `json:"explore_text"`
-	Translations []HeroFeaturedArchiveInsertTranslation `json:"translations"`
+	Archive      ArchiveFull           `json:"archive"`
+	Tag          string                `json:"tag"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
-type HeroSingleInsertTranslation struct {
-	LanguageId  int    `json:"language_id"`
-	Headline    string `json:"headline"`
-	ExploreText string `json:"explore_text"`
+type HeroEmbedWithTranslations struct {
+	EmbedUrl     string                `json:"embed_url"`
+	Fallback     HeroMediaFull         `json:"fallback"`
+	CtaLink      string                `json:"cta_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
-type HeroMainInsertTranslation struct {
-	LanguageId  int    `json:"language_id"`
-	Tag         string `json:"tag"`
-	Description string `json:"description"`
-	Headline    string `json:"headline"`
-	ExploreText string `json:"explore_text"`
+type HeroDropWithTranslations struct {
+	Media        HeroMediaFull         `json:"media"`
+	ReleaseAt    time.Time             `json:"release_at"`
+	ExploreLink  string                `json:"explore_link"`
+	Tag          string                `json:"tag"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
-type HeroFeaturedProductsInsertTranslation struct {
-	LanguageId  int    `json:"language_id"`
-	Headline    string `json:"headline"`
-	ExploreText string `json:"explore_text"`
+type HeroLastChanceWithTranslations struct {
+	Products     []Product             `json:"products"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
-type HeroFeaturedProductsTagInsertTranslation struct {
-	LanguageId  int    `json:"language_id"`
-	Headline    string `json:"headline"`
-	ExploreText string `json:"explore_text"`
+type HeroMarqueeWithTranslations struct {
+	Link         string                `json:"link"`
+	Speed        int                   `json:"speed"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
-type HeroFeaturedArchiveInsertTranslation struct {
-	LanguageId  int    `json:"language_id"`
-	Headline    string `json:"headline"`
-	ExploreText string `json:"explore_text"`
+type HeroNewArrivalsWithTranslations struct {
+	Products     []Product             `json:"products"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
+
+type HeroSlideshowWithTranslations struct {
+	Slides     []HeroSingleWithTranslations `json:"slides"`
+	IntervalMs int                          `json:"interval_ms"`
+}
+
+type HeroMosaicWithTranslations struct {
+	Tiles   []HeroSingleWithTranslations `json:"tiles"`
+	Columns int                          `json:"columns"`
+}
+
+type HeroSplitWithTranslations struct {
+	Media     HeroSingleWithTranslations `json:"media"`
+	Products  []Product                  `json:"products"`
+	MediaLeft bool                       `json:"media_left"`
+}
+
+type HeroVideoWithTranslations struct {
+	Media        MediaFull             `json:"media"`
+	PosterMedia  MediaFull             `json:"poster_media"`
+	Autoplay     bool                  `json:"autoplay"`
+	Loop         bool                  `json:"loop"`
+	Muted        bool                  `json:"muted"`
+	CtaLink      string                `json:"cta_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroProductSpotlightWithTranslations struct {
+	Product      Product               `json:"product"`
+	Media        HeroMediaFull         `json:"media"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroNewsletterWithTranslations struct {
+	Media        HeroMediaFull         `json:"media"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroStatementWithTranslations struct {
+	Media        HeroMediaFull         `json:"media"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroLookbookWithTranslations struct {
+	Frames       []HeroSingleWithTranslations `json:"frames"`
+	ExploreLink  string                       `json:"explore_link"`
+	Translations []HeroCopyTranslation        `json:"translations"`
+}
+
+// ─── translations (nav still carries its own minimal shape) ─────────────────
 
 type NavFeaturedEntityInsertTranslation struct {
 	LanguageId  int    `json:"language_id"`
 	ExploreText string `json:"explore_text"`
 }
 
+// ─── write side (insert) — this is what is persisted in the hero table ──────
+
 type HeroFullInsert struct {
-	Entities    []HeroEntityInsert
-	NavFeatured NavFeaturedInsert
+	Entities    []HeroEntityInsert `json:"entities"`
+	NavFeatured NavFeaturedInsert  `json:"nav_featured"`
 }
-
-type HeroType int32
-
-const (
-	HeroTypeUnknown             HeroType = 0
-	HeroTypeSingle              HeroType = 1
-	HeroTypeDouble              HeroType = 2
-	HeroTypeMain                HeroType = 3
-	HeroTypeFeaturedProducts    HeroType = 4
-	HeroTypeFeaturedProductsTag HeroType = 5
-	HeroTypeFeaturedArchive     HeroType = 6
-)
 
 type HeroEntityInsert struct {
 	Type                HeroType                      `json:"type"`
@@ -127,13 +255,27 @@ type HeroEntityInsert struct {
 	FeaturedProducts    HeroFeaturedProductsInsert    `json:"featured_products"`
 	FeaturedProductsTag HeroFeaturedProductsTagInsert `json:"featured_products_tag"`
 	FeaturedArchive     HeroFeaturedArchiveInsert     `json:"featured_archive"`
+	Embed               HeroEmbedInsert               `json:"embed"`
+	Drop                HeroDropInsert                `json:"drop"`
+	LastChance          HeroLastChanceInsert          `json:"last_chance"`
+	Marquee             HeroMarqueeInsert             `json:"marquee"`
+	NewArrivals         HeroNewArrivalsInsert         `json:"new_arrivals"`
+	Slideshow           HeroSlideshowInsert           `json:"slideshow"`
+	Mosaic              HeroMosaicInsert              `json:"mosaic"`
+	Split               HeroSplitInsert               `json:"split"`
+	Video               HeroVideoInsert               `json:"video"`
+	ProductSpotlight    HeroProductSpotlightInsert    `json:"product_spotlight"`
+	Newsletter          HeroNewsletterInsert          `json:"newsletter"`
+	Statement           HeroStatementInsert           `json:"statement"`
+	Lookbook            HeroLookbookInsert            `json:"lookbook"`
+	Audience            HeroAudience                  `json:"audience"`
+	MinTierId           int                           `json:"min_tier_id"`
 }
 
 type HeroSingleInsert struct {
-	MediaPortraitId  int                           `json:"media_portrait_id"`
-	MediaLandscapeId int                           `json:"media_landscape_id"`
-	ExploreLink      string                        `json:"explore_link"`
-	Translations     []HeroSingleInsertTranslation `json:"translations"`
+	Media        HeroMedia             `json:"media"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
 type HeroDoubleInsert struct {
@@ -142,39 +284,110 @@ type HeroDoubleInsert struct {
 }
 
 type HeroMainInsert struct {
-	MediaPortraitId  int                         `json:"media_portrait_id"`
-	MediaLandscapeId int                         `json:"media_landscape_id"`
-	ExploreLink      string                      `json:"explore_link"`
-	Translations     []HeroMainInsertTranslation `json:"translations"`
-}
-
-type HeroFeaturedProducts struct {
-	Products    []Product `json:"products"`
-	Headline    string    `json:"headline"`
-	ExploreText string    `json:"explore_text"`
-	ExploreLink string    `json:"explore_link"`
-}
-
-type HeroFeaturedProductsTag struct {
-	Tag      string               `json:"tag"`
-	Products HeroFeaturedProducts `json:"products"`
+	Media        HeroMedia             `json:"media"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
 type HeroFeaturedProductsInsert struct {
-	ProductIDs   []int                                   `json:"product_ids"`
-	ExploreLink  string                                  `json:"explore_link"`
-	Translations []HeroFeaturedProductsInsertTranslation `json:"translations"`
+	ProductIDs   []int                 `json:"product_ids"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
 type HeroFeaturedProductsTagInsert struct {
-	Tag          string                                     `json:"tag"`
-	Translations []HeroFeaturedProductsTagInsertTranslation `json:"translations"`
+	Tag          string                `json:"tag"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
 type HeroFeaturedArchiveInsert struct {
-	ArchiveId    int                                    `json:"archive_id"`
-	Tag          string                                 `json:"tag"`
-	Translations []HeroFeaturedArchiveInsertTranslation `json:"translations"`
+	ArchiveId    int                   `json:"archive_id"`
+	Tag          string                `json:"tag"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroEmbedInsert struct {
+	EmbedUrl     string                `json:"embed_url"`
+	Fallback     HeroMedia             `json:"fallback"`
+	CtaLink      string                `json:"cta_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroDropInsert struct {
+	Media        HeroMedia             `json:"media"`
+	ReleaseAt    time.Time             `json:"release_at"`
+	ExploreLink  string                `json:"explore_link"`
+	Tag          string                `json:"tag"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroLastChanceInsert struct {
+	StockThreshold int                   `json:"stock_threshold"`
+	Limit          int                   `json:"limit"`
+	ExploreLink    string                `json:"explore_link"`
+	Translations   []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroMarqueeInsert struct {
+	Link         string                `json:"link"`
+	Speed        int                   `json:"speed"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroNewArrivalsInsert struct {
+	Limit        int                   `json:"limit"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroSlideshowInsert struct {
+	Slides     []HeroSingleInsert `json:"slides"`
+	IntervalMs int                `json:"interval_ms"`
+}
+
+type HeroMosaicInsert struct {
+	Tiles   []HeroSingleInsert `json:"tiles"`
+	Columns int                `json:"columns"`
+}
+
+type HeroSplitInsert struct {
+	Media      HeroSingleInsert `json:"media"`
+	ProductIDs []int            `json:"product_ids"`
+	MediaLeft  bool             `json:"media_left"`
+}
+
+type HeroVideoInsert struct {
+	MediaId       int                   `json:"media_id"`
+	PosterMediaId int                   `json:"poster_media_id"`
+	Autoplay      bool                  `json:"autoplay"`
+	Loop          bool                  `json:"loop"`
+	Muted         bool                  `json:"muted"`
+	CtaLink       string                `json:"cta_link"`
+	Translations  []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroProductSpotlightInsert struct {
+	ProductId    int                   `json:"product_id"`
+	Media        HeroMedia             `json:"media"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroNewsletterInsert struct {
+	Media        HeroMedia             `json:"media"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroStatementInsert struct {
+	Media        HeroMedia             `json:"media"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
+}
+
+type HeroLookbookInsert struct {
+	Frames       []HeroSingleInsert    `json:"frames"`
+	ExploreLink  string                `json:"explore_link"`
+	Translations []HeroCopyTranslation `json:"translations"`
 }
 
 type NavFeaturedInsert struct {

--- a/internal/entity/hero.go
+++ b/internal/entity/hero.go
@@ -5,11 +5,15 @@ import "time"
 // ─── shared fragments ───────────────────────────────────────────────────────
 
 // HeroMedia is a portrait/landscape media pair addressed by id (write side).
-// DisableOverlay lives here so the scrim can be toggled per media slot.
+// The per-slot presentation modifiers live here: DisableOverlay toggles the
+// scrim, DisableTint toggles the frontend's background colour tint, and Stroke
+// toggles a border/outline around the media.
 type HeroMedia struct {
 	PortraitId     int  `json:"portrait_id"`
 	LandscapeId    int  `json:"landscape_id"`
 	DisableOverlay bool `json:"disable_overlay"`
+	DisableTint    bool `json:"disable_tint"`
+	Stroke         bool `json:"stroke"`
 }
 
 // HeroMediaFull is the resolved form of HeroMedia (read side).
@@ -17,6 +21,8 @@ type HeroMediaFull struct {
 	Portrait       MediaFull `json:"portrait"`
 	Landscape      MediaFull `json:"landscape"`
 	DisableOverlay bool      `json:"disable_overlay"`
+	DisableTint    bool      `json:"disable_tint"`
+	Stroke         bool      `json:"stroke"`
 }
 
 // HeroCopyTranslation is the single, shared translation for every hero block.

--- a/internal/store/content/hero.go
+++ b/internal/store/content/hero.go
@@ -238,7 +238,7 @@ func filterVisibleProducts(products []entity.Product) []entity.Product {
 
 func buildHeroData(ctx context.Context, rep dependency.Repository, hfi entity.HeroFullInsert) (*entity.HeroFullWithTranslations, error) {
 	entities := make([]entity.HeroEntityWithTranslations, 0, len(hfi.Entities))
-	for n, e := range hfi.Entities {
+	for _, e := range hfi.Entities {
 		before := len(entities)
 		switch e.Type {
 		case entity.HeroTypeSingle:
@@ -272,10 +272,7 @@ func buildHeroData(ctx context.Context, rep dependency.Repository, hfi entity.He
 			})
 
 		case entity.HeroTypeMain:
-			// main is only allowed at the first position
-			if n != 0 {
-				continue
-			}
+			// main can now appear any number of times and at any position
 			if heroMediaEmpty(e.Main.Media) {
 				continue
 			}

--- a/internal/store/content/hero.go
+++ b/internal/store/content/hero.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
-	"time"
 
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
@@ -16,99 +15,38 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
 )
 
-// RefreshHero re-builds and updates hero from existing data.
+// RefreshHero re-resolves the stored hero (Insert form) and refreshes the cache.
+// With Insert-form storage there is no reverse flatten: we just read what the
+// admin stored and re-run resolution (picking up e.g. media/product changes).
 func (s *Store) RefreshHero(ctx context.Context) error {
-	hero, err := s.GetHero(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get hero: %w", err)
-	}
-
 	//TODO: update categories count
-
-	heroInsert := entity.HeroFullInsert{
-		Entities:    []entity.HeroEntityInsert{},
-		NavFeatured: entity.NavFeaturedInsert{},
-	}
-	for _, e := range hero.Entities {
-		switch e.Type {
-		case entity.HeroTypeFeaturedProducts:
-			ids := make([]int, 0, len(e.FeaturedProducts.Products))
-			for _, p := range e.FeaturedProducts.Products {
-				ids = append(ids, p.Id)
-			}
-			heroInsert.Entities = append(heroInsert.Entities, entity.HeroEntityInsert{Type: e.Type, FeaturedProducts: entity.HeroFeaturedProductsInsert{
-				ProductIDs:   ids,
-				ExploreLink:  e.FeaturedProducts.ExploreLink,
-				Translations: e.FeaturedProducts.Translations,
-			}})
-		case entity.HeroTypeFeaturedProductsTag:
-			heroInsert.Entities = append(heroInsert.Entities, entity.HeroEntityInsert{Type: e.Type, FeaturedProductsTag: entity.HeroFeaturedProductsTagInsert{
-				Tag:          e.FeaturedProductsTag.Tag,
-				Translations: e.FeaturedProductsTag.Translations,
-			}})
-		case entity.HeroTypeMain:
-			heroInsert.Entities = append(heroInsert.Entities, entity.HeroEntityInsert{Type: e.Type, Main: entity.HeroMainInsert{
-				MediaPortraitId:  e.Main.Single.MediaPortrait.Id,
-				MediaLandscapeId: e.Main.Single.MediaLandscape.Id,
-				ExploreLink:      e.Main.Single.ExploreLink,
-				Translations:     e.Main.Translations,
-			}})
-		case entity.HeroTypeSingle:
-			heroInsert.Entities = append(heroInsert.Entities, entity.HeroEntityInsert{Type: e.Type, Single: entity.HeroSingleInsert{
-				MediaPortraitId:  e.Single.MediaPortrait.Id,
-				MediaLandscapeId: e.Single.MediaLandscape.Id,
-				ExploreLink:      e.Single.ExploreLink,
-				Translations:     e.Single.Translations,
-			}})
-		case entity.HeroTypeDouble:
-			heroInsert.Entities = append(heroInsert.Entities, entity.HeroEntityInsert{Type: e.Type, Double: entity.HeroDoubleInsert{
-				Left: entity.HeroSingleInsert{
-					MediaPortraitId:  e.Double.Left.MediaPortrait.Id,
-					MediaLandscapeId: e.Double.Left.MediaLandscape.Id,
-					ExploreLink:      e.Double.Left.ExploreLink,
-					Translations:     e.Double.Left.Translations,
-				},
-				Right: entity.HeroSingleInsert{
-					MediaPortraitId:  e.Double.Right.MediaPortrait.Id,
-					MediaLandscapeId: e.Double.Right.MediaLandscape.Id,
-					ExploreLink:      e.Double.Right.ExploreLink,
-					Translations:     e.Double.Right.Translations,
-				},
-			}})
-		case entity.HeroTypeFeaturedArchive:
-			heroInsert.Entities = append(heroInsert.Entities, entity.HeroEntityInsert{Type: e.Type, FeaturedArchive: entity.HeroFeaturedArchiveInsert{
-				ArchiveId:    e.FeaturedArchive.Archive.ArchiveList.Id,
-				Tag:          e.FeaturedArchive.Tag,
-				Translations: e.FeaturedArchive.Translations,
-			}})
-		}
-	}
-
-	err = s.SetHero(ctx, heroInsert)
+	hfi, legacy, err := s.getHeroInsert(ctx)
 	if err != nil {
+		return fmt.Errorf("failed to get hero insert: %w", err)
+	}
+	if legacy {
+		// Never overwrite a legacy row from an incidental refresh — that would
+		// destroy the admin's configured hero. It is replaced only by a
+		// deliberate admin SetHero (AddHero).
+		slog.WarnContext(ctx, "skipping RefreshHero: hero is in legacy format; not overwriting to preserve data")
+		return nil
+	}
+	if hfi == nil {
+		return nil // nothing stored yet
+	}
+	if err := s.SetHero(ctx, *hfi); err != nil {
 		return fmt.Errorf("failed to set hero: %w", err)
 	}
-
 	return nil
 }
 
 func isValidHeroType(t entity.HeroType) bool {
-	switch t {
-	case entity.HeroTypeSingle,
-		entity.HeroTypeDouble,
-		entity.HeroTypeMain,
-		entity.HeroTypeFeaturedProducts,
-		entity.HeroTypeFeaturedProductsTag,
-		entity.HeroTypeFeaturedArchive:
-		return true
-	default:
-		return false
-	}
+	return t >= entity.HeroTypeSingle && t <= entity.HeroTypeLookbook
 }
 
-// SetHero sets hero content with validation and transaction safety.
+// SetHero persists the hero in its Insert form (the source of truth) and
+// refreshes the resolved cache in the same transaction.
 func (s *Store) SetHero(ctx context.Context, hfi entity.HeroFullInsert) error {
-	// Validate hero types
 	for _, e := range hfi.Entities {
 		if !isValidHeroType(e.Type) {
 			return fmt.Errorf("invalid hero type: %d", e.Type)
@@ -116,203 +54,259 @@ func (s *Store) SetHero(ctx context.Context, hfi entity.HeroFullInsert) error {
 	}
 
 	return s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
-		// Delete existing hero data
-		err := deleteExistingHeroData(ctx, rep)
-		if err != nil {
+		if err := deleteExistingHeroData(ctx, rep); err != nil {
 			return fmt.Errorf("failed to delete hero data: %w", err)
 		}
 
+		if err := insertHeroInsert(ctx, rep, hfi); err != nil {
+			return fmt.Errorf("failed to insert hero data: %w", err)
+		}
+
+		// Resolve once for the cache (frontend reads the resolved form from cache).
 		heroFull, err := buildHeroData(ctx, rep, hfi)
 		if err != nil {
 			return fmt.Errorf("failed to build hero data: %w", err)
 		}
-		slog.Info("heroFull", "heroFull", heroFull)
-
-		if err := insertHeroData(ctx, rep, heroFull); err != nil {
-			return fmt.Errorf("failed to insert hero data: %w", err)
-		}
-
-		// Update cache
-		hero, err := rep.Hero().GetHero(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get hero: %w", err)
-		}
-		cache.UpdateHero(hero)
+		cache.UpdateHero(heroFull)
 
 		return nil
 	})
 }
 
-// GetHero retrieves the current hero configuration.
+// GetHero reads the stored Insert form and resolves it into the read shape.
+// Resolution needs cross-store access (media/products/archive), so it runs
+// inside a (read) transaction to obtain a repository handle.
 func (s *Store) GetHero(ctx context.Context) (*entity.HeroFullWithTranslations, error) {
+	hfi, legacy, err := s.getHeroInsert(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if legacy {
+		slog.WarnContext(ctx, "hero is in legacy (pre-L2) format; serving empty until re-saved from admin (legacy data preserved)")
+		return &entity.HeroFullWithTranslations{}, nil
+	}
+	if hfi == nil {
+		return &entity.HeroFullWithTranslations{}, nil
+	}
+
+	var heroFull *entity.HeroFullWithTranslations
+	err = s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
+		heroFull, err = buildHeroData(ctx, rep, *hfi)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve hero: %w", err)
+	}
+	return heroFull, nil
+}
+
+// heroSchemaVersion identifies the persisted hero payload shape. Bump it when
+// the stored HeroFullInsert JSON changes incompatibly. Rows without a matching
+// version are treated as legacy and are never auto-overwritten.
+const heroSchemaVersion = 2
+
+// storedHero is the on-disk envelope: a schema version plus the Insert-form hero.
+// Pre-L2 rows have no envelope (they stored the resolved shape at the top level),
+// so they decode with SchemaVersion == 0 and are recognised as legacy.
+type storedHero struct {
+	SchemaVersion int                   `json:"schema_version"`
+	Hero          entity.HeroFullInsert `json:"hero"`
+}
+
+// getHeroInsert reads the stored hero envelope. It returns (insert, legacy, err):
+//   - legacy == true means the row predates L2 Insert-form storage (resolved
+//     shape, no schema version). Such rows are NOT auto-migratable and MUST NOT
+//     be overwritten by an incidental RefreshHero — only a deliberate admin
+//     SetHero replaces them. Callers should serve an empty hero in that case.
+//   - a genuine JSON error is propagated (fail fast), not silently swallowed.
+func (s *Store) getHeroInsert(ctx context.Context) (*entity.HeroFullInsert, bool, error) {
 	query := `SELECT data FROM hero`
 
-	type hero struct {
-		Id        int       `db:"id"`
-		CreatedAt time.Time `db:"created_at"`
-		Data      []byte    `db:"data"`
+	type heroRow struct {
+		Data []byte `db:"data"`
 	}
 
-	heroRaw, err := storeutil.QueryNamedOne[hero](ctx, s.DB, query, nil)
+	heroRaw, err := storeutil.QueryNamedOne[heroRow](ctx, s.DB, query, nil)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			slog.Error("no hero data found")
-			return &entity.HeroFullWithTranslations{}, nil
+			return nil, false, nil
 		}
-		return nil, fmt.Errorf("failed to get hero: %w", err)
-	}
-	heroFull := entity.HeroFullWithTranslations{}
-
-	err = json.Unmarshal(heroRaw.Data, &heroFull)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal hero data: %w %s", err, string(heroRaw.Data))
+		return nil, false, fmt.Errorf("failed to get hero: %w", err)
 	}
 
-	return &heroFull, nil
+	var env storedHero
+	if err := json.Unmarshal(heroRaw.Data, &env); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal hero data: %w", err)
+	}
+	if env.SchemaVersion < heroSchemaVersion {
+		// Legacy (pre-L2) resolved-shape row: preserve it, do not overwrite.
+		return nil, true, nil
+	}
+	return &env.Hero, false, nil
 }
 
 func deleteExistingHeroData(ctx context.Context, rep dependency.Repository) error {
 	query := `DELETE FROM hero`
-	_, err := rep.DB().ExecContext(ctx, query)
-	if err != nil {
+	if _, err := rep.DB().ExecContext(ctx, query); err != nil {
 		return fmt.Errorf("failed to delete hero data: %w", err)
 	}
-
 	return nil
 }
 
-func buildHeroData(ctx context.Context, rep dependency.Repository, heroFullInsert entity.HeroFullInsert) (*entity.HeroFullWithTranslations, error) {
+func insertHeroInsert(ctx context.Context, rep dependency.Repository, hfi entity.HeroFullInsert) error {
+	jsonData, err := json.Marshal(storedHero{SchemaVersion: heroSchemaVersion, Hero: hfi})
+	if err != nil {
+		return fmt.Errorf("failed to marshal hero insert: %w", err)
+	}
+	query := `INSERT INTO hero (data) VALUES (:data)`
+	if _, err := rep.DB().NamedExecContext(ctx, query, map[string]any{"data": jsonData}); err != nil {
+		return fmt.Errorf("failed to insert hero data: %w", err)
+	}
+	return nil
+}
 
-	entities := make([]entity.HeroEntityWithTranslations, 0, len(heroFullInsert.Entities))
-	for n, e := range heroFullInsert.Entities {
+// ─── resolvers (shared across block types) ──────────────────────────────────
 
+// heroMediaEmpty reports whether a media slot has no image referenced at all.
+func heroMediaEmpty(m entity.HeroMedia) bool {
+	return m.PortraitId == 0 && m.LandscapeId == 0
+}
+
+// resolveHeroMedia turns a HeroMedia (ids) into a HeroMediaFull. A missing
+// portrait/landscape id falls back to the other, matching the prior behaviour.
+func resolveHeroMedia(ctx context.Context, rep dependency.Repository, m entity.HeroMedia) (entity.HeroMediaFull, error) {
+	portraitId, landscapeId := m.PortraitId, m.LandscapeId
+	if portraitId == 0 {
+		portraitId = landscapeId
+	}
+	if landscapeId == 0 {
+		landscapeId = portraitId
+	}
+
+	full := entity.HeroMediaFull{DisableOverlay: m.DisableOverlay}
+	if portraitId != 0 {
+		pm, err := rep.Media().GetMediaById(ctx, portraitId)
+		if err != nil {
+			return full, fmt.Errorf("failed to get portrait media %d: %w", portraitId, err)
+		}
+		full.Portrait = *pm
+	}
+	if landscapeId != 0 {
+		lm, err := rep.Media().GetMediaById(ctx, landscapeId)
+		if err != nil {
+			return full, fmt.Errorf("failed to get landscape media %d: %w", landscapeId, err)
+		}
+		full.Landscape = *lm
+	}
+	return full, nil
+}
+
+func resolveHeroSingle(ctx context.Context, rep dependency.Repository, s entity.HeroSingleInsert) (entity.HeroSingleWithTranslations, error) {
+	media, err := resolveHeroMedia(ctx, rep, s.Media)
+	if err != nil {
+		return entity.HeroSingleWithTranslations{}, err
+	}
+	return entity.HeroSingleWithTranslations{
+		Media:        media,
+		ExploreLink:  s.ExploreLink,
+		Translations: s.Translations,
+	}, nil
+}
+
+func resolveHeroSingleSlice(ctx context.Context, rep dependency.Repository, in []entity.HeroSingleInsert) ([]entity.HeroSingleWithTranslations, error) {
+	out := make([]entity.HeroSingleWithTranslations, 0, len(in))
+	for i := range in {
+		s, err := resolveHeroSingle(ctx, rep, in[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func filterVisibleProducts(products []entity.Product) []entity.Product {
+	prds := make([]entity.Product, 0, len(products))
+	for _, p := range products {
+		if p.ProductDisplay.ProductBody.ProductBodyInsert.Hidden.Valid && p.ProductDisplay.ProductBody.ProductBodyInsert.Hidden.Bool {
+			continue
+		}
+		prds = append(prds, p)
+	}
+	return prds
+}
+
+func buildHeroData(ctx context.Context, rep dependency.Repository, hfi entity.HeroFullInsert) (*entity.HeroFullWithTranslations, error) {
+	entities := make([]entity.HeroEntityWithTranslations, 0, len(hfi.Entities))
+	for n, e := range hfi.Entities {
+		before := len(entities)
 		switch e.Type {
 		case entity.HeroTypeSingle:
-			portraitMedia, err := rep.Media().GetMediaById(ctx, e.Single.MediaPortraitId)
-			if err != nil {
-				slog.Error("failed to get media by id",
-					slog.String("err", err.Error()),
-					slog.Int("media_id", e.Single.MediaPortraitId))
+			if heroMediaEmpty(e.Single.Media) {
 				continue
 			}
-			landscapeMedia, err := rep.Media().GetMediaById(ctx, e.Single.MediaLandscapeId)
+			single, err := resolveHeroSingle(ctx, rep, e.Single)
 			if err != nil {
-				slog.Error("failed to get media by id",
-					slog.String("err", err.Error()),
-					slog.Int("media_id", e.Single.MediaLandscapeId))
+				slog.ErrorContext(ctx, "failed to resolve single hero, skipping", slog.String("err", err.Error()))
 				continue
 			}
+			entities = append(entities, entity.HeroEntityWithTranslations{Type: e.Type, Single: &single})
 
-			entities = append(entities, entity.HeroEntityWithTranslations{
-				Type: e.Type,
-				Single: &entity.HeroSingleWithTranslations{
-					MediaPortrait:  *portraitMedia,
-					MediaLandscape: *landscapeMedia,
-					ExploreLink:    e.Single.ExploreLink,
-					Translations:   e.Single.Translations,
-				},
-			})
 		case entity.HeroTypeDouble:
-
-			leftMediaId := e.Double.Left.MediaPortraitId
-			if leftMediaId == 0 {
-				leftMediaId = e.Double.Left.MediaLandscapeId
-			}
-
-			leftMedia, err := rep.Media().GetMediaById(ctx, leftMediaId)
-			if err != nil {
-				slog.Error("failed to get media by id",
-					slog.String("err", err.Error()),
-					slog.Int("media_id", leftMediaId))
+			if heroMediaEmpty(e.Double.Left.Media) || heroMediaEmpty(e.Double.Right.Media) {
 				continue
 			}
-
-			rightMediaId := e.Double.Right.MediaPortraitId
-			if rightMediaId == 0 {
-				rightMediaId = e.Double.Right.MediaLandscapeId
-			}
-
-			rightMedia, err := rep.Media().GetMediaById(ctx, rightMediaId)
+			left, err := resolveHeroSingle(ctx, rep, e.Double.Left)
 			if err != nil {
-				slog.Error("failed to get media by id",
-					slog.String("err", err.Error()),
-					slog.Int("media_id", rightMediaId))
+				slog.ErrorContext(ctx, "failed to resolve double hero left, skipping", slog.String("err", err.Error()))
 				continue
 			}
-
+			right, err := resolveHeroSingle(ctx, rep, e.Double.Right)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve double hero right, skipping", slog.String("err", err.Error()))
+				continue
+			}
 			entities = append(entities, entity.HeroEntityWithTranslations{
-				Type: e.Type,
-				Double: &entity.HeroDoubleWithTranslations{
-					Left: entity.HeroSingleWithTranslations{
-						MediaPortrait:  *leftMedia,
-						MediaLandscape: *leftMedia,
-						ExploreLink:    e.Double.Left.ExploreLink,
-						Translations:   e.Double.Left.Translations,
-					},
-					Right: entity.HeroSingleWithTranslations{
-						MediaPortrait:  *rightMedia,
-						MediaLandscape: *rightMedia,
-						ExploreLink:    e.Double.Right.ExploreLink,
-						Translations:   e.Double.Right.Translations,
-					},
-				},
+				Type:   e.Type,
+				Double: &entity.HeroDoubleWithTranslations{Left: left, Right: right},
 			})
+
 		case entity.HeroTypeMain:
-			// main add should be only on first position
+			// main is only allowed at the first position
 			if n != 0 {
 				continue
 			}
-			portraitMedia, err := rep.Media().GetMediaById(ctx, e.Main.MediaPortraitId)
-			if err != nil {
-				slog.Error("failed to get media by id",
-					slog.String("err", err.Error()),
-					slog.Int("media_id", e.Main.MediaPortraitId))
+			if heroMediaEmpty(e.Main.Media) {
 				continue
 			}
-
-			landscapeMedia, err := rep.Media().GetMediaById(ctx, e.Main.MediaLandscapeId)
+			media, err := resolveHeroMedia(ctx, rep, e.Main.Media)
 			if err != nil {
-				slog.Error("failed to get media by id",
-					slog.String("err", err.Error()),
-					slog.Int("media_id", e.Main.MediaLandscapeId))
+				slog.ErrorContext(ctx, "failed to resolve main hero, skipping", slog.String("err", err.Error()))
 				continue
 			}
-
 			entities = append(entities, entity.HeroEntityWithTranslations{
 				Type: e.Type,
 				Main: &entity.HeroMainWithTranslations{
-					Single: entity.HeroSingleWithTranslations{
-						MediaPortrait:  *portraitMedia,
-						MediaLandscape: *landscapeMedia,
-						ExploreLink:    e.Main.ExploreLink,
-						Translations:   []entity.HeroSingleInsertTranslation{}, // Main doesn't use single translations
-					},
+					Media:        media,
+					ExploreLink:  e.Main.ExploreLink,
 					Translations: e.Main.Translations,
 				},
 			})
+
 		case entity.HeroTypeFeaturedProducts:
 			if len(e.FeaturedProducts.ProductIDs) == 0 {
-				slog.Error("no product ids provided for featured products skipping",
-					slog.Int("product_ids", len(e.FeaturedProducts.ProductIDs)))
+				slog.ErrorContext(ctx, "no product ids provided for featured products, skipping")
 				continue
 			}
-
 			products, err := rep.Products().GetProductsByIds(ctx, e.FeaturedProducts.ProductIDs)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get products by ids: %w", err)
+				slog.ErrorContext(ctx, "failed to get featured products, skipping", slog.String("err", err.Error()))
+				continue
 			}
-			prds := make([]entity.Product, 0, len(products))
-			for _, p := range products {
-				if p.ProductDisplay.ProductBody.ProductBodyInsert.Hidden.Valid && p.ProductDisplay.ProductBody.ProductBodyInsert.Hidden.Bool {
-					continue
-				}
-				prds = append(prds, p)
-			}
-
+			prds := filterVisibleProducts(products)
 			if len(prds) == 0 {
 				continue
 			}
-
 			entities = append(entities, entity.HeroEntityWithTranslations{
 				Type: e.Type,
 				FeaturedProducts: &entity.HeroFeaturedProductsWithTranslations{
@@ -321,117 +315,343 @@ func buildHeroData(ctx context.Context, rep dependency.Repository, heroFullInser
 					Translations: e.FeaturedProducts.Translations,
 				},
 			})
+
 		case entity.HeroTypeFeaturedProductsTag:
 			if e.FeaturedProductsTag.Tag == "" {
 				continue
 			}
-
 			products, err := rep.Products().GetProductsByTag(ctx, e.FeaturedProductsTag.Tag)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get products by ids: %w", err)
+				slog.ErrorContext(ctx, "failed to get products by tag, skipping", slog.String("err", err.Error()))
+				continue
 			}
-
-			prds := make([]entity.Product, 0, len(products))
-			for _, p := range products {
-				if p.ProductDisplay.ProductBody.ProductBodyInsert.Hidden.Valid && p.ProductDisplay.ProductBody.ProductBodyInsert.Hidden.Bool {
-					continue
-				}
-				prds = append(prds, p)
-			}
-
+			prds := filterVisibleProducts(products)
 			if len(prds) == 0 {
 				continue
 			}
-
 			entities = append(entities, entity.HeroEntityWithTranslations{
 				Type: e.Type,
 				FeaturedProductsTag: &entity.HeroFeaturedProductsTagWithTranslations{
 					Tag: e.FeaturedProductsTag.Tag,
 					Products: entity.HeroFeaturedProductsWithTranslations{
 						Products:     prds,
-						ExploreLink:  "",                                               // No explore link for tag-based products
-						Translations: []entity.HeroFeaturedProductsInsertTranslation{}, // Products has its own translations
+						ExploreLink:  "",  // tag-based products carry no explore link
+						Translations: nil, // outer block carries the translations
 					},
 					Translations: e.FeaturedProductsTag.Translations,
 				},
 			})
-		case entity.HeroTypeFeaturedArchive:
-			if e.FeaturedArchive.ArchiveId == 0 {
-				slog.Error("failed to get archive by id",
-					slog.Int("archive_id", e.FeaturedArchive.ArchiveId))
-			}
 
+		case entity.HeroTypeFeaturedArchive:
 			archive, err := rep.Archive().GetArchiveById(ctx, e.FeaturedArchive.ArchiveId)
 			if err != nil {
-				slog.Error("failed to get archive by id",
+				slog.ErrorContext(ctx, "failed to get archive by id, skipping",
 					slog.String("err", err.Error()),
 					slog.Int("archive_id", e.FeaturedArchive.ArchiveId))
 				continue
 			}
-
 			entities = append(entities, entity.HeroEntityWithTranslations{
 				Type: e.Type,
 				FeaturedArchive: &entity.HeroFeaturedArchiveWithTranslations{
 					Archive:      *archive,
 					Tag:          e.FeaturedArchive.Tag,
-					Headline:     "", // Will be populated from translations when needed
-					ExploreText:  "", // Will be populated from translations when needed
 					Translations: e.FeaturedArchive.Translations,
 				},
 			})
+
+		case entity.HeroTypeEmbed:
+			fallback, err := resolveHeroMedia(ctx, rep, e.Embed.Fallback)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve embed fallback, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				Embed: &entity.HeroEmbedWithTranslations{
+					EmbedUrl:     e.Embed.EmbedUrl,
+					Fallback:     fallback,
+					CtaLink:      e.Embed.CtaLink,
+					Translations: e.Embed.Translations,
+				},
+			})
+
+		case entity.HeroTypeDrop:
+			media, err := resolveHeroMedia(ctx, rep, e.Drop.Media)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve drop media, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				Drop: &entity.HeroDropWithTranslations{
+					Media:        media,
+					ReleaseAt:    e.Drop.ReleaseAt,
+					ExploreLink:  e.Drop.ExploreLink,
+					Tag:          e.Drop.Tag,
+					Translations: e.Drop.Translations,
+				},
+			})
+
+		case entity.HeroTypeLastChance:
+			products, err := rep.Products().GetLowStockProducts(ctx, e.LastChance.StockThreshold, e.LastChance.Limit)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to get low stock products, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			prds := filterVisibleProducts(products)
+			if len(prds) == 0 {
+				continue
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				LastChance: &entity.HeroLastChanceWithTranslations{
+					Products:     prds,
+					ExploreLink:  e.LastChance.ExploreLink,
+					Translations: e.LastChance.Translations,
+				},
+			})
+
+		case entity.HeroTypeMarquee:
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				Marquee: &entity.HeroMarqueeWithTranslations{
+					Link:         e.Marquee.Link,
+					Speed:        e.Marquee.Speed,
+					Translations: e.Marquee.Translations,
+				},
+			})
+
+		case entity.HeroTypeNewArrivals:
+			limit := e.NewArrivals.Limit
+			if limit <= 0 {
+				limit = 8
+			}
+			products, _, err := rep.Products().GetProductsPaged(ctx, limit, 0, []entity.SortFactor{entity.CreatedAt}, entity.Descending, nil, false)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to get newest products, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			prds := filterVisibleProducts(products)
+			if len(prds) == 0 {
+				continue
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				NewArrivals: &entity.HeroNewArrivalsWithTranslations{
+					Products:     prds,
+					ExploreLink:  e.NewArrivals.ExploreLink,
+					Translations: e.NewArrivals.Translations,
+				},
+			})
+
+		case entity.HeroTypeSlideshow:
+			slides, err := resolveHeroSingleSlice(ctx, rep, e.Slideshow.Slides)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve slideshow slides, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			if len(slides) == 0 {
+				continue
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				Slideshow: &entity.HeroSlideshowWithTranslations{
+					Slides:     slides,
+					IntervalMs: e.Slideshow.IntervalMs,
+				},
+			})
+
+		case entity.HeroTypeMosaic:
+			tiles, err := resolveHeroSingleSlice(ctx, rep, e.Mosaic.Tiles)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve mosaic tiles, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			if len(tiles) == 0 {
+				continue
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				Mosaic: &entity.HeroMosaicWithTranslations{
+					Tiles:   tiles,
+					Columns: e.Mosaic.Columns,
+				},
+			})
+
+		case entity.HeroTypeSplit:
+			media, err := resolveHeroSingle(ctx, rep, e.Split.Media)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve split media, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			var prds []entity.Product
+			if len(e.Split.ProductIDs) > 0 {
+				products, err := rep.Products().GetProductsByIds(ctx, e.Split.ProductIDs)
+				if err != nil {
+					slog.ErrorContext(ctx, "failed to get split products, showing media only", slog.String("err", err.Error()))
+				} else {
+					prds = filterVisibleProducts(products)
+				}
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				Split: &entity.HeroSplitWithTranslations{
+					Media:     media,
+					Products:  prds,
+					MediaLeft: e.Split.MediaLeft,
+				},
+			})
+
+		case entity.HeroTypeVideo:
+			if e.Video.MediaId == 0 {
+				slog.ErrorContext(ctx, "video hero has no media id, skipping")
+				continue
+			}
+			videoMedia, err := rep.Media().GetMediaById(ctx, e.Video.MediaId)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to get video media, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			video := &entity.HeroVideoWithTranslations{
+				Media:        *videoMedia,
+				Autoplay:     e.Video.Autoplay,
+				Loop:         e.Video.Loop,
+				Muted:        e.Video.Muted,
+				CtaLink:      e.Video.CtaLink,
+				Translations: e.Video.Translations,
+			}
+			if e.Video.PosterMediaId != 0 {
+				poster, err := rep.Media().GetMediaById(ctx, e.Video.PosterMediaId)
+				if err != nil {
+					slog.ErrorContext(ctx, "failed to get video poster media", slog.String("err", err.Error()))
+				} else {
+					video.PosterMedia = *poster
+				}
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{Type: e.Type, Video: video})
+
+		case entity.HeroTypeProductSpotlight:
+			if e.ProductSpotlight.ProductId == 0 {
+				slog.ErrorContext(ctx, "product spotlight has no product id, skipping")
+				continue
+			}
+			products, err := rep.Products().GetProductsByIds(ctx, []int{e.ProductSpotlight.ProductId})
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to get spotlight product, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			prds := filterVisibleProducts(products)
+			if len(prds) == 0 {
+				continue
+			}
+			media, err := resolveHeroMedia(ctx, rep, e.ProductSpotlight.Media)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve spotlight media, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				ProductSpotlight: &entity.HeroProductSpotlightWithTranslations{
+					Product:      prds[0],
+					Media:        media,
+					ExploreLink:  e.ProductSpotlight.ExploreLink,
+					Translations: e.ProductSpotlight.Translations,
+				},
+			})
+
+		case entity.HeroTypeNewsletter:
+			media, err := resolveHeroMedia(ctx, rep, e.Newsletter.Media)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve newsletter media, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				Newsletter: &entity.HeroNewsletterWithTranslations{
+					Media:        media,
+					Translations: e.Newsletter.Translations,
+				},
+			})
+
+		case entity.HeroTypeStatement:
+			media, err := resolveHeroMedia(ctx, rep, e.Statement.Media)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve statement media, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				Statement: &entity.HeroStatementWithTranslations{
+					Media:        media,
+					ExploreLink:  e.Statement.ExploreLink,
+					Translations: e.Statement.Translations,
+				},
+			})
+
+		case entity.HeroTypeLookbook:
+			frames, err := resolveHeroSingleSlice(ctx, rep, e.Lookbook.Frames)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve lookbook frames, skipping", slog.String("err", err.Error()))
+				continue
+			}
+			if len(frames) == 0 {
+				continue
+			}
+			entities = append(entities, entity.HeroEntityWithTranslations{
+				Type: e.Type,
+				Lookbook: &entity.HeroLookbookWithTranslations{
+					Frames:       frames,
+					ExploreLink:  e.Lookbook.ExploreLink,
+					Translations: e.Lookbook.Translations,
+				},
+			})
+		}
+
+		// carry the cross-cutting modifiers onto whatever block this iteration
+		// appended (works for every type, old and new)
+		if len(entities) > before {
+			entities[len(entities)-1].Audience = e.Audience
+			entities[len(entities)-1].MinTierId = e.MinTierId
 		}
 	}
+
 	heroFull := entity.HeroFullWithTranslations{
 		Entities: entities,
 		NavFeatured: entity.NavFeaturedWithTranslations{
 			Men: entity.NavFeaturedEntityWithTranslations{
-				FeaturedTag:       heroFullInsert.NavFeatured.Men.FeaturedTag,
-				FeaturedArchiveId: strconv.Itoa(heroFullInsert.NavFeatured.Men.FeaturedArchiveId),
-				Translations:      heroFullInsert.NavFeatured.Men.Translations,
+				FeaturedTag:       hfi.NavFeatured.Men.FeaturedTag,
+				FeaturedArchiveId: strconv.Itoa(hfi.NavFeatured.Men.FeaturedArchiveId),
+				Translations:      hfi.NavFeatured.Men.Translations,
 			},
 			Women: entity.NavFeaturedEntityWithTranslations{
-				FeaturedTag:       heroFullInsert.NavFeatured.Women.FeaturedTag,
-				FeaturedArchiveId: strconv.Itoa(heroFullInsert.NavFeatured.Women.FeaturedArchiveId),
-				Translations:      heroFullInsert.NavFeatured.Women.Translations,
+				FeaturedTag:       hfi.NavFeatured.Women.FeaturedTag,
+				FeaturedArchiveId: strconv.Itoa(hfi.NavFeatured.Women.FeaturedArchiveId),
+				Translations:      hfi.NavFeatured.Women.Translations,
 			},
 		},
 	}
 
-	if heroFullInsert.NavFeatured.Men.MediaId != 0 {
-		menMedia, err := rep.Media().GetMediaById(ctx, heroFullInsert.NavFeatured.Men.MediaId)
+	if hfi.NavFeatured.Men.MediaId != 0 {
+		menMedia, err := rep.Media().GetMediaById(ctx, hfi.NavFeatured.Men.MediaId)
 		if err != nil {
-			slog.Error("failed to get media by id",
+			slog.ErrorContext(ctx, "failed to get nav men media",
 				slog.String("err", err.Error()),
-				slog.Int("media_id", heroFullInsert.NavFeatured.Men.MediaId))
-
+				slog.Int("media_id", hfi.NavFeatured.Men.MediaId))
+		} else {
+			heroFull.NavFeatured.Men.Media = *menMedia
 		}
-		heroFull.NavFeatured.Men.Media = *menMedia
 	}
 
-	if heroFullInsert.NavFeatured.Women.MediaId != 0 {
-		womenMedia, err := rep.Media().GetMediaById(ctx, heroFullInsert.NavFeatured.Women.MediaId)
+	if hfi.NavFeatured.Women.MediaId != 0 {
+		womenMedia, err := rep.Media().GetMediaById(ctx, hfi.NavFeatured.Women.MediaId)
 		if err != nil {
-			slog.Error("failed to get media by id",
+			slog.ErrorContext(ctx, "failed to get nav women media",
 				slog.String("err", err.Error()),
-				slog.Int("media_id", heroFullInsert.NavFeatured.Women.MediaId))
+				slog.Int("media_id", hfi.NavFeatured.Women.MediaId))
+		} else {
+			heroFull.NavFeatured.Women.Media = *womenMedia
 		}
-		heroFull.NavFeatured.Women.Media = *womenMedia
 	}
 
 	return &heroFull, nil
-}
-
-func insertHeroData(ctx context.Context, rep dependency.Repository, hf *entity.HeroFullWithTranslations) error {
-	jsonData, err := json.Marshal(hf)
-	if err != nil {
-		return fmt.Errorf("failed to marshal hero data: %w", err)
-	}
-	query := `INSERT INTO hero (data) VALUES (:data)`
-	_, err = rep.DB().NamedExecContext(ctx, query, map[string]any{
-		"data": jsonData,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to insert hero data: %w", err)
-	}
-	return nil
 }

--- a/internal/store/content/hero.go
+++ b/internal/store/content/hero.go
@@ -183,7 +183,11 @@ func resolveHeroMedia(ctx context.Context, rep dependency.Repository, m entity.H
 		landscapeId = portraitId
 	}
 
-	full := entity.HeroMediaFull{DisableOverlay: m.DisableOverlay}
+	full := entity.HeroMediaFull{
+		DisableOverlay: m.DisableOverlay,
+		DisableTint:    m.DisableTint,
+		Stroke:         m.Stroke,
+	}
 	if portraitId != 0 {
 		pm, err := rep.Media().GetMediaById(ctx, portraitId)
 		if err != nil {

--- a/internal/store/product/query.go
+++ b/internal/store/product/query.go
@@ -258,6 +258,80 @@ func (s *Store) GetProductsByIds(ctx context.Context, ids []int) ([]entity.Produ
 	return result, nil
 }
 
+// GetLowStockProducts returns visible, non-deleted products whose total stock
+// is in the range (0, threshold], ordered by ascending stock (closest to
+// selling out first), limited to `limit`.
+func (s *Store) GetLowStockProducts(ctx context.Context, threshold int, limit int) ([]entity.Product, error) {
+	if threshold <= 0 {
+		threshold = 3
+	}
+	if limit <= 0 {
+		limit = 8
+	}
+
+	query := `
+	SELECT
+		p.id, p.created_at, p.updated_at, p.deleted_at, p.preorder, p.brand, p.sku,
+		p.color, p.color_hex, p.country_of_origin, p.sale_percentage,
+		p.top_category_id, p.sub_category_id, p.type_id,
+		p.model_wears_height_cm, p.model_wears_size_id, p.hidden, p.target_gender,
+		p.care_instructions, p.composition, p.thumbnail_id, p.secondary_thumbnail_id,
+		p.version, p.collection, p.fit, p.min_tier, p.hidden_for_non_qualified,
+		m.full_size, m.full_size_width, m.full_size_height,
+		m.thumbnail, m.thumbnail_width, m.thumbnail_height,
+		m.compressed, m.compressed_width, m.compressed_height, m.blur_hash,
+		sm.created_at AS secondary_thumbnail_created_at,
+		sm.full_size AS secondary_full_size, sm.full_size_width AS secondary_full_size_width,
+		sm.full_size_height AS secondary_full_size_height,
+		sm.thumbnail AS secondary_thumbnail, sm.thumbnail_width AS secondary_thumbnail_width,
+		sm.thumbnail_height AS secondary_thumbnail_height,
+		sm.compressed AS secondary_compressed, sm.compressed_width AS secondary_compressed_width,
+		sm.compressed_height AS secondary_compressed_height, sm.blur_hash AS secondary_blur_hash,
+		COALESCE((SELECT SUM(COALESCE(ps.quantity, 0)) FROM product_size ps WHERE ps.product_id = p.id), 0) = 0 AS sold_out
+	FROM product p
+	JOIN media m ON p.thumbnail_id = m.id
+	LEFT JOIN media sm ON p.secondary_thumbnail_id = sm.id
+	WHERE p.hidden = 0 AND p.deleted_at IS NULL
+		AND COALESCE((SELECT SUM(COALESCE(ps.quantity, 0)) FROM product_size ps WHERE ps.product_id = p.id), 0) BETWEEN 1 AND :threshold
+	ORDER BY COALESCE((SELECT SUM(COALESCE(ps.quantity, 0)) FROM product_size ps WHERE ps.product_id = p.id), 0) ASC
+	LIMIT :limit`
+
+	prdResults, err := storeutil.QueryListNamed[productQueryResult](ctx, s.DB, query, map[string]any{
+		"threshold": threshold,
+		"limit":     limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't get low stock products: %w", err)
+	}
+	if len(prdResults) == 0 {
+		return []entity.Product{}, nil
+	}
+
+	ids := make([]int, 0, len(prdResults))
+	for _, r := range prdResults {
+		ids = append(ids, r.Id)
+	}
+
+	translationMap, err := fetchProductTranslations(ctx, s.DB, ids)
+	if err != nil {
+		return nil, fmt.Errorf("can't get product translations: %w", err)
+	}
+
+	priceMap, err := fetchProductPrices(ctx, s.DB, ids)
+	if err != nil {
+		return nil, fmt.Errorf("can't get product prices: %w", err)
+	}
+
+	result := make([]entity.Product, 0, len(prdResults))
+	for _, r := range prdResults {
+		product := r.toProduct(translationMap[r.Id])
+		product.Prices = priceMap[r.Id]
+		result = append(result, product)
+	}
+
+	return result, nil
+}
+
 // GetProductsByTag returns a list of products by their tag.
 func (s *Store) GetProductsByTag(ctx context.Context, tag string) ([]entity.Product, error) {
 	if tag == "" {

--- a/proto/common/common/hero.proto
+++ b/proto/common/common/hero.proto
@@ -47,11 +47,15 @@ enum HeroAudience {
 // ─── shared fragments ───────────────────────────────────────────────────────
 
 // HeroMedia is a portrait/landscape media pair addressed by id (write side).
-// disable_overlay lives here so the scrim can be toggled per media slot.
+// The per-slot presentation modifiers live here: disable_overlay toggles the
+// scrim, disable_tint toggles the frontend's background colour tint, and stroke
+// toggles a border/outline around the media.
 message HeroMedia {
   int32 portrait_id = 1;
   int32 landscape_id = 2;
   bool disable_overlay = 3;
+  bool disable_tint = 4;
+  bool stroke = 5;
 }
 
 // HeroMediaFull is the resolved form of HeroMedia (read side).
@@ -59,6 +63,8 @@ message HeroMediaFull {
   common.MediaFull portrait = 1;
   common.MediaFull landscape = 2;
   bool disable_overlay = 3;
+  bool disable_tint = 4;
+  bool stroke = 5;
 }
 
 // ─── read side (resolved) ───────────────────────────────────────────────────

--- a/proto/common/common/hero.proto
+++ b/proto/common/common/hero.proto
@@ -6,10 +6,63 @@ import "common/archive.proto";
 import "common/language.proto";
 import "common/media.proto";
 import "common/product.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/jekabolt/grbpwr-manager/proto/gen/common;common";
 
-// Extended hero structures with translations
+enum HeroType {
+  HERO_TYPE_UNKNOWN = 0;
+  HERO_TYPE_SINGLE = 1;
+  HERO_TYPE_DOUBLE = 2;
+  HERO_TYPE_MAIN = 3;
+  HERO_TYPE_FEATURED_PRODUCTS = 4;
+  HERO_TYPE_FEATURED_PRODUCTS_TAG = 5;
+  HERO_TYPE_FEATURED_ARCHIVE = 6;
+  HERO_TYPE_EMBED = 7;
+  HERO_TYPE_DROP = 8;
+  HERO_TYPE_LAST_CHANCE = 9;
+  HERO_TYPE_MARQUEE = 10;
+  HERO_TYPE_NEW_ARRIVALS = 11;
+  HERO_TYPE_SLIDESHOW = 12;
+  HERO_TYPE_MOSAIC = 13;
+  HERO_TYPE_SPLIT = 14;
+  HERO_TYPE_VIDEO = 15;
+  HERO_TYPE_PRODUCT_SPOTLIGHT = 16;
+  HERO_TYPE_NEWSLETTER = 17;
+  HERO_TYPE_STATEMENT = 18;
+  HERO_TYPE_LOOKBOOK = 19;
+}
+
+// HeroAudience is the TARGETING modifier: who a block is shown to. Enforcement
+// requires the frontend GetHero to know the viewer (auth → tier); until then it
+// is carried through and may be applied client-side.
+enum HeroAudience {
+  HERO_AUDIENCE_UNKNOWN = 0; // treated as ALL
+  HERO_AUDIENCE_ALL = 1;
+  HERO_AUDIENCE_GUESTS = 2;
+  HERO_AUDIENCE_MEMBERS = 3;
+  HERO_AUDIENCE_TIER = 4; // tier >= min_tier_id
+}
+
+// ─── shared fragments ───────────────────────────────────────────────────────
+
+// HeroMedia is a portrait/landscape media pair addressed by id (write side).
+// disable_overlay lives here so the scrim can be toggled per media slot.
+message HeroMedia {
+  int32 portrait_id = 1;
+  int32 landscape_id = 2;
+  bool disable_overlay = 3;
+}
+
+// HeroMediaFull is the resolved form of HeroMedia (read side).
+message HeroMediaFull {
+  common.MediaFull portrait = 1;
+  common.MediaFull landscape = 2;
+  bool disable_overlay = 3;
+}
+
+// ─── read side (resolved) ───────────────────────────────────────────────────
+
 message HeroFullWithTranslations {
   repeated HeroEntityWithTranslations entities = 1;
   NavFeaturedWithTranslations nav_featured = 2;
@@ -27,16 +80,6 @@ message NavFeaturedEntityWithTranslations {
   repeated common.NavFeaturedEntityInsertTranslation translations = 4;
 }
 
-enum HeroType {
-  HERO_TYPE_UNKNOWN = 0;
-  HERO_TYPE_SINGLE = 1;
-  HERO_TYPE_DOUBLE = 2;
-  HERO_TYPE_MAIN = 3;
-  HERO_TYPE_FEATURED_PRODUCTS = 4;
-  HERO_TYPE_FEATURED_PRODUCTS_TAG = 5;
-  HERO_TYPE_FEATURED_ARCHIVE = 6;
-}
-
 message HeroEntityWithTranslations {
   HeroType type = 1;
   HeroSingleWithTranslations single = 2;
@@ -45,13 +88,28 @@ message HeroEntityWithTranslations {
   HeroFeaturedProductsWithTranslations featured_products = 5;
   HeroFeaturedProductsTagWithTranslations featured_products_tag = 6;
   HeroFeaturedArchiveWithTranslations featured_archive = 7;
+  HeroEmbedWithTranslations embed = 8;
+  HeroDropWithTranslations drop = 9;
+  HeroLastChanceWithTranslations last_chance = 10;
+  HeroMarqueeWithTranslations marquee = 11;
+  HeroNewArrivalsWithTranslations new_arrivals = 12;
+  HeroSlideshowWithTranslations slideshow = 13;
+  HeroMosaicWithTranslations mosaic = 14;
+  HeroSplitWithTranslations split = 15;
+  HeroVideoWithTranslations video = 16;
+  HeroProductSpotlightWithTranslations product_spotlight = 17;
+  HeroNewsletterWithTranslations newsletter = 18;
+  HeroStatementWithTranslations statement = 19;
+  HeroLookbookWithTranslations lookbook = 20;
+  // modifiers
+  HeroAudience audience = 50;
+  int32 min_tier_id = 51;
 }
 
 message HeroSingleWithTranslations {
-  common.MediaFull media_portrait = 1;
-  common.MediaFull media_landscape = 2;
-  string explore_link = 3;
-  repeated common.HeroSingleInsertTranslation translations = 4;
+  HeroMediaFull media = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
 }
 
 message HeroDoubleWithTranslations {
@@ -60,29 +118,113 @@ message HeroDoubleWithTranslations {
 }
 
 message HeroMainWithTranslations {
-  HeroSingleWithTranslations single = 1;
-  repeated common.HeroMainInsertTranslation translations = 2;
+  HeroMediaFull media = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
 }
 
 message HeroFeaturedProductsWithTranslations {
   repeated common.Product products = 1;
   string explore_link = 2;
-  repeated common.HeroFeaturedProductsInsertTranslation translations = 3;
+  repeated common.HeroCopyTranslation translations = 3;
 }
 
 message HeroFeaturedProductsTagWithTranslations {
   string tag = 1;
   HeroFeaturedProductsWithTranslations products = 2;
-  repeated common.HeroFeaturedProductsTagInsertTranslation translations = 3;
+  repeated common.HeroCopyTranslation translations = 3;
 }
 
 message HeroFeaturedArchiveWithTranslations {
   common.ArchiveFull archive = 1;
   string tag = 2;
-  string headline = 3;
-  string explore_text = 4;
-  repeated common.HeroFeaturedArchiveInsertTranslation translations = 5;
+  repeated common.HeroCopyTranslation translations = 3;
 }
+
+message HeroEmbedWithTranslations {
+  string embed_url = 1;
+  HeroMediaFull fallback = 2;
+  string cta_link = 3;
+  repeated common.HeroCopyTranslation translations = 4;
+}
+
+message HeroDropWithTranslations {
+  HeroMediaFull media = 1;
+  google.protobuf.Timestamp release_at = 2;
+  string explore_link = 3;
+  string tag = 4;
+  repeated common.HeroCopyTranslation translations = 5;
+}
+
+message HeroLastChanceWithTranslations {
+  repeated common.Product products = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+message HeroMarqueeWithTranslations {
+  string link = 1;
+  int32 speed = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+message HeroNewArrivalsWithTranslations {
+  repeated common.Product products = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+message HeroSlideshowWithTranslations {
+  repeated HeroSingleWithTranslations slides = 1;
+  int32 interval_ms = 2;
+}
+
+message HeroMosaicWithTranslations {
+  repeated HeroSingleWithTranslations tiles = 1;
+  int32 columns = 2;
+}
+
+message HeroSplitWithTranslations {
+  HeroSingleWithTranslations media = 1;
+  repeated common.Product products = 2;
+  bool media_left = 3;
+}
+
+message HeroVideoWithTranslations {
+  common.MediaFull media = 1;
+  common.MediaFull poster_media = 2;
+  bool autoplay = 3;
+  bool loop = 4;
+  bool muted = 5;
+  string cta_link = 6;
+  repeated common.HeroCopyTranslation translations = 7;
+}
+
+message HeroProductSpotlightWithTranslations {
+  common.Product product = 1;
+  HeroMediaFull media = 2;
+  string explore_link = 3;
+  repeated common.HeroCopyTranslation translations = 4;
+}
+
+message HeroNewsletterWithTranslations {
+  HeroMediaFull media = 1;
+  repeated common.HeroCopyTranslation translations = 2;
+}
+
+message HeroStatementWithTranslations {
+  HeroMediaFull media = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+message HeroLookbookWithTranslations {
+  repeated HeroSingleWithTranslations frames = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+// ─── write side (insert) ────────────────────────────────────────────────────
 
 message NavFeaturedInsert {
   NavFeaturedEntityInsert men = 1;
@@ -109,30 +251,28 @@ message HeroEntityInsert {
   HeroFeaturedProductsInsert featured_products = 5;
   HeroFeaturedProductsTagInsert featured_products_tag = 6;
   HeroFeaturedArchiveInsert featured_archive = 7;
-}
-
-message HeroFeaturedArchiveInsert {
-  int32 archive_id = 1;
-  string tag = 2;
-  repeated common.HeroFeaturedArchiveInsertTranslation translations = 3;
-}
-
-message HeroFeaturedProductsInsert {
-  repeated int32 product_ids = 1;
-  string explore_link = 2;
-  repeated common.HeroFeaturedProductsInsertTranslation translations = 3;
-}
-
-message HeroFeaturedProductsTagInsert {
-  string tag = 1;
-  repeated common.HeroFeaturedProductsTagInsertTranslation translations = 2;
+  HeroEmbedInsert embed = 8;
+  HeroDropInsert drop = 9;
+  HeroLastChanceInsert last_chance = 10;
+  HeroMarqueeInsert marquee = 11;
+  HeroNewArrivalsInsert new_arrivals = 12;
+  HeroSlideshowInsert slideshow = 13;
+  HeroMosaicInsert mosaic = 14;
+  HeroSplitInsert split = 15;
+  HeroVideoInsert video = 16;
+  HeroProductSpotlightInsert product_spotlight = 17;
+  HeroNewsletterInsert newsletter = 18;
+  HeroStatementInsert statement = 19;
+  HeroLookbookInsert lookbook = 20;
+  // modifiers
+  HeroAudience audience = 50;
+  int32 min_tier_id = 51;
 }
 
 message HeroSingleInsert {
-  int32 media_portrait_id = 1;
-  int32 media_landscape_id = 2;
-  string explore_link = 3;
-  repeated common.HeroSingleInsertTranslation translations = 4;
+  HeroMedia media = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
 }
 
 message HeroDoubleInsert {
@@ -141,8 +281,108 @@ message HeroDoubleInsert {
 }
 
 message HeroMainInsert {
-  int32 media_portrait_id = 1;
-  int32 media_landscape_id = 2;
+  HeroMedia media = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+message HeroFeaturedProductsInsert {
+  repeated int32 product_ids = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+message HeroFeaturedProductsTagInsert {
+  string tag = 1;
+  repeated common.HeroCopyTranslation translations = 2;
+}
+
+message HeroFeaturedArchiveInsert {
+  int32 archive_id = 1;
+  string tag = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+message HeroEmbedInsert {
+  string embed_url = 1;
+  HeroMedia fallback = 2;
+  string cta_link = 3;
+  repeated common.HeroCopyTranslation translations = 4;
+}
+
+message HeroDropInsert {
+  HeroMedia media = 1;
+  google.protobuf.Timestamp release_at = 2;
   string explore_link = 3;
-  repeated common.HeroMainInsertTranslation translations = 4;
+  string tag = 4;
+  repeated common.HeroCopyTranslation translations = 5;
+}
+
+message HeroLastChanceInsert {
+  int32 stock_threshold = 1;
+  int32 limit = 2;
+  string explore_link = 3;
+  repeated common.HeroCopyTranslation translations = 4;
+}
+
+message HeroMarqueeInsert {
+  string link = 1;
+  int32 speed = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+message HeroNewArrivalsInsert {
+  int32 limit = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+message HeroSlideshowInsert {
+  repeated HeroSingleInsert slides = 1;
+  int32 interval_ms = 2;
+}
+
+message HeroMosaicInsert {
+  repeated HeroSingleInsert tiles = 1;
+  int32 columns = 2;
+}
+
+message HeroSplitInsert {
+  HeroSingleInsert media = 1;
+  repeated int32 product_ids = 2;
+  bool media_left = 3;
+}
+
+message HeroVideoInsert {
+  int32 media_id = 1;
+  int32 poster_media_id = 2;
+  bool autoplay = 3;
+  bool loop = 4;
+  bool muted = 5;
+  string cta_link = 6;
+  repeated common.HeroCopyTranslation translations = 7;
+}
+
+message HeroProductSpotlightInsert {
+  int32 product_id = 1;
+  HeroMedia media = 2;
+  string explore_link = 3;
+  repeated common.HeroCopyTranslation translations = 4;
+}
+
+message HeroNewsletterInsert {
+  HeroMedia media = 1;
+  repeated common.HeroCopyTranslation translations = 2;
+}
+
+message HeroStatementInsert {
+  HeroMedia media = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
+}
+
+message HeroLookbookInsert {
+  repeated HeroSingleInsert frames = 1;
+  string explore_link = 2;
+  repeated common.HeroCopyTranslation translations = 3;
 }

--- a/proto/common/common/language.proto
+++ b/proto/common/common/language.proto
@@ -26,36 +26,26 @@ message ArchiveInsertTranslation {
   string description = 3;
 }
 
-message HeroSingleInsertTranslation {
-  int32 language_id = 1;
-  string headline = 2;
-  string explore_text = 3;
-}
-
-message HeroMainInsertTranslation {
+// HeroCopyTranslation is the single, shared translation for every hero block.
+// Each block type uses only the subset of fields it needs:
+//   single/double        -> headline, explore_text
+//   main                 -> tag, body, headline, explore_text
+//   featured_products    -> headline, explore_text
+//   featured_products_tag-> headline, explore_text
+//   featured_archive     -> headline, explore_text
+// (further fields — subhead, cta_text, caption, placeholder, success_text —
+//  are reserved for the block types added on top of this foundation.)
+message HeroCopyTranslation {
   int32 language_id = 1;
   string tag = 2;
-  string description = 3;
-  string headline = 4;
-  string explore_text = 5;
-}
-
-message HeroFeaturedProductsInsertTranslation {
-  int32 language_id = 1;
-  string headline = 2;
-  string explore_text = 3;
-}
-
-message HeroFeaturedProductsTagInsertTranslation {
-  int32 language_id = 1;
-  string headline = 2;
-  string explore_text = 3;
-}
-
-message HeroFeaturedArchiveInsertTranslation {
-  int32 language_id = 1;
-  string headline = 2;
-  string explore_text = 3;
+  string headline = 3;
+  string subhead = 4;
+  string body = 5;
+  string cta_text = 6;
+  string explore_text = 7;
+  string caption = 8;
+  string placeholder = 9;
+  string success_text = 10;
 }
 
 message NavFeaturedEntityInsertTranslation {


### PR DESCRIPTION
Promotes the hero v2 work from beta (verified) to master / prod.

## What's included
- **Hero v2 architecture**: shared fragments (`HeroMedia`/`HeroCopyTranslation`), Insert-form storage with resolve-on-read, versioned envelope (`schema_version = 2`, legacy-preserving).
- **13 new block types**: EMBED, DROP, LAST_CHANCE, MARQUEE, NEW_ARRIVALS, SLIDESHOW, MOSAIC, SPLIT, VIDEO, PRODUCT_SPOTLIGHT, NEWSLETTER, STATEMENT, LOOKBOOK.
- **TARGETING modifier** (`HeroAudience`: all/guests/members/tier) filtered per viewer in the frontend service.
- **Per-media presentation modifiers**: `disable_overlay`, `disable_tint` (drop frontend background tint), `stroke` (outline).
- **MAIN block** can now appear any number of times and at any position.
- **EMBED** iframe source validated against an https + host allowlist (`HERO_EMBED_ALLOWED_HOSTS`).
- **`GetLowStockProducts`** store query for LAST_CHANCE.

## Compatibility / ops
- Hero is a JSON blob (`schema_version = 2`); new bool fields default to `false` (current behaviour). **No DB migration.**
- New config: `HERO_EMBED_ALLOWED_HOSTS` (already set to "" in `.do/app.yaml`).
- After deploy: re-save the hero via admin so it re-serializes into the v2 envelope, and update the storefront/admin frontends to read the new fields (`disable_tint`, `stroke`, audience, new block types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)