### PR TITLE
Promote beta → master: newsletter block headline+body only

### DIFF
--- a/internal/dto/hero.go
+++ b/internal/dto/hero.go
@@ -77,6 +77,30 @@ func convertEntityHeroCopyTranslationsToCommon(in []entity.HeroCopyTranslation) 
 	return out
 }
 
+func convertCommonHeroNewsletterTranslationsToEntity(in []*pb_common.HeroNewsletterTranslation) []entity.HeroNewsletterTranslation {
+	out := make([]entity.HeroNewsletterTranslation, len(in))
+	for i, t := range in {
+		out[i] = entity.HeroNewsletterTranslation{
+			LanguageId: int(t.LanguageId),
+			Headline:   t.Headline,
+			Body:       t.Body,
+		}
+	}
+	return out
+}
+
+func convertEntityHeroNewsletterTranslationsToCommon(in []entity.HeroNewsletterTranslation) []*pb_common.HeroNewsletterTranslation {
+	out := make([]*pb_common.HeroNewsletterTranslation, len(in))
+	for i, t := range in {
+		out[i] = &pb_common.HeroNewsletterTranslation{
+			LanguageId: int32(t.LanguageId),
+			Headline:   t.Headline,
+			Body:       t.Body,
+		}
+	}
+	return out
+}
+
 func convertCommonHeroMediaToEntity(m *pb_common.HeroMedia) entity.HeroMedia {
 	if m == nil {
 		return entity.HeroMedia{}
@@ -309,7 +333,7 @@ func ConvertCommonHeroEntityInsertToEntity(hi *pb_common.HeroEntityInsert) entit
 		if hi.Newsletter != nil {
 			result.Newsletter = entity.HeroNewsletterInsert{
 				Media:        convertCommonHeroMediaToEntity(hi.Newsletter.Media),
-				Translations: convertCommonHeroCopyTranslationsToEntity(hi.Newsletter.Translations),
+				Translations: convertCommonHeroNewsletterTranslationsToEntity(hi.Newsletter.Translations),
 			}
 		}
 	case pb_common.HeroType_HERO_TYPE_STATEMENT:
@@ -601,7 +625,7 @@ func ConvertEntityHeroEntityToCommonWithTranslations(he *entity.HeroEntityWithTr
 		if he.Newsletter != nil {
 			result.Newsletter = &pb_common.HeroNewsletterWithTranslations{
 				Media:        convertEntityHeroMediaFullToCommon(&he.Newsletter.Media),
-				Translations: convertEntityHeroCopyTranslationsToCommon(he.Newsletter.Translations),
+				Translations: convertEntityHeroNewsletterTranslationsToCommon(he.Newsletter.Translations),
 			}
 		}
 	case entity.HeroTypeStatement:

--- a/internal/entity/hero.go
+++ b/internal/entity/hero.go
@@ -222,9 +222,17 @@ type HeroProductSpotlightWithTranslations struct {
 	Translations []HeroCopyTranslation `json:"translations"`
 }
 
+// HeroNewsletterTranslation is the newsletter block copy — headline + body only
+// (email placeholder, button text and success message are handled client-side).
+type HeroNewsletterTranslation struct {
+	LanguageId int    `json:"language_id"`
+	Headline   string `json:"headline"`
+	Body       string `json:"body"`
+}
+
 type HeroNewsletterWithTranslations struct {
-	Media        HeroMediaFull         `json:"media"`
-	Translations []HeroCopyTranslation `json:"translations"`
+	Media        HeroMediaFull               `json:"media"`
+	Translations []HeroNewsletterTranslation `json:"translations"`
 }
 
 type HeroStatementWithTranslations struct {
@@ -380,8 +388,8 @@ type HeroProductSpotlightInsert struct {
 }
 
 type HeroNewsletterInsert struct {
-	Media        HeroMedia             `json:"media"`
-	Translations []HeroCopyTranslation `json:"translations"`
+	Media        HeroMedia                   `json:"media"`
+	Translations []HeroNewsletterTranslation `json:"translations"`
 }
 
 type HeroStatementInsert struct {

--- a/proto/common/common/hero.proto
+++ b/proto/common/common/hero.proto
@@ -215,7 +215,7 @@ message HeroProductSpotlightWithTranslations {
 
 message HeroNewsletterWithTranslations {
   HeroMediaFull media = 1;
-  repeated common.HeroCopyTranslation translations = 2;
+  repeated common.HeroNewsletterTranslation translations = 2;
 }
 
 message HeroStatementWithTranslations {
@@ -378,7 +378,7 @@ message HeroProductSpotlightInsert {
 
 message HeroNewsletterInsert {
   HeroMedia media = 1;
-  repeated common.HeroCopyTranslation translations = 2;
+  repeated common.HeroNewsletterTranslation translations = 2;
 }
 
 message HeroStatementInsert {

--- a/proto/common/common/language.proto
+++ b/proto/common/common/language.proto
@@ -58,6 +58,14 @@ message HeroCopyTranslation {
   string success_text = 10;
 }
 
+// HeroNewsletterTranslation is the newsletter block copy — headline + body only
+// (the email placeholder, button text and success message are handled client-side).
+message HeroNewsletterTranslation {
+  int32 language_id = 1;
+  string headline = 2;
+  string body = 3;
+}
+
 message NavFeaturedEntityInsertTranslation {
   int32 language_id = 1;
   string explore_text = 2;


### PR DESCRIPTION
Trims the hero NEWSLETTER (email-signup) block copy to headline + body.

- Dedicated `HeroNewsletterTranslation { language_id, headline, body }` replaces the shared `HeroCopyTranslation` for the newsletter block. The email placeholder, button text and success message are handled client-side.
- Existing stored hero blobs decode fine (dropped copy keys ignored, headline/body preserved). Hero is a JSON blob — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)