### PR TITLE
Archive timeline block model v2 (8 typed blocks) + wipe migration 0081

### DIFF
--- a/internal/apisrv/admin/archive.go
+++ b/internal/apisrv/admin/archive.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *Server) AddArchive(ctx context.Context, req *pb_admin.AddArchiveRequest) (*pb_admin.AddArchiveResponse, error) {
-	if err := s.validateArchiveEmbeds(req.ArchiveInsert); err != nil {
+	if err := s.validateArchiveItems(req.ArchiveInsert); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -45,7 +45,7 @@ func (s *Server) AddArchive(ctx context.Context, req *pb_admin.AddArchiveRequest
 }
 
 func (s *Server) UpdateArchive(ctx context.Context, req *pb_admin.UpdateArchiveRequest) (*pb_admin.UpdateArchiveResponse, error) {
-	if err := s.validateArchiveEmbeds(req.ArchiveInsert); err != nil {
+	if err := s.validateArchiveItems(req.ArchiveInsert); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -122,18 +122,69 @@ func (s *Server) GetArchiveByID(ctx context.Context, req *pb_admin.GetArchiveByI
 	}, nil
 }
 
-// validateArchiveEmbeds enforces the shared iframe embed policy on every EMBED
-// timeline block (see validateEmbedURL).
-func (s *Server) validateArchiveEmbeds(ai *pb_common.ArchiveInsert) error {
+// maxArchiveMediaLine is the upper bound on media in a single MEDIA_LINE block.
+const maxArchiveMediaLine = 4
+
+// countNonZero returns how many ids are non-zero (unselected media/product slots
+// arrive as 0 and would otherwise pass a naive len() check then vanish on read).
+func countNonZero(ids []int32) int {
+	n := 0
+	for _, id := range ids {
+		if id != 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// validateArchiveItems enforces per-block invariants on the timeline body so that
+// a block which would silently vanish on read (its required reference missing) is
+// instead rejected up front. It also enforces the shared iframe embed allowlist on
+// EMBED blocks and the 1..4 media count on MEDIA_LINE.
+func (s *Server) validateArchiveItems(ai *pb_common.ArchiveInsert) error {
 	if ai == nil {
 		return nil
 	}
 	for i, it := range ai.Items {
-		if it.Type != pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_EMBED {
-			continue
-		}
-		if err := s.validateEmbedURL(it.EmbedUrl); err != nil {
-			return fmt.Errorf("archive item %d: %w", i, err)
+		switch it.Type {
+		case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_MAIN_MEDIA:
+			if it.MainMedia == nil || it.MainMedia.MediaId == 0 {
+				return fmt.Errorf("archive item %d: main_media requires a media id", i)
+			}
+		case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_MEDIA_LINE:
+			n := 0
+			if it.MediaLine != nil {
+				n = countNonZero(it.MediaLine.MediaIds)
+			}
+			if n < 1 || n > maxArchiveMediaLine {
+				return fmt.Errorf("archive item %d: media_line must have 1..%d media, got %d", i, maxArchiveMediaLine, n)
+			}
+		case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_MEDIA_WITH_CAPTION:
+			if it.MediaWithCaption == nil || it.MediaWithCaption.MediaId == 0 {
+				return fmt.Errorf("archive item %d: media_with_caption requires a media id", i)
+			}
+		case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_EMBED:
+			var url string
+			if it.Embed != nil {
+				url = it.Embed.EmbedUrl
+			}
+			if err := s.validateEmbedURL(url); err != nil {
+				return fmt.Errorf("archive item %d: %w", i, err)
+			}
+		case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_PRODUCT:
+			if it.Product == nil || it.Product.ProductId == 0 {
+				return fmt.Errorf("archive item %d: product requires a product id", i)
+			}
+		case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_PRODUCTS_TAG:
+			if it.ProductsTag == nil || it.ProductsTag.Tag == "" {
+				return fmt.Errorf("archive item %d: products_tag requires a tag", i)
+			}
+		case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_PRODUCTS_MANUAL:
+			if it.ProductsManual == nil || countNonZero(it.ProductsManual.ProductIds) == 0 {
+				return fmt.Errorf("archive item %d: products_manual requires at least one product id", i)
+			}
+		case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_UNKNOWN:
+			return fmt.Errorf("archive item %d: block type is unset", i)
 		}
 	}
 	return nil

--- a/internal/dto/archive.go
+++ b/internal/dto/archive.go
@@ -19,17 +19,11 @@ func ConvertPbArchiveInsertToEntity(pbArchiveInsert *pb_common.ArchiveInsert) (*
 		return nil, errors.New("archive insert is nil")
 	}
 
-	mainMediaIds := make([]int, 0, len(pbArchiveInsert.MainMediaIds))
-	for _, mid := range pbArchiveInsert.MainMediaIds {
-		mainMediaIds = append(mainMediaIds, int(mid))
-	}
-
 	translations := make([]entity.ArchiveTranslation, 0, len(pbArchiveInsert.Translations))
 	for _, translation := range pbArchiveInsert.Translations {
 		translations = append(translations, entity.ArchiveTranslation{
-			LanguageId:  int(translation.LanguageId),
-			Heading:     translation.Heading,
-			Description: translation.Description,
+			LanguageId: int(translation.LanguageId),
+			Heading:    translation.Heading,
 		})
 	}
 
@@ -42,29 +36,78 @@ func ConvertPbArchiveInsertToEntity(pbArchiveInsert *pb_common.ArchiveInsert) (*
 		Translations: translations,
 		Tag:          pbArchiveInsert.Tag,
 		Items:        items,
-		MainMediaIds: mainMediaIds,
 		ThumbnailId:  int(pbArchiveInsert.ThumbnailId),
 	}, nil
 }
 
+// convertPbArchiveItemInsertToEntity maps a single timeline block, copying only
+// the payload selected by Type into its typed sub-struct.
 func convertPbArchiveItemInsertToEntity(it *pb_common.ArchiveItemInsert) entity.ArchiveItemInsert {
 	if it == nil {
 		return entity.ArchiveItemInsert{}
 	}
-	productIds := make([]int, 0, len(it.ProductIds))
-	for _, id := range it.ProductIds {
-		productIds = append(productIds, int(id))
+	out := entity.ArchiveItemInsert{Type: entity.ArchiveItemType(it.Type)}
+	switch it.Type {
+	case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_MAIN_MEDIA:
+		if b := it.MainMedia; b != nil {
+			out.MainMedia = &entity.ArchiveMainMediaInsert{
+				MediaId:     int(b.MediaId),
+				AspectRatio: entity.ArchiveMediaAspectRatio(b.AspectRatio),
+			}
+		}
+	case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_MEDIA_LINE:
+		if b := it.MediaLine; b != nil {
+			out.MediaLine = &entity.ArchiveMediaLineInsert{
+				MediaIds:    convertMediaIds(b.MediaIds),
+				AspectRatio: entity.ArchiveMediaAspectRatio(b.AspectRatio),
+			}
+		}
+	case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_TEXT:
+		if b := it.Text; b != nil {
+			out.Text = &entity.ArchiveTextInsert{
+				Translations: convertPbArchiveItemTranslationsToEntity(b.Translations),
+			}
+		}
+	case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_EMBED:
+		if b := it.Embed; b != nil {
+			out.Embed = &entity.ArchiveEmbedInsert{
+				EmbedUrl:     b.EmbedUrl,
+				Translations: convertPbArchiveItemTranslationsToEntity(b.Translations),
+			}
+		}
+	case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_MEDIA_WITH_CAPTION:
+		if b := it.MediaWithCaption; b != nil {
+			out.MediaWithCaption = &entity.ArchiveMediaWithCaptionInsert{
+				MediaId:      int(b.MediaId),
+				Link:         b.Link,
+				AspectRatio:  entity.ArchiveMediaAspectRatio(b.AspectRatio),
+				Translations: convertPbArchiveItemTranslationsToEntity(b.Translations),
+			}
+		}
+	case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_PRODUCT:
+		if b := it.Product; b != nil {
+			out.Product = &entity.ArchiveProductInsert{
+				ProductId:    int(b.ProductId),
+				Translations: convertPbArchiveItemTranslationsToEntity(b.Translations),
+			}
+		}
+	case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_PRODUCTS_TAG:
+		if b := it.ProductsTag; b != nil {
+			out.ProductsTag = &entity.ArchiveProductsTagInsert{
+				Tag:          b.Tag,
+				Limit:        int(b.Limit),
+				Translations: convertPbArchiveItemTranslationsToEntity(b.Translations),
+			}
+		}
+	case pb_common.ArchiveItemType_ARCHIVE_ITEM_TYPE_PRODUCTS_MANUAL:
+		if b := it.ProductsManual; b != nil {
+			out.ProductsManual = &entity.ArchiveProductsManualInsert{
+				ProductIds:   convertMediaIds(b.ProductIds),
+				Translations: convertPbArchiveItemTranslationsToEntity(b.Translations),
+			}
+		}
 	}
-	return entity.ArchiveItemInsert{
-		Type:         entity.ArchiveItemType(it.Type),
-		MediaId:      int(it.MediaId),
-		EmbedUrl:     it.EmbedUrl,
-		ProductId:    int(it.ProductId),
-		Tag:          it.Tag,
-		Limit:        int(it.Limit),
-		ProductIds:   productIds,
-		Translations: convertPbArchiveItemTranslationsToEntity(it.Translations),
-	}
+	return out
 }
 
 func convertPbArchiveItemTranslationsToEntity(in []*pb_common.ArchiveItemTranslation) []entity.ArchiveItemTranslation {
@@ -85,11 +128,6 @@ func ConvertArchiveFullEntityToPb(af *entity.ArchiveFull) (*pb_common.ArchiveFul
 		return nil, nil
 	}
 
-	mainMediaPb := make([]*pb_common.MediaFull, 0, len(af.MainMedia))
-	for _, m := range af.MainMedia {
-		mainMediaPb = append(mainMediaPb, ConvertEntityToCommonMedia(&m))
-	}
-
 	itemsPb := make([]*pb_common.ArchiveItemFull, 0, len(af.Items))
 	for i := range af.Items {
 		itemPb, err := convertEntityArchiveItemFullToPb(&af.Items[i])
@@ -101,41 +139,91 @@ func ConvertArchiveFullEntityToPb(af *entity.ArchiveFull) (*pb_common.ArchiveFul
 
 	return &pb_common.ArchiveFull{
 		ArchiveList: ConvertEntityToCommonArchiveList(&af.ArchiveList),
-		MainMedia:   mainMediaPb,
 		Items:       itemsPb,
 	}, nil
 }
 
+// convertEntityArchiveItemFullToPb maps a single resolved timeline block into its
+// typed pb payload, selected by Type.
 func convertEntityArchiveItemFullToPb(it *entity.ArchiveItemFull) (*pb_common.ArchiveItemFull, error) {
 	if it == nil {
 		return nil, nil
 	}
-	out := &pb_common.ArchiveItemFull{
-		Type:         pb_common.ArchiveItemType(it.Type),
-		EmbedUrl:     it.EmbedUrl,
-		Tag:          it.Tag,
-		Translations: convertEntityArchiveItemTranslationsToPb(it.Translations),
-	}
-	if it.Media.Id != 0 {
-		out.Media = ConvertEntityToCommonMedia(&it.Media)
-	}
-	if it.Product != nil {
-		p, err := ConvertEntityProductToCommon(it.Product)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert product: %w", err)
-		}
-		out.Product = p
-	}
-	if len(it.Products) > 0 {
-		products := make([]*pb_common.Product, 0, len(it.Products))
-		for i := range it.Products {
-			p, err := ConvertEntityProductToCommon(&it.Products[i])
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert product at index %d: %w", i, err)
+	out := &pb_common.ArchiveItemFull{Type: pb_common.ArchiveItemType(it.Type)}
+	switch it.Type {
+	case entity.ArchiveItemTypeMainMedia:
+		if b := it.MainMedia; b != nil {
+			out.MainMedia = &pb_common.ArchiveMainMediaFull{
+				Media:       ConvertEntityToCommonMedia(&b.Media),
+				AspectRatio: pb_common.ArchiveMediaAspectRatio(b.AspectRatio),
 			}
-			products = append(products, p)
 		}
-		out.Products = products
+	case entity.ArchiveItemTypeMediaLine:
+		if b := it.MediaLine; b != nil {
+			out.MediaLine = &pb_common.ArchiveMediaLineFull{
+				Media:       ConvertEntityMediaListToPbMedia(b.Media),
+				AspectRatio: pb_common.ArchiveMediaAspectRatio(b.AspectRatio),
+			}
+		}
+	case entity.ArchiveItemTypeText:
+		if b := it.Text; b != nil {
+			out.Text = &pb_common.ArchiveTextFull{
+				Translations: convertEntityArchiveItemTranslationsToPb(b.Translations),
+			}
+		}
+	case entity.ArchiveItemTypeEmbed:
+		if b := it.Embed; b != nil {
+			out.Embed = &pb_common.ArchiveEmbedFull{
+				EmbedUrl:     b.EmbedUrl,
+				Translations: convertEntityArchiveItemTranslationsToPb(b.Translations),
+			}
+		}
+	case entity.ArchiveItemTypeMediaWithCaption:
+		if b := it.MediaWithCaption; b != nil {
+			out.MediaWithCaption = &pb_common.ArchiveMediaWithCaptionFull{
+				Media:        ConvertEntityToCommonMedia(&b.Media),
+				Link:         b.Link,
+				AspectRatio:  pb_common.ArchiveMediaAspectRatio(b.AspectRatio),
+				Translations: convertEntityArchiveItemTranslationsToPb(b.Translations),
+			}
+		}
+	case entity.ArchiveItemTypeProduct:
+		if b := it.Product; b != nil {
+			pf := &pb_common.ArchiveProductFull{
+				Translations: convertEntityArchiveItemTranslationsToPb(b.Translations),
+			}
+			if b.Product != nil {
+				p, err := ConvertEntityProductToCommon(b.Product)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert product: %w", err)
+				}
+				pf.Product = p
+			}
+			out.Product = pf
+		}
+	case entity.ArchiveItemTypeProductsTag:
+		if b := it.ProductsTag; b != nil {
+			products, err := convertEntityProductsToCommon(b.Products)
+			if err != nil {
+				return nil, err
+			}
+			out.ProductsTag = &pb_common.ArchiveProductsTagFull{
+				Tag:          b.Tag,
+				Products:     products,
+				Translations: convertEntityArchiveItemTranslationsToPb(b.Translations),
+			}
+		}
+	case entity.ArchiveItemTypeProductsManual:
+		if b := it.ProductsManual; b != nil {
+			products, err := convertEntityProductsToCommon(b.Products)
+			if err != nil {
+				return nil, err
+			}
+			out.ProductsManual = &pb_common.ArchiveProductsManualFull{
+				Products:     products,
+				Translations: convertEntityArchiveItemTranslationsToPb(b.Translations),
+			}
+		}
 	}
 	return out, nil
 }
@@ -160,9 +248,8 @@ func ConvertEntityToCommonArchiveList(al *entity.ArchiveList) *pb_common.Archive
 	translations := make([]*pb_common.ArchiveInsertTranslation, 0, len(al.Translations))
 	for _, t := range al.Translations {
 		translations = append(translations, &pb_common.ArchiveInsertTranslation{
-			LanguageId:  int32(t.LanguageId),
-			Heading:     t.Heading,
-			Description: t.Description,
+			LanguageId: int32(t.LanguageId),
+			Heading:    t.Heading,
 		})
 	}
 

--- a/internal/entity/archive.go
+++ b/internal/entity/archive.go
@@ -15,65 +15,169 @@ type ArchiveList struct {
 
 type ArchiveFull struct {
 	ArchiveList ArchiveList
-	MainMedia   []MediaFull       `db:"main_media" json:"main_media"`
 	Items       []ArchiveItemFull `json:"items"`
 }
 
 type ArchiveInsert struct {
 	Tag          string               `db:"tag" json:"tag"`
-	MainMediaIds []int                `db:"main_media_ids" json:"main_media_ids"`
 	ThumbnailId  int                  `db:"thumbnail_id" json:"thumbnail_id"`
 	Items        []ArchiveItemInsert  `json:"items"`
 	Translations []ArchiveTranslation `db:"translations" json:"translations"`
 }
 
+// ArchiveTranslation is the archive's translatable copy: the title (heading)
+// only — the archive has no description.
 type ArchiveTranslation struct {
-	LanguageId  int    `db:"language_id" json:"language_id"`
-	Heading     string `db:"heading" json:"heading"`
-	Description string `db:"description" json:"description"`
+	LanguageId int    `db:"language_id" json:"language_id"`
+	Heading    string `db:"heading" json:"heading"`
 }
 
 // ArchiveItemType discriminates a timeline body block.
 type ArchiveItemType int32
 
 const (
-	ArchiveItemTypeUnknown        ArchiveItemType = 0
-	ArchiveItemTypeMedia          ArchiveItemType = 1
-	ArchiveItemTypeText           ArchiveItemType = 2
-	ArchiveItemTypeEmbed          ArchiveItemType = 3
-	ArchiveItemTypeProduct        ArchiveItemType = 4
-	ArchiveItemTypeProductsTag    ArchiveItemType = 5
-	ArchiveItemTypeProductsManual ArchiveItemType = 6
+	ArchiveItemTypeUnknown          ArchiveItemType = 0
+	ArchiveItemTypeMainMedia        ArchiveItemType = 1
+	ArchiveItemTypeMediaLine        ArchiveItemType = 2
+	ArchiveItemTypeText             ArchiveItemType = 3
+	ArchiveItemTypeEmbed            ArchiveItemType = 4
+	ArchiveItemTypeMediaWithCaption ArchiveItemType = 5
+	ArchiveItemTypeProduct          ArchiveItemType = 6
+	ArchiveItemTypeProductsTag      ArchiveItemType = 7
+	ArchiveItemTypeProductsManual   ArchiveItemType = 8
+)
+
+// ArchiveMediaAspectRatio is the presentation aspect ratio for the media blocks.
+type ArchiveMediaAspectRatio int32
+
+const (
+	ArchiveMediaAspectRatioUnknown ArchiveMediaAspectRatio = 0
+	ArchiveMediaAspectRatio16x9    ArchiveMediaAspectRatio = 1
+	ArchiveMediaAspectRatio2x1     ArchiveMediaAspectRatio = 2
+	ArchiveMediaAspectRatio1x1     ArchiveMediaAspectRatio = 3
+	ArchiveMediaAspectRatio3x4     ArchiveMediaAspectRatio = 4
 )
 
 // ArchiveItemTranslation is the per-block translation. text is used by TEXT
-// blocks; caption by media/embed/product/products blocks.
+// blocks; caption by media_with_caption/embed/product/products blocks.
 type ArchiveItemTranslation struct {
 	LanguageId int    `json:"language_id"`
 	Caption    string `json:"caption"`
 	Text       string `json:"text"`
 }
 
-// ArchiveItemInsert is a single timeline body block as persisted (write side).
-// Only the fields relevant to Type are meaningful.
-type ArchiveItemInsert struct {
-	Type         ArchiveItemType          `json:"type"`
-	MediaId      int                      `json:"media_id"`     // MEDIA
-	EmbedUrl     string                   `json:"embed_url"`    // EMBED
-	ProductId    int                      `json:"product_id"`   // PRODUCT
-	Tag          string                   `json:"tag"`          // PRODUCTS_TAG
-	Limit        int                      `json:"limit"`        // PRODUCTS_TAG cap
-	ProductIds   []int                    `json:"product_ids"`  // PRODUCTS_MANUAL
-	Translations []ArchiveItemTranslation `json:"translations"` // caption / text
+// ─── write side (stored body blocks) ─────────────────────────────────────────
+
+type ArchiveMainMediaInsert struct {
+	MediaId     int                     `json:"media_id"`
+	AspectRatio ArchiveMediaAspectRatio `json:"aspect_ratio"`
 }
 
-// ArchiveItemFull is the resolved timeline body block (read side).
+type ArchiveMediaLineInsert struct {
+	MediaIds    []int                   `json:"media_ids"`
+	AspectRatio ArchiveMediaAspectRatio `json:"aspect_ratio"`
+}
+
+type ArchiveTextInsert struct {
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+type ArchiveEmbedInsert struct {
+	EmbedUrl     string                   `json:"embed_url"`
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+type ArchiveMediaWithCaptionInsert struct {
+	MediaId      int                      `json:"media_id"`
+	Link         string                   `json:"link"`
+	AspectRatio  ArchiveMediaAspectRatio  `json:"aspect_ratio"`
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+type ArchiveProductInsert struct {
+	ProductId    int                      `json:"product_id"`
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+type ArchiveProductsTagInsert struct {
+	Tag          string                   `json:"tag"`
+	Limit        int                      `json:"limit"`
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+type ArchiveProductsManualInsert struct {
+	ProductIds   []int                    `json:"product_ids"`
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+// ArchiveItemInsert is a single timeline body block as persisted (write side).
+// Exactly one payload pointer is set, selected by Type.
+type ArchiveItemInsert struct {
+	Type             ArchiveItemType                `json:"type"`
+	MainMedia        *ArchiveMainMediaInsert        `json:"main_media,omitempty"`
+	MediaLine        *ArchiveMediaLineInsert        `json:"media_line,omitempty"`
+	Text             *ArchiveTextInsert             `json:"text,omitempty"`
+	Embed            *ArchiveEmbedInsert            `json:"embed,omitempty"`
+	MediaWithCaption *ArchiveMediaWithCaptionInsert `json:"media_with_caption,omitempty"`
+	Product          *ArchiveProductInsert          `json:"product,omitempty"`
+	ProductsTag      *ArchiveProductsTagInsert      `json:"products_tag,omitempty"`
+	ProductsManual   *ArchiveProductsManualInsert   `json:"products_manual,omitempty"`
+}
+
+// ─── read side (resolved) ────────────────────────────────────────────────────
+
+type ArchiveMainMediaFull struct {
+	Media       MediaFull               `json:"media"`
+	AspectRatio ArchiveMediaAspectRatio `json:"aspect_ratio"`
+}
+
+type ArchiveMediaLineFull struct {
+	Media       []MediaFull             `json:"media"`
+	AspectRatio ArchiveMediaAspectRatio `json:"aspect_ratio"`
+}
+
+type ArchiveTextFull struct {
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+type ArchiveEmbedFull struct {
+	EmbedUrl     string                   `json:"embed_url"`
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+type ArchiveMediaWithCaptionFull struct {
+	Media        MediaFull                `json:"media"`
+	Link         string                   `json:"link"`
+	AspectRatio  ArchiveMediaAspectRatio  `json:"aspect_ratio"`
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+type ArchiveProductFull struct {
+	Product      *Product                 `json:"product"`
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+type ArchiveProductsTagFull struct {
+	Tag          string                   `json:"tag"`
+	Products     []Product                `json:"products"`
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+type ArchiveProductsManualFull struct {
+	Products     []Product                `json:"products"`
+	Translations []ArchiveItemTranslation `json:"translations"`
+}
+
+// ArchiveItemFull is a single resolved timeline body block (read side). Exactly
+// one payload pointer is set, selected by Type.
 type ArchiveItemFull struct {
-	Type         ArchiveItemType          `json:"type"`
-	Media        MediaFull                `json:"media"`        // MEDIA
-	EmbedUrl     string                   `json:"embed_url"`    // EMBED
-	Product      *Product                 `json:"product"`      // PRODUCT
-	Tag          string                   `json:"tag"`          // PRODUCTS_TAG label
-	Products     []Product                `json:"products"`     // PRODUCTS_TAG + PRODUCTS_MANUAL
-	Translations []ArchiveItemTranslation `json:"translations"` // caption / text
+	Type             ArchiveItemType              `json:"type"`
+	MainMedia        *ArchiveMainMediaFull        `json:"main_media,omitempty"`
+	MediaLine        *ArchiveMediaLineFull        `json:"media_line,omitempty"`
+	Text             *ArchiveTextFull             `json:"text,omitempty"`
+	Embed            *ArchiveEmbedFull            `json:"embed,omitempty"`
+	MediaWithCaption *ArchiveMediaWithCaptionFull `json:"media_with_caption,omitempty"`
+	Product          *ArchiveProductFull          `json:"product,omitempty"`
+	ProductsTag      *ArchiveProductsTagFull      `json:"products_tag,omitempty"`
+	ProductsManual   *ArchiveProductsManualFull   `json:"products_manual,omitempty"`
 }

--- a/internal/store/content/archive.go
+++ b/internal/store/content/archive.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/jekabolt/grbpwr-manager/internal/dependency"
 	"github.com/jekabolt/grbpwr-manager/internal/dto"
@@ -23,8 +24,9 @@ func marshalArchiveBody(items []entity.ArchiveItemInsert) ([]byte, error) {
 	return json.Marshal(items)
 }
 
-// AddArchive adds a new archive: metadata + main media + translations, and the
-// ordered timeline body (typed blocks) stored as JSON in the `body` column.
+// AddArchive adds a new archive: metadata + translations, and the ordered
+// timeline body (typed blocks — main media, media lines, products, etc.) stored
+// as JSON in the `body` column.
 func (s *Store) AddArchive(ctx context.Context, aNew *entity.ArchiveInsert) (int, error) {
 	bodyJSON, err := marshalArchiveBody(aNew.Items)
 	if err != nil {
@@ -44,24 +46,6 @@ func (s *Store) AddArchive(ctx context.Context, aNew *entity.ArchiveInsert) (int
 			return fmt.Errorf("failed to add archive: %w", err)
 		}
 
-		// Insert main media items
-		if len(aNew.MainMediaIds) > 0 {
-			mainMediaRows := make([]map[string]any, 0, len(aNew.MainMediaIds))
-			for i, mid := range aNew.MainMediaIds {
-				row := map[string]any{
-					"archive_id":    aid,
-					"media_id":      mid,
-					"display_order": i,
-				}
-				mainMediaRows = append(mainMediaRows, row)
-			}
-
-			err = storeutil.BulkInsert(ctx, rep.DB(), "archive_main_media", mainMediaRows)
-			if err != nil {
-				return fmt.Errorf("failed to add archive main media: %w", err)
-			}
-		}
-
 		// Insert translations
 		rows := make([]map[string]any, 0, len(aNew.Translations))
 		for _, t := range aNew.Translations {
@@ -69,7 +53,6 @@ func (s *Store) AddArchive(ctx context.Context, aNew *entity.ArchiveInsert) (int
 				"archive_id":  aid,
 				"language_id": t.LanguageId,
 				"heading":     t.Heading,
-				"description": t.Description,
 			}
 			rows = append(rows, row)
 		}
@@ -98,25 +81,16 @@ func (s *Store) UpdateArchive(ctx context.Context, aid int, aInsert *entity.Arch
 		// Ensure the archive exists so an update to a missing id fails loudly
 		// instead of silently affecting zero rows (an UPDATE with unchanged
 		// values reports 0 affected rows, so RowsAffected can't be trusted here).
-		existsQuery := `SELECT 1 FROM archive WHERE id = :id`
-		if _, err := storeutil.QueryNamedOne[int](ctx, rep.DB(), existsQuery, map[string]any{"id": aid}); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("archive %d not found: %w", aid, sql.ErrNoRows)
-			}
+		cnt, err := storeutil.QueryCountNamed(ctx, rep.DB(), `SELECT COUNT(*) FROM archive WHERE id = :id`, map[string]any{"id": aid})
+		if err != nil {
 			return fmt.Errorf("failed to check archive %d exists: %w", aid, err)
 		}
-
-		// Delete existing main media items
-		query := `DELETE FROM archive_main_media WHERE archive_id = :archiveId`
-		_, err = rep.DB().NamedExecContext(ctx, query, map[string]interface{}{
-			"archiveId": aid,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to delete archive main media with archive Id %d: %w", aid, err)
+		if cnt == 0 {
+			return fmt.Errorf("archive %d not found: %w", aid, sql.ErrNoRows)
 		}
 
 		// Update the archive itself (incl. the timeline body)
-		query = `
+		query := `
 		UPDATE archive SET
 			tag = :tag,
 			thumbnail_id = :thumbnail_id,
@@ -131,24 +105,6 @@ func (s *Store) UpdateArchive(ctx context.Context, aid int, aInsert *entity.Arch
 		})
 		if err != nil {
 			return fmt.Errorf("failed to update archive: %w", err)
-		}
-
-		// Insert new main media items
-		if len(aInsert.MainMediaIds) > 0 {
-			mainMediaRows := make([]map[string]any, 0, len(aInsert.MainMediaIds))
-			for i, mid := range aInsert.MainMediaIds {
-				row := map[string]any{
-					"archive_id":    aid,
-					"media_id":      mid,
-					"display_order": i,
-				}
-				mainMediaRows = append(mainMediaRows, row)
-			}
-
-			err = storeutil.BulkInsert(ctx, rep.DB(), "archive_main_media", mainMediaRows)
-			if err != nil {
-				return fmt.Errorf("failed to add archive main media: %w", err)
-			}
 		}
 
 		// Delete existing translations
@@ -167,7 +123,6 @@ func (s *Store) UpdateArchive(ctx context.Context, aid int, aInsert *entity.Arch
 				"archive_id":  aid,
 				"language_id": t.LanguageId,
 				"heading":     t.Heading,
-				"description": t.Description,
 			}
 			rows = append(rows, row)
 		}
@@ -283,14 +238,6 @@ func (s *Store) DeleteArchiveById(ctx context.Context, id int) error {
 			return fmt.Errorf("failed to delete archive with ID %d: %w", id, err)
 		}
 
-		query = `DELETE FROM archive_item WHERE archive_id = :id`
-		_, err = rep.DB().NamedExecContext(ctx, query, map[string]interface{}{
-			"id": id,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to delete archive items with ID %d: %w", id, err)
-		}
-
 		query = `DELETE FROM archive_translation WHERE archive_id = :id`
 		_, err = rep.DB().NamedExecContext(ctx, query, map[string]interface{}{
 			"id": id,
@@ -365,24 +312,16 @@ func (s *Store) GetArchiveById(ctx context.Context, id int) (*entity.ArchiveFull
 		al.Slug = dto.GetArchiveSlug(al.Id, "", al.Tag)
 	}
 
-	// Query all main media for this archive
-	mainMediaQuery := `
-	SELECT 
-		m.id, m.created_at, m.full_size, m.full_size_width, m.full_size_height, m.thumbnail, m.thumbnail_width, m.thumbnail_height, m.compressed, m.compressed_width, m.compressed_height, m.blur_hash
-	FROM archive_main_media amm
-	JOIN media m ON amm.media_id = m.id
-	WHERE amm.archive_id = :archiveId
-	ORDER BY amm.display_order ASC`
-	mainMedia, err := storeutil.QueryListNamed[entity.MediaFull](ctx, s.DB, mainMediaQuery, map[string]any{"archiveId": id})
-	if err != nil {
-		return nil, err
-	}
-
-	// Decode the stored timeline body (typed blocks) and resolve it.
+	// Decode the stored timeline body (typed blocks) and resolve it. A malformed
+	// blob degrades to an empty timeline rather than failing the read: GetArchiveById
+	// runs at boot via hero FEATURED_ARCHIVE resolution, so a single bad body must
+	// not crash App.Start (mirrors the hero getHeroInsert boot-resilience rule).
 	var storedItems []entity.ArchiveItemInsert
 	if len(body) > 0 {
 		if err := json.Unmarshal(body, &storedItems); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal archive body for %d: %w", id, err)
+			slog.ErrorContext(ctx, "failed to unmarshal archive body, serving empty timeline",
+				slog.Int("archive_id", id), slog.String("err", err.Error()))
+			storedItems = nil
 		}
 	}
 
@@ -395,7 +334,6 @@ func (s *Store) GetArchiveById(ctx context.Context, id int) (*entity.ArchiveFull
 
 	return &entity.ArchiveFull{
 		ArchiveList: al,
-		MainMedia:   mainMedia,
 		Items:       items,
 	}, nil
 }
@@ -408,88 +346,120 @@ func (s *Store) GetArchiveById(ctx context.Context, id int) (*entity.ArchiveFull
 func resolveArchiveItems(ctx context.Context, rep dependency.Repository, items []entity.ArchiveItemInsert) ([]entity.ArchiveItemFull, error) {
 	out := make([]entity.ArchiveItemFull, 0, len(items))
 	for _, it := range items {
-		full := entity.ArchiveItemFull{
-			Type:         it.Type,
-			EmbedUrl:     it.EmbedUrl,
-			Tag:          it.Tag,
-			Translations: it.Translations,
-		}
+		full := entity.ArchiveItemFull{Type: it.Type}
 
 		switch it.Type {
-		case entity.ArchiveItemTypeMedia:
-			if it.MediaId == 0 {
-				slog.WarnContext(ctx, "archive media block has no media id, skipping")
+		case entity.ArchiveItemTypeMainMedia:
+			if it.MainMedia == nil || it.MainMedia.MediaId == 0 {
+				slog.WarnContext(ctx, "archive main_media block has no media id, skipping")
 				continue
 			}
-			m, err := rep.Media().GetMediaById(ctx, it.MediaId)
+			m, ok, err := resolveMediaById(ctx, rep, it.MainMedia.MediaId, "main_media")
 			if err != nil {
-				if errors.Is(err, sql.ErrNoRows) {
-					slog.WarnContext(ctx, "archive media block references missing media, skipping", slog.Int("media_id", it.MediaId))
-					continue
-				}
-				return nil, fmt.Errorf("failed to get archive media %d: %w", it.MediaId, err)
+				return nil, err
 			}
-			full.Media = *m
+			if !ok {
+				continue
+			}
+			full.MainMedia = &entity.ArchiveMainMediaFull{Media: *m, AspectRatio: it.MainMedia.AspectRatio}
+
+		case entity.ArchiveItemTypeMediaLine:
+			if it.MediaLine == nil || len(it.MediaLine.MediaIds) == 0 {
+				slog.WarnContext(ctx, "archive media_line block has no media ids, skipping")
+				continue
+			}
+			media, err := resolveMediaByIds(ctx, rep, it.MediaLine.MediaIds, "media_line")
+			if err != nil {
+				return nil, err
+			}
+			if len(media) == 0 {
+				continue
+			}
+			full.MediaLine = &entity.ArchiveMediaLineFull{Media: media, AspectRatio: it.MediaLine.AspectRatio}
 
 		case entity.ArchiveItemTypeText:
-			// text lives entirely in the block translations
+			if it.Text == nil || !hasArchiveText(it.Text.Translations) {
+				slog.WarnContext(ctx, "archive text block has no copy, skipping")
+				continue
+			}
+			full.Text = &entity.ArchiveTextFull{Translations: it.Text.Translations}
 
 		case entity.ArchiveItemTypeEmbed:
-			if it.EmbedUrl == "" {
+			if it.Embed == nil || it.Embed.EmbedUrl == "" {
 				slog.WarnContext(ctx, "archive embed block has no url, skipping")
 				continue
 			}
+			full.Embed = &entity.ArchiveEmbedFull{EmbedUrl: it.Embed.EmbedUrl, Translations: it.Embed.Translations}
+
+		case entity.ArchiveItemTypeMediaWithCaption:
+			if it.MediaWithCaption == nil || it.MediaWithCaption.MediaId == 0 {
+				slog.WarnContext(ctx, "archive media_with_caption block has no media id, skipping")
+				continue
+			}
+			m, ok, err := resolveMediaById(ctx, rep, it.MediaWithCaption.MediaId, "media_with_caption")
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+			full.MediaWithCaption = &entity.ArchiveMediaWithCaptionFull{
+				Media:        *m,
+				Link:         it.MediaWithCaption.Link,
+				AspectRatio:  it.MediaWithCaption.AspectRatio,
+				Translations: it.MediaWithCaption.Translations,
+			}
 
 		case entity.ArchiveItemTypeProduct:
-			if it.ProductId == 0 {
+			if it.Product == nil || it.Product.ProductId == 0 {
 				slog.WarnContext(ctx, "archive product block has no product id, skipping")
 				continue
 			}
-			products, err := rep.Products().GetProductsByIds(ctx, []int{it.ProductId})
+			products, err := rep.Products().GetProductsByIds(ctx, []int{it.Product.ProductId})
 			if err != nil {
-				return nil, fmt.Errorf("failed to get archive product %d: %w", it.ProductId, err)
+				return nil, fmt.Errorf("failed to get archive product %d: %w", it.Product.ProductId, err)
 			}
 			prds := filterVisibleProducts(products)
 			if len(prds) == 0 {
-				slog.WarnContext(ctx, "archive product block references missing/hidden product, skipping", slog.Int("product_id", it.ProductId))
+				slog.WarnContext(ctx, "archive product block references missing/hidden product, skipping", slog.Int("product_id", it.Product.ProductId))
 				continue
 			}
 			p := prds[0]
-			full.Product = &p
+			full.Product = &entity.ArchiveProductFull{Product: &p, Translations: it.Product.Translations}
 
 		case entity.ArchiveItemTypeProductsTag:
-			if it.Tag == "" {
+			if it.ProductsTag == nil || it.ProductsTag.Tag == "" {
 				slog.WarnContext(ctx, "archive products-by-tag block has no tag, skipping")
 				continue
 			}
-			products, err := rep.Products().GetProductsByTag(ctx, it.Tag)
+			products, err := rep.Products().GetProductsByTag(ctx, it.ProductsTag.Tag)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get archive products by tag %q: %w", it.Tag, err)
+				return nil, fmt.Errorf("failed to get archive products by tag %q: %w", it.ProductsTag.Tag, err)
 			}
 			prds := filterVisibleProducts(products)
-			if it.Limit > 0 && len(prds) > it.Limit {
-				prds = prds[:it.Limit]
+			if it.ProductsTag.Limit > 0 && len(prds) > it.ProductsTag.Limit {
+				prds = prds[:it.ProductsTag.Limit]
 			}
 			if len(prds) == 0 {
 				continue
 			}
-			full.Products = prds
+			full.ProductsTag = &entity.ArchiveProductsTagFull{Tag: it.ProductsTag.Tag, Products: prds, Translations: it.ProductsTag.Translations}
 
 		case entity.ArchiveItemTypeProductsManual:
-			if len(it.ProductIds) == 0 {
+			if it.ProductsManual == nil || len(it.ProductsManual.ProductIds) == 0 {
 				slog.WarnContext(ctx, "archive manual-products block has no product ids, skipping")
 				continue
 			}
-			products, err := rep.Products().GetProductsByIds(ctx, it.ProductIds)
+			products, err := rep.Products().GetProductsByIds(ctx, it.ProductsManual.ProductIds)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get archive manual products: %w", err)
 			}
 			// Preserve the hand-picked order (GetProductsByIds returns DB order).
-			prds := orderProductsByIds(filterVisibleProducts(products), it.ProductIds)
+			prds := orderProductsByIds(filterVisibleProducts(products), it.ProductsManual.ProductIds)
 			if len(prds) == 0 {
 				continue
 			}
-			full.Products = prds
+			full.ProductsManual = &entity.ArchiveProductsManualFull{Products: prds, Translations: it.ProductsManual.Translations}
 
 		default:
 			slog.ErrorContext(ctx, "unknown archive block type, skipping", slog.Int("type", int(it.Type)))
@@ -499,6 +469,52 @@ func resolveArchiveItems(ctx context.Context, rep dependency.Repository, items [
 		out = append(out, full)
 	}
 	return out, nil
+}
+
+// resolveMediaById fetches a single media by id. It returns ok=false (and no
+// error) when the media row is gone, so callers skip just that reference; a
+// genuine DB failure is returned as an error.
+func resolveMediaById(ctx context.Context, rep dependency.Repository, id int, block string) (*entity.MediaFull, bool, error) {
+	m, err := rep.Media().GetMediaById(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.WarnContext(ctx, "archive "+block+" references missing media, skipping", slog.Int("media_id", id))
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to get archive %s media %d: %w", block, id, err)
+	}
+	return m, true, nil
+}
+
+// resolveMediaByIds fetches media by id in order, skipping (with a warning) any
+// id that is zero or no longer resolves to a row, and propagating genuine DB errors.
+func resolveMediaByIds(ctx context.Context, rep dependency.Repository, ids []int, block string) ([]entity.MediaFull, error) {
+	media := make([]entity.MediaFull, 0, len(ids))
+	for _, mid := range ids {
+		if mid == 0 {
+			continue
+		}
+		m, ok, err := resolveMediaById(ctx, rep, mid, block)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		media = append(media, *m)
+	}
+	return media, nil
+}
+
+// hasArchiveText reports whether any translation carries non-blank body copy, so
+// a TEXT block with no actual text is dropped rather than rendered empty.
+func hasArchiveText(ts []entity.ArchiveItemTranslation) bool {
+	for _, t := range ts {
+		if strings.TrimSpace(t.Text) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // orderProductsByIds returns products ordered to match ids, dropping any id with
@@ -519,8 +535,8 @@ func orderProductsByIds(products []entity.Product, ids []int) []entity.Product {
 
 func (s *Store) GetArchiveTranslations(ctx context.Context, id int) ([]entity.ArchiveTranslation, error) {
 	query := `
-	SELECT 
-		at.language_id, at.heading, at.description
+	SELECT
+		at.language_id, at.heading
 	FROM archive_translation at
 	WHERE at.archive_id = :id`
 	translations, err := storeutil.QueryListNamed[entity.ArchiveTranslation](ctx, s.DB, query, map[string]any{"id": id})

--- a/internal/store/sql/0081_archive_timeline_body_v2.sql
+++ b/internal/store/sql/0081_archive_timeline_body_v2.sql
@@ -1,0 +1,22 @@
+-- +migrate Up
+-- Timeline body v2: every archive element is now a typed block in the JSON `body`
+-- column (added in 0080) — main media, media lines, text, iframe, media+caption,
+-- product, products-by-tag, hand-picked products.
+--
+-- DELIBERATE BREAKING CHANGE (product decision — "accept the wipe"): the block
+-- model was restructured (ArchiveItemType renumbered, payloads moved into nested
+-- objects) and the archive hero media moved out of its own join table into a
+-- MAIN_MEDIA block, so pre-v2 content cannot be carried forward. Every archive
+-- must be re-authored from admin after this deploys. Concretely:
+--   1. Stale pre-v2 `body` blobs (old flat format) are cleared to NULL so an
+--      un-re-authored archive is explicitly empty rather than silently skipped.
+--   2. The per-archive main-media join table and the long-superseded flat
+--      archive_item table (unused since 0080) are dropped.
+--   3. The archive carries a title only now, so archive_translation.description
+--      is removed (irreversible — description copy is discarded).
+-- This is Up-only and irreversible (mirrors 0080); on prod it auto-applies via
+-- MYSQL_AUTOMIGRATE and reaches prod through the feature->beta->master flow.
+UPDATE archive SET body = NULL;
+DROP TABLE IF EXISTS archive_main_media;
+DROP TABLE IF EXISTS archive_item;
+ALTER TABLE archive_translation DROP COLUMN description;

--- a/proto/common/common/archive.proto
+++ b/proto/common/common/archive.proto
@@ -11,14 +11,29 @@ option go_package = "github.com/jekabolt/grbpwr-manager/proto/gen/common;common"
 
 // ArchiveItemType discriminates a timeline body block. The archive body is an
 // ordered, heterogeneous list of these blocks (Insert-form storage, like hero).
+// Blocks may repeat and appear in any order; only the archive thumbnail, title
+// (heading translation) and tag are mandatory — every timeline block is optional.
 enum ArchiveItemType {
   ARCHIVE_ITEM_TYPE_UNKNOWN = 0;
-  ARCHIVE_ITEM_TYPE_MEDIA = 1; // image / video
-  ARCHIVE_ITEM_TYPE_TEXT = 2; // translatable text block
-  ARCHIVE_ITEM_TYPE_EMBED = 3; // iframe
-  ARCHIVE_ITEM_TYPE_PRODUCT = 4; // a single product
-  ARCHIVE_ITEM_TYPE_PRODUCTS_TAG = 5; // products resolved by tag
-  ARCHIVE_ITEM_TYPE_PRODUCTS_MANUAL = 6; // hand-picked products
+  ARCHIVE_ITEM_TYPE_MAIN_MEDIA = 1; // single hero-scale media (video or image)
+  ARCHIVE_ITEM_TYPE_MEDIA_LINE = 2; // a row of 1..4 media
+  ARCHIVE_ITEM_TYPE_TEXT = 3; // translatable text block
+  ARCHIVE_ITEM_TYPE_EMBED = 4; // iframe
+  ARCHIVE_ITEM_TYPE_MEDIA_WITH_CAPTION = 5; // media + caption + link
+  ARCHIVE_ITEM_TYPE_PRODUCT = 6; // a single product
+  ARCHIVE_ITEM_TYPE_PRODUCTS_TAG = 7; // products resolved by tag
+  ARCHIVE_ITEM_TYPE_PRODUCTS_MANUAL = 8; // hand-picked products
+}
+
+// ArchiveMediaAspectRatio is the presentation aspect ratio for the media blocks.
+// MAIN_MEDIA uses 16X9 / 2X1 / 1X1 (or UNKNOWN — e.g. a video that carries its
+// own dimensions); MEDIA_LINE and MEDIA_WITH_CAPTION use 3X4 / 1X1.
+enum ArchiveMediaAspectRatio {
+  ARCHIVE_MEDIA_ASPECT_RATIO_UNKNOWN = 0;
+  ARCHIVE_MEDIA_ASPECT_RATIO_16X9 = 1;
+  ARCHIVE_MEDIA_ASPECT_RATIO_2X1 = 2;
+  ARCHIVE_MEDIA_ASPECT_RATIO_1X1 = 3;
+  ARCHIVE_MEDIA_ASPECT_RATIO_3X4 = 4;
 }
 
 message ArchiveList {
@@ -30,33 +45,137 @@ message ArchiveList {
   common.MediaFull thumbnail = 6;
 }
 
-// ArchiveItemInsert is a single timeline body block (write side). Only the
-// fields relevant to `type` are used.
-message ArchiveItemInsert {
-  ArchiveItemType type = 1;
-  int32 media_id = 2; // MEDIA
-  string embed_url = 3; // EMBED (iframe src)
-  int32 product_id = 4; // PRODUCT
-  string tag = 5; // PRODUCTS_TAG
-  int32 limit = 6; // PRODUCTS_TAG cap (0 = no cap)
-  repeated int32 product_ids = 7; // PRODUCTS_MANUAL
-  repeated common.ArchiveItemTranslation translations = 8; // caption / text
+// ─── read side (resolved timeline blocks) ────────────────────────────────────
+
+// MAIN_MEDIA: a single hero-scale media (image or video). aspect_ratio applies
+// to images (16X9 / 2X1 / 1X1) and is UNKNOWN for video.
+message ArchiveMainMediaFull {
+  common.MediaFull media = 1;
+  ArchiveMediaAspectRatio aspect_ratio = 2;
 }
 
-// ArchiveItemFull is the resolved timeline body block (read side).
+// MEDIA_LINE: a row of 1..4 media sharing one aspect ratio (3X4 or 1X1).
+message ArchiveMediaLineFull {
+  repeated common.MediaFull media = 1;
+  ArchiveMediaAspectRatio aspect_ratio = 2;
+}
+
+// TEXT: a translatable text block (copy lives in translations.text).
+message ArchiveTextFull {
+  repeated common.ArchiveItemTranslation translations = 1;
+}
+
+// EMBED: an iframe. Optional caption in translations.caption.
+message ArchiveEmbedFull {
+  string embed_url = 1;
+  repeated common.ArchiveItemTranslation translations = 2;
+}
+
+// MEDIA_WITH_CAPTION: one media with a translatable caption and an outbound link.
+message ArchiveMediaWithCaptionFull {
+  common.MediaFull media = 1;
+  string link = 2;
+  ArchiveMediaAspectRatio aspect_ratio = 3;
+  repeated common.ArchiveItemTranslation translations = 4; // caption
+}
+
+// PRODUCT: a single product. Optional caption in translations.caption.
+message ArchiveProductFull {
+  common.Product product = 1;
+  repeated common.ArchiveItemTranslation translations = 2;
+}
+
+// PRODUCTS_TAG: products resolved by tag. Optional caption in translations.caption.
+message ArchiveProductsTagFull {
+  string tag = 1;
+  repeated common.Product products = 2;
+  repeated common.ArchiveItemTranslation translations = 3;
+}
+
+// PRODUCTS_MANUAL: hand-picked, ordered products. Optional caption.
+message ArchiveProductsManualFull {
+  repeated common.Product products = 1;
+  repeated common.ArchiveItemTranslation translations = 2;
+}
+
+// ArchiveItemFull is a single resolved timeline body block (read side). Exactly
+// one payload field is populated, selected by `type`.
 message ArchiveItemFull {
   ArchiveItemType type = 1;
-  common.MediaFull media = 2; // MEDIA
-  string embed_url = 3; // EMBED
-  common.Product product = 4; // PRODUCT
-  string tag = 5; // PRODUCTS_TAG label
-  repeated common.Product products = 6; // PRODUCTS_TAG + PRODUCTS_MANUAL
-  repeated common.ArchiveItemTranslation translations = 7; // caption / text
+  ArchiveMainMediaFull main_media = 2;
+  ArchiveMediaLineFull media_line = 3;
+  ArchiveTextFull text = 4;
+  ArchiveEmbedFull embed = 5;
+  ArchiveMediaWithCaptionFull media_with_caption = 6;
+  ArchiveProductFull product = 7;
+  ArchiveProductsTagFull products_tag = 8;
+  ArchiveProductsManualFull products_manual = 9;
 }
+
+// ─── write side (insert timeline blocks) ─────────────────────────────────────
+
+message ArchiveMainMediaInsert {
+  int32 media_id = 1;
+  ArchiveMediaAspectRatio aspect_ratio = 2;
+}
+
+message ArchiveMediaLineInsert {
+  repeated int32 media_ids = 1; // 1..4
+  ArchiveMediaAspectRatio aspect_ratio = 2;
+}
+
+message ArchiveTextInsert {
+  repeated common.ArchiveItemTranslation translations = 1;
+}
+
+message ArchiveEmbedInsert {
+  string embed_url = 1;
+  repeated common.ArchiveItemTranslation translations = 2; // optional caption
+}
+
+message ArchiveMediaWithCaptionInsert {
+  int32 media_id = 1;
+  string link = 2;
+  ArchiveMediaAspectRatio aspect_ratio = 3;
+  repeated common.ArchiveItemTranslation translations = 4; // caption
+}
+
+message ArchiveProductInsert {
+  int32 product_id = 1;
+  repeated common.ArchiveItemTranslation translations = 2; // optional caption
+}
+
+message ArchiveProductsTagInsert {
+  string tag = 1;
+  int32 limit = 2; // 0 = no cap
+  repeated common.ArchiveItemTranslation translations = 3; // optional caption
+}
+
+message ArchiveProductsManualInsert {
+  repeated int32 product_ids = 1;
+  repeated common.ArchiveItemTranslation translations = 2; // optional caption
+}
+
+// ArchiveItemInsert is a single timeline body block (write side). Exactly one
+// payload field is set, selected by `type`.
+message ArchiveItemInsert {
+  ArchiveItemType type = 1;
+  ArchiveMainMediaInsert main_media = 2;
+  ArchiveMediaLineInsert media_line = 3;
+  ArchiveTextInsert text = 4;
+  ArchiveEmbedInsert embed = 5;
+  ArchiveMediaWithCaptionInsert media_with_caption = 6;
+  ArchiveProductInsert product = 7;
+  ArchiveProductsTagInsert products_tag = 8;
+  ArchiveProductsManualInsert products_manual = 9;
+}
+
+// ─── top-level archive ───────────────────────────────────────────────────────
 
 message ArchiveFull {
   ArchiveList archive_list = 1;
-  repeated common.MediaFull main_media = 2;
+  reserved 2; // was `main_media` (top-level hero) — now the MAIN_MEDIA timeline block
+  reserved "main_media";
   reserved 3; // was `media` (flat media-only body) — replaced by items
   reserved "media";
   repeated ArchiveItemFull items = 4; // ordered, resolved timeline body
@@ -66,7 +185,8 @@ message ArchiveInsert {
   string tag = 1;
   reserved 2; // was `media_ids` (flat media-only body) — replaced by items
   reserved "media_ids";
-  repeated int32 main_media_ids = 3;
+  reserved 3; // was `main_media_ids` (top-level hero) — now the MAIN_MEDIA timeline block
+  reserved "main_media_ids";
   int32 thumbnail_id = 4;
   repeated common.ArchiveInsertTranslation translations = 5;
   repeated ArchiveItemInsert items = 6; // ordered timeline body

--- a/proto/common/common/language.proto
+++ b/proto/common/common/language.proto
@@ -22,14 +22,14 @@ message ProductInsertTranslation {
 
 message ArchiveInsertTranslation {
   int32 language_id = 1;
-  string heading = 2;
-  string description = 3;
+  string heading = 2; // the archive title
 }
 
 // ArchiveItemTranslation is the per-block translation for a timeline body item.
 // Each block type uses only the subset it needs:
-//   text                         -> text
-//   media/embed/product/products -> caption
+//   text                                          -> text
+//   media_with_caption/embed/product/products_*   -> caption
+// (main_media and media_line carry no copy.)
 message ArchiveItemTranslation {
   int32 language_id = 1;
   string caption = 2;


### PR DESCRIPTION
Reworks the archive timeline into a hero-style typed union: 8 block types
(main_media, media_line, text, embed, media_with_caption, product,
products_tag, products_manual) with per-block aspect ratios, stored as a
typed JSON body. Main media moves from its own join table into a MAIN_MEDIA
block; the archive carries a title only.

⚠️ BREAKING / IRREVERSIBLE on prod: migration 0081 wipes pre-v2 archive
bodies and drops archive_main_media, archive_item, and
archive_translation.description. Existing archives must be re-authored from
admin, and the Vercel storefront/admin frontends must be updated to read the
MAIN_MEDIA block instead of archive.main_media and to stop reading
translations[].description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)