### PR TITLE
Margin/analytics v2: dashboard, tunable alerts, payment fees, per-row margin (breaking proto)

### DIFF
--- a/internal/apisrv/admin/metrics.go
+++ b/internal/apisrv/admin/metrics.go
@@ -836,6 +836,35 @@ func (s *Server) GetDashboard(ctx context.Context, req *pb_admin.GetDashboardReq
 	return dto.ConvertDashboardToPb(d), nil
 }
 
+// GetAlertSettings returns the operator-tunable dashboard alert thresholds.
+func (s *Server) GetAlertSettings(ctx context.Context, _ *pb_admin.GetAlertSettingsRequest) (*pb_admin.GetAlertSettingsResponse, error) {
+	t, err := s.repo.Metrics().GetAlertThresholds(ctx)
+	if err != nil {
+		slog.Default().ErrorContext(ctx, "can't get alert settings", slog.String("err", err.Error()))
+		return nil, status.Errorf(codes.Internal, "can't get alert settings")
+	}
+	return &pb_admin.GetAlertSettingsResponse{Settings: dto.AlertThresholdsToPb(t)}, nil
+}
+
+// UpsertAlertSettings updates the dashboard alert thresholds after validating their ranges.
+func (s *Server) UpsertAlertSettings(ctx context.Context, req *pb_admin.UpsertAlertSettingsRequest) (*pb_admin.UpsertAlertSettingsResponse, error) {
+	if req.Settings == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "settings is required")
+	}
+	t := dto.AlertThresholdsFromPb(req.Settings)
+	if t.CoverageWarnPct < 0 || t.CoverageWarnPct > 100 ||
+		t.RefundRateWarnPct < 0 || t.RefundRateWarnPct > 100 ||
+		t.ContributionTrustPct < 0 || t.ContributionTrustPct > 100 ||
+		t.RateFloorN < 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "percentages must be within [0,100] and rate_floor_n >= 0")
+	}
+	if err := s.repo.Metrics().UpsertAlertThresholds(ctx, t); err != nil {
+		slog.Default().ErrorContext(ctx, "can't upsert alert settings", slog.String("err", err.Error()))
+		return nil, status.Errorf(codes.Internal, "can't upsert alert settings")
+	}
+	return &pb_admin.UpsertAlertSettingsResponse{}, nil
+}
+
 // enrichCampaignSpend fills Spend and ROAS on the attribution rows from channel_spend,
 // matching by the UTM triple over the same period. Mutates rows in place.
 func (s *Server) enrichCampaignSpend(ctx context.Context, from, to time.Time, rows []entity.CampaignAttributionAggregatedFull) error {

--- a/internal/apisrv/admin/metrics.go
+++ b/internal/apisrv/admin/metrics.go
@@ -809,6 +809,33 @@ func channelKey(source, medium, campaign string) string {
 	return source + "\x00" + medium + "\x00" + campaign
 }
 
+// GetDashboard returns the small, DB-trusted decision payload. It reuses the GetMetrics
+// period grammar but computes only the headline figures, alerts and short action lists.
+func (s *Server) GetDashboard(ctx context.Context, req *pb_admin.GetDashboardRequest) (*pb_admin.GetDashboardResponse, error) {
+	if strings.TrimSpace(req.Period) == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "period is required (e.g. 7d, 30d, 90d, today, WTD, MTD, QTD, YTD)")
+	}
+	endAt := time.Now().UTC()
+	if req.EndAt != nil {
+		endAt = req.EndAt.AsTime().UTC()
+	}
+	from, to, isSpecial := computePeriodBounds(req.Period, endAt)
+	if !isSpecial {
+		dur, err := parseMetricsPeriod(req.Period)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid period %q: %v", req.Period, err)
+		}
+		to = endAt
+		from = endAt.Add(-dur)
+	}
+	d, err := s.repo.Metrics().GetDashboard(ctx, from, to, int(req.Limit))
+	if err != nil {
+		slog.Default().ErrorContext(ctx, "can't get dashboard", slog.String("err", err.Error()))
+		return nil, status.Errorf(codes.Internal, "can't get dashboard")
+	}
+	return dto.ConvertDashboardToPb(d), nil
+}
+
 // enrichCampaignSpend fills Spend and ROAS on the attribution rows from channel_spend,
 // matching by the UTM triple over the same period. Mutates rows in place.
 func (s *Server) enrichCampaignSpend(ctx context.Context, from, to time.Time, rows []entity.CampaignAttributionAggregatedFull) error {

--- a/internal/apisrv/admin/metrics.go
+++ b/internal/apisrv/admin/metrics.go
@@ -339,6 +339,15 @@ func (s *Server) GetMetrics(ctx context.Context, req *pb_admin.GetMetricsRequest
 		resp.SlowMovers = dto.ConvertSlowMoversToPb(items)
 	}
 
+	if want(pb_admin.MetricsSection_METRICS_SECTION_SELL_THROUGH_BY_DROP) {
+		items, err := s.repo.Metrics().GetSellThroughByDrop(ctx, from, to, limit)
+		if err != nil {
+			slog.Default().ErrorContext(ctx, "can't get sell-through by drop", slog.String("err", err.Error()))
+			return nil, status.Errorf(codes.Internal, "can't get sell-through by drop")
+		}
+		resp.SellThroughByDrop = dto.ConvertSellThroughByDropToPb(items)
+	}
+
 	if want(pb_admin.MetricsSection_METRICS_SECTION_RETURN_ANALYSIS) {
 		byProduct, err := s.repo.Metrics().GetReturnByProduct(ctx, from, to, limit)
 		if err != nil {

--- a/internal/apisrv/admin/metrics.go
+++ b/internal/apisrv/admin/metrics.go
@@ -833,6 +833,9 @@ func (s *Server) enrichCampaignSpend(ctx context.Context, from, to time.Time, ro
 		}
 		rows[i].Spend = sp
 		rows[i].ROAS = rows[i].Revenue.Div(sp).InexactFloat64()
+		if rows[i].Conversions > 0 {
+			rows[i].CAC = sp.Div(decimal.NewFromInt(rows[i].Conversions)).InexactFloat64()
+		}
 	}
 	return nil
 }

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -244,6 +244,9 @@ type (
 		GetSizeRunEfficiency(ctx context.Context, from, to time.Time, limit int) ([]entity.SizeRunEfficiencyRow, error)
 		// UpsertInventoryTargets sets per-SKU reorder targets (insert or replace by product+size).
 		UpsertInventoryTargets(ctx context.Context, targets []entity.InventoryTargetInsert) error
+		// GetSellThroughByDrop rolls each drop cohort (product.collection) into lifetime
+		// sell-through totals. from/to are accepted for interface consistency but not applied.
+		GetSellThroughByDrop(ctx context.Context, from, to time.Time, limit int) ([]entity.SellThroughByDropRow, error)
 	}
 
 	Retention interface {

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -274,6 +274,9 @@ type (
 		Inventory
 		Analytics
 		GetBusinessMetrics(ctx context.Context, period, comparePeriod entity.TimeRange, granularity entity.MetricsGranularity) (*entity.BusinessMetrics, error)
+		// GetDashboard returns the small, DB-trusted decision payload (headline + alerts +
+		// action lists) without building the full BusinessMetrics god-object.
+		GetDashboard(ctx context.Context, from, to time.Time, limit int) (*entity.Dashboard, error)
 		// GetEmailMetricsSummary aggregates email delivery counters for a date range and computes rates.
 		GetEmailMetricsSummary(ctx context.Context, from, to time.Time) (*entity.EmailMetricsSummary, error)
 		// GetPeriodOrderCount returns the number of placed orders (valid statuses) in [from, to).

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -113,7 +113,7 @@ type (
 		InsertFiatInvoice(ctx context.Context, orderUUID string, clientSecret string, pm entity.PaymentMethod, expiredAt time.Time) (*entity.OrderFull, error)
 		AssociatePaymentIntentWithOrder(ctx context.Context, orderUUID string, paymentIntentId string) error
 		UpdateTotalPaymentCurrency(ctx context.Context, orderUUID string, tapc decimal.Decimal) error
-		UpdateTotalSettledBase(ctx context.Context, orderUUID string, settledBase decimal.Decimal) error
+		UpdateSettledBaseAndFee(ctx context.Context, orderUUID string, settledBase, paymentFee decimal.Decimal) error
 		SetTrackingNumber(ctx context.Context, orderUUID string, trackingCode string) (*entity.OrderBuyerShipment, error)
 		GetOrderById(ctx context.Context, orderID int) (*entity.OrderFull, error)
 		GetPaymentByOrderUUID(ctx context.Context, orderUUID string) (*entity.Payment, error)

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -277,6 +277,10 @@ type (
 		// GetDashboard returns the small, DB-trusted decision payload (headline + alerts +
 		// action lists) without building the full BusinessMetrics god-object.
 		GetDashboard(ctx context.Context, from, to time.Time, limit int) (*entity.Dashboard, error)
+		// GetAlertThresholds / UpsertAlertThresholds read and write the operator-tunable
+		// thresholds behind the dashboard alerts (alert_setting table).
+		GetAlertThresholds(ctx context.Context) (entity.AlertThresholds, error)
+		UpsertAlertThresholds(ctx context.Context, t entity.AlertThresholds) error
 		// GetEmailMetricsSummary aggregates email delivery counters for a date range and computes rates.
 		GetEmailMetricsSummary(ctx context.Context, from, to time.Time) (*entity.EmailMetricsSummary, error)
 		// GetPeriodOrderCount returns the number of placed orders (valid statuses) in [from, to).

--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -1076,6 +1076,28 @@ func ConvertSellThroughByDropToPb(list []entity.SellThroughByDropRow) []*pb_admi
 	return pb
 }
 
+// AlertThresholdsToPb / AlertThresholdsFromPb map the operator-tunable alert thresholds.
+func AlertThresholdsToPb(t entity.AlertThresholds) *pb_admin.AlertSettings {
+	return &pb_admin.AlertSettings{
+		CoverageWarnPct:      t.CoverageWarnPct,
+		RefundRateWarnPct:    t.RefundRateWarnPct,
+		RateFloorN:           int32(t.RateFloorN),
+		ContributionTrustPct: t.ContributionTrustPct,
+	}
+}
+
+func AlertThresholdsFromPb(s *pb_admin.AlertSettings) entity.AlertThresholds {
+	if s == nil {
+		return entity.DefaultAlertThresholds()
+	}
+	return entity.AlertThresholds{
+		CoverageWarnPct:      s.CoverageWarnPct,
+		RefundRateWarnPct:    s.RefundRateWarnPct,
+		RateFloorN:           int(s.RateFloorN),
+		ContributionTrustPct: s.ContributionTrustPct,
+	}
+}
+
 func alertSeverityToPb(s entity.AlertSeverity) pb_admin.AlertSeverity {
 	switch s {
 	case entity.AlertSeverityInfo:

--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -980,6 +980,7 @@ func ConvertInventoryHealthToPb(list []entity.InventoryHealthRow) []*pb_admin.In
 			LeadTimeDays:    int32(r.LeadTimeDays.Int64),
 			NeedsReorder:    r.NeedsReorder,
 			HasTarget:       r.HasTarget,
+			IsSelling:       r.IsSelling,
 		}
 	}
 	return pb

--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -231,6 +231,12 @@ func metricWithComparisonToPb(m entity.MetricWithComparison, opts ...any) *pb_ad
 	if m.Caveat != "" {
 		pb.Caveat = m.Caveat
 	}
+	if m.SampleSize > 0 {
+		pb.SampleSize = int32(m.SampleSize)
+	}
+	if m.MarginOfError > 0 {
+		pb.MarginOfError = m.MarginOfError
+	}
 	return pb
 }
 

--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -1048,6 +1048,54 @@ func ConvertSellThroughByDropToPb(list []entity.SellThroughByDropRow) []*pb_admi
 	return pb
 }
 
+func alertSeverityToPb(s entity.AlertSeverity) pb_admin.AlertSeverity {
+	switch s {
+	case entity.AlertSeverityInfo:
+		return pb_admin.AlertSeverity_ALERT_SEVERITY_INFO
+	case entity.AlertSeverityWarning:
+		return pb_admin.AlertSeverity_ALERT_SEVERITY_WARNING
+	case entity.AlertSeverityCritical:
+		return pb_admin.AlertSeverity_ALERT_SEVERITY_CRITICAL
+	default:
+		return pb_admin.AlertSeverity_ALERT_SEVERITY_UNSPECIFIED
+	}
+}
+
+// ConvertDashboardToPb maps the decision-grade dashboard payload, reusing the section
+// converters for the action lists.
+func ConvertDashboardToPb(d *entity.Dashboard) *pb_admin.GetDashboardResponse {
+	if d == nil {
+		return nil
+	}
+	resp := &pb_admin.GetDashboardResponse{
+		Period:             timeRangeToPb(d.Period),
+		Revenue:            &decimal.Decimal{Value: d.Revenue.String()},
+		Orders:             int32(d.Orders),
+		GrossMargin:        &decimal.Decimal{Value: d.GrossMargin.String()},
+		GrossMarginPct:     d.GrossMarginPct,
+		ContributionMargin: &decimal.Decimal{Value: d.ContributionMargin.String()},
+		CostCoveragePct:    d.CostCoveragePct,
+		Caveat:             d.Caveat,
+		UncostedProductIds: intsToInt32(d.UncostedProductIds),
+		TopByMargin:        productMetricsToPb(d.TopByMargin),
+		Reorder:            ConvertInventoryHealthToPb(d.Reorder),
+		Clear:              ConvertSlowMoversToPb(d.Clear),
+		Drops:              ConvertSellThroughByDropToPb(d.Drops),
+	}
+	if len(d.Alerts) > 0 {
+		resp.Alerts = make([]*pb_admin.DashboardAlert, len(d.Alerts))
+		for i, a := range d.Alerts {
+			resp.Alerts[i] = &pb_admin.DashboardAlert{
+				Severity: alertSeverityToPb(a.Severity),
+				Code:     a.Code,
+				Title:    a.Title,
+				Detail:   a.Detail,
+			}
+		}
+	}
+	return resp
+}
+
 func ConvertSlowMoversToPb(list []entity.SlowMoverRow) []*pb_admin.SlowMoverRow {
 	if len(list) == 0 {
 		return nil

--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -65,6 +65,7 @@ func ConvertEntityBusinessMetricsToPb(m *entity.BusinessMetrics) *pb_admin.Busin
 		RevenueCost:        metricWithComparisonToPb(m.RevenueCost, false, false, int32(2)),
 		GrossMargin:        metricWithComparisonToPb(m.GrossMargin, false, false, int32(2)),
 		GrossMarginPct:     metricWithComparisonToPb(m.GrossMarginPct, false, false, int32(2)),
+		PaymentFees:        metricWithComparisonToPb(m.PaymentFees, false, false, int32(2)),
 		ContributionMargin: metricWithComparisonToPb(m.ContributionMargin, false, false, int32(2)),
 		CostCoveragePct:    m.CostCoveragePct,
 		UncostedProductIds: intsToInt32(m.UncostedProductIds),

--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -1457,6 +1457,7 @@ func ConvertCampaignAttributionAggregatedToPb(list []entity.CampaignAttributionA
 			ConversionRate: r.ConversionRate,
 			Spend:          &decimal.Decimal{Value: r.Spend.String()},
 			Roas:           r.ROAS,
+			Cac:            r.CAC,
 		})
 	}
 	return pb

--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -22,12 +22,30 @@ func fractionToPct(v float64) float64 {
 	return v * 100
 }
 
+// ConvertEntityBusinessMetricsToPb maps the flat internal entity into the typed, provenance-
+// grouped API message (commerce / margin / traffic / email). The entity stays flat; only the
+// wire shape is grouped.
 func ConvertEntityBusinessMetricsToPb(m *entity.BusinessMetrics) *pb_admin.BusinessMetrics {
 	if m == nil {
 		return nil
 	}
 	pb := &pb_admin.BusinessMetrics{
-		Period:               timeRangeToPb(m.Period),
+		Period:   timeRangeToPb(m.Period),
+		Commerce: commerceCoreMetricsToPb(m),
+		Margin:   marginMetricsToPb(m),
+		Traffic:  trafficMetricsToPb(m),
+		Email:    emailMetricsToPb(m),
+	}
+	if m.ComparePeriod != nil && (!m.ComparePeriod.From.IsZero() || !m.ComparePeriod.To.IsZero()) {
+		pb.ComparePeriod = timeRangeToPb(*m.ComparePeriod)
+	}
+	return pb
+}
+
+// commerceCoreMetricsToPb builds the DB-trusted commerce view (sales, customers, discounts,
+// shipping) with its breakdowns and daily series.
+func commerceCoreMetricsToPb(m *entity.BusinessMetrics) *pb_admin.CommerceCoreMetrics {
+	return &pb_admin.CommerceCoreMetrics{
 		Revenue:              metricWithComparisonToPb(m.Revenue),
 		OrdersCount:          metricWithComparisonToPb(m.OrdersCount),
 		TotalPlacedOrders:    metricWithComparisonToPb(m.TotalPlacedOrders),
@@ -40,50 +58,25 @@ func ConvertEntityBusinessMetricsToPb(m *entity.BusinessMetrics) *pb_admin.Busin
 		TotalDiscount:        metricWithComparisonToPb(m.TotalDiscount),
 		ProductSaleDiscount:  metricWithComparisonToPb(m.ProductSaleDiscount),
 		PromoCodeDiscount:    metricWithComparisonToPb(m.PromoCodeDiscount),
-		Sessions:             metricWithComparisonToPb(m.Sessions),
-		Users:                metricWithComparisonToPb(m.Users),
-		NewUsers:             metricWithComparisonToPb(m.NewUsers),
-		PageViews:            metricWithComparisonToPb(m.PageViews),
-		BounceRate:           metricWithComparisonToPb(m.BounceRate, true),                           // lower is better
-		AvgSessionDuration:   metricWithComparisonToPb(m.AvgSessionDuration, false, false, int32(1)), // round to 1 decimal place for consistent delta display
-		PagesPerSession:      metricWithComparisonToPb(m.PagesPerSession),
-		ConversionRate:       metricWithComparisonToPb(m.ConversionRate),
-		RevenuePerSession:    metricWithComparisonToPb(m.RevenuePerSession),
 		NewSubscribers:       metricWithComparisonToPb(m.NewSubscribers),
+		NewCustomers:         metricWithComparisonToPb(m.NewCustomers),
 		RepeatCustomersRate:  metricWithComparisonToPb(m.RepeatCustomersRate),
 		AvgOrdersPerCustomer: metricWithComparisonToPb(m.AvgOrdersPerCustomer),
 		AvgDaysBetweenOrders: metricWithComparisonToPb(m.AvgDaysBetweenOrders),
-		NewCustomers:         metricWithComparisonToPb(m.NewCustomers),
+		AvgShippingCost:      metricWithComparisonToPb(m.AvgShippingCost, false, false, int32(2)),
+		TotalShippingCost:    metricWithComparisonToPb(m.TotalShippingCost, false, false, int32(2)),
 		ClvDistribution:      clvStatsToPb(m.CLVDistribution),
-
-		// Shipping / logistics metrics
-		AvgShippingCost:   metricWithComparisonToPb(m.AvgShippingCost, false, false, int32(2)), // Round to 2 decimal places
-		TotalShippingCost: metricWithComparisonToPb(m.TotalShippingCost, false, false, int32(2)),
-
-		// Margin metrics (COGS from product.cost_price). COGS is a volume-scaling cost like
-		// shipping — neutral, not "lower is better" (higher COGS from more sales isn't bad).
-		RevenueCost:        metricWithComparisonToPb(m.RevenueCost, false, false, int32(2)),
-		GrossMargin:        metricWithComparisonToPb(m.GrossMargin, false, false, int32(2)),
-		GrossMarginPct:     metricWithComparisonToPb(m.GrossMarginPct, false, false, int32(2)),
-		PaymentFees:        metricWithComparisonToPb(m.PaymentFees, false, false, int32(2)),
-		ContributionMargin: metricWithComparisonToPb(m.ContributionMargin, false, false, int32(2)),
-		CostCoveragePct:    m.CostCoveragePct,
-		UncostedProductIds: intsToInt32(m.UncostedProductIds),
 
 		RevenueByCountry:               geographyMetricsToPb(m.RevenueByCountry),
 		RevenueByCity:                  geographyMetricsToPb(m.RevenueByCity),
 		RevenueByRegion:                regionMetricsToPb(m.RevenueByRegion),
 		AvgOrderByCountry:              geographyMetricsToPb(m.AvgOrderByCountry),
-		SessionsByCountry:              geographySessionMetricsToPb(m.SessionsByCountry),
 		RevenueByCurrency:              currencyMetricsToPb(m.RevenueByCurrency),
 		RevenueByPaymentMethod:         paymentMethodMetricsToPb(m.RevenueByPaymentMethod),
 		TopProductsByRevenue:           productMetricsToPb(m.TopProductsByRevenue),
 		TopProductsByQuantity:          productMetricsToPb(m.TopProductsByQuantity),
-		TopProductsByViews:             productViewMetricsToPb(m.TopProductsByViews),
 		RevenueByCategory:              categoryMetricsToPb(m.RevenueByCategory),
 		CrossSellPairs:                 crossSellPairsToPb(m.CrossSellPairs),
-		TrafficBySource:                trafficSourceMetricsToPb(m.TrafficBySource),
-		TrafficByDevice:                deviceMetricsToPb(m.TrafficByDevice),
 		RevenueByPromo:                 promoMetricsToPb(m.RevenueByPromo),
 		OrdersByStatus:                 statusCountsToPb(m.OrdersByStatus),
 		RevenueByDay:                   timeSeriesToPb(m.RevenueByDay),
@@ -97,10 +90,6 @@ func ConvertEntityBusinessMetricsToPb(m *entity.BusinessMetrics) *pb_admin.Busin
 		ReturningCustomersByDay:        timeSeriesToPb(m.ReturningCustomersByDay),
 		ShippedByDay:                   timeSeriesToPb(m.ShippedByDay),
 		DeliveredByDay:                 timeSeriesToPb(m.DeliveredByDay),
-		SessionsByDay:                  timeSeriesToPb(m.SessionsByDay),
-		UsersByDay:                     timeSeriesToPb(m.UsersByDay),
-		PageViewsByDay:                 timeSeriesToPb(m.PageViewsByDay),
-		ConversionRateByDay:            timeSeriesToPb(m.ConversionRateByDay),
 		RevenueByDayCompare:            timeSeriesToPb(m.RevenueByDayCompare),
 		OrdersByDayCompare:             timeSeriesToPb(m.OrdersByDayCompare),
 		SubscribersByDayCompare:        timeSeriesToPb(m.SubscribersByDayCompare),
@@ -112,21 +101,60 @@ func ConvertEntityBusinessMetricsToPb(m *entity.BusinessMetrics) *pb_admin.Busin
 		ReturningCustomersByDayCompare: timeSeriesToPb(m.ReturningCustomersByDayCompare),
 		ShippedByDayCompare:            timeSeriesToPb(m.ShippedByDayCompare),
 		DeliveredByDayCompare:          timeSeriesToPb(m.DeliveredByDayCompare),
-		SessionsByDayCompare:           timeSeriesToPb(m.SessionsByDayCompare),
-		UsersByDayCompare:              timeSeriesToPb(m.UsersByDayCompare),
-		PageViewsByDayCompare:          timeSeriesToPb(m.PageViewsByDayCompare),
-		ConversionRateByDayCompare:     timeSeriesToPb(m.ConversionRateByDayCompare),
-		EmailsSent:                     metricWithComparisonToPb(m.EmailsSent),
-		EmailsDelivered:                metricWithComparisonToPb(m.EmailsDelivered),
-		EmailDeliveryRate:              metricWithComparisonToPb(m.EmailDeliveryRate),
-		EmailOpenRate:                  metricWithComparisonToPb(m.EmailOpenRate),
-		EmailClickRate:                 metricWithComparisonToPb(m.EmailClickRate),
-		EmailBounceRate:                metricWithComparisonToPb(m.EmailBounceRate, true), // lower is better
 	}
-	if m.ComparePeriod != nil && (!m.ComparePeriod.From.IsZero() || !m.ComparePeriod.To.IsZero()) {
-		pb.ComparePeriod = timeRangeToPb(*m.ComparePeriod)
+}
+
+// marginMetricsToPb builds the DB-trusted COGS / margin view. COGS is a volume-scaling cost
+// like shipping — neutral, not "lower is better".
+func marginMetricsToPb(m *entity.BusinessMetrics) *pb_admin.MarginMetrics {
+	return &pb_admin.MarginMetrics{
+		RevenueCost:        metricWithComparisonToPb(m.RevenueCost, false, false, int32(2)),
+		GrossMargin:        metricWithComparisonToPb(m.GrossMargin, false, false, int32(2)),
+		GrossMarginPct:     metricWithComparisonToPb(m.GrossMarginPct, false, false, int32(2)),
+		PaymentFees:        metricWithComparisonToPb(m.PaymentFees, false, false, int32(2)),
+		ContributionMargin: metricWithComparisonToPb(m.ContributionMargin, false, false, int32(2)),
+		CostCoveragePct:    m.CostCoveragePct,
+		UncostedProductIds: intsToInt32(m.UncostedProductIds),
 	}
-	return pb
+}
+
+// trafficMetricsToPb builds the GA4-estimated traffic / engagement view.
+func trafficMetricsToPb(m *entity.BusinessMetrics) *pb_admin.TrafficMetrics {
+	return &pb_admin.TrafficMetrics{
+		Sessions:                   metricWithComparisonToPb(m.Sessions),
+		Users:                      metricWithComparisonToPb(m.Users),
+		NewUsers:                   metricWithComparisonToPb(m.NewUsers),
+		PageViews:                  metricWithComparisonToPb(m.PageViews),
+		BounceRate:                 metricWithComparisonToPb(m.BounceRate, true),                           // lower is better
+		AvgSessionDuration:         metricWithComparisonToPb(m.AvgSessionDuration, false, false, int32(1)), // 1 decimal place
+		PagesPerSession:            metricWithComparisonToPb(m.PagesPerSession),
+		ConversionRate:             metricWithComparisonToPb(m.ConversionRate),
+		RevenuePerSession:          metricWithComparisonToPb(m.RevenuePerSession),
+		SessionsByCountry:          geographySessionMetricsToPb(m.SessionsByCountry),
+		TopProductsByViews:         productViewMetricsToPb(m.TopProductsByViews),
+		TrafficBySource:            trafficSourceMetricsToPb(m.TrafficBySource),
+		TrafficByDevice:            deviceMetricsToPb(m.TrafficByDevice),
+		SessionsByDay:              timeSeriesToPb(m.SessionsByDay),
+		UsersByDay:                 timeSeriesToPb(m.UsersByDay),
+		PageViewsByDay:             timeSeriesToPb(m.PageViewsByDay),
+		ConversionRateByDay:        timeSeriesToPb(m.ConversionRateByDay),
+		SessionsByDayCompare:       timeSeriesToPb(m.SessionsByDayCompare),
+		UsersByDayCompare:          timeSeriesToPb(m.UsersByDayCompare),
+		PageViewsByDayCompare:      timeSeriesToPb(m.PageViewsByDayCompare),
+		ConversionRateByDayCompare: timeSeriesToPb(m.ConversionRateByDayCompare),
+	}
+}
+
+// emailMetricsToPb builds the Resend email-delivery view.
+func emailMetricsToPb(m *entity.BusinessMetrics) *pb_admin.EmailMetrics {
+	return &pb_admin.EmailMetrics{
+		EmailsSent:        metricWithComparisonToPb(m.EmailsSent),
+		EmailsDelivered:   metricWithComparisonToPb(m.EmailsDelivered),
+		EmailDeliveryRate: metricWithComparisonToPb(m.EmailDeliveryRate),
+		EmailOpenRate:     metricWithComparisonToPb(m.EmailOpenRate),
+		EmailClickRate:    metricWithComparisonToPb(m.EmailClickRate),
+		EmailBounceRate:   metricWithComparisonToPb(m.EmailBounceRate, true), // lower is better
+	}
 }
 
 func timeRangeToPb(tr entity.TimeRange) *pb_admin.TimeRange {

--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -1030,6 +1030,24 @@ func ConvertSizeRunEfficiencyToPb(list []entity.SizeRunEfficiencyRow) []*pb_admi
 	return pb
 }
 
+func ConvertSellThroughByDropToPb(list []entity.SellThroughByDropRow) []*pb_admin.SellThroughByDropRow {
+	if len(list) == 0 {
+		return nil
+	}
+	pb := make([]*pb_admin.SellThroughByDropRow, len(list))
+	for i, r := range list {
+		pb[i] = &pb_admin.SellThroughByDropRow{
+			Collection:     r.Collection,
+			ProductCount:   int32(r.ProductCount),
+			UnitsSold:      r.UnitsSold,
+			UnitsRemaining: r.UnitsRemaining,
+			SellThroughPct: r.SellThroughPct,
+			Revenue:        &decimal.Decimal{Value: r.Revenue.String()},
+		}
+	}
+	return pb
+}
+
 func ConvertSlowMoversToPb(list []entity.SlowMoverRow) []*pb_admin.SlowMoverRow {
 	if len(list) == 0 {
 		return nil

--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -67,6 +67,7 @@ func ConvertEntityBusinessMetricsToPb(m *entity.BusinessMetrics) *pb_admin.Busin
 		GrossMarginPct:     metricWithComparisonToPb(m.GrossMarginPct, false, false, int32(2)),
 		ContributionMargin: metricWithComparisonToPb(m.ContributionMargin, false, false, int32(2)),
 		CostCoveragePct:    m.CostCoveragePct,
+		UncostedProductIds: intsToInt32(m.UncostedProductIds),
 
 		RevenueByCountry:               geographyMetricsToPb(m.RevenueByCountry),
 		RevenueByCity:                  geographyMetricsToPb(m.RevenueByCity),
@@ -902,13 +903,23 @@ func ConvertRevenueParetoToPb(list []entity.RevenueParetoRow) []*pb_admin.Revenu
 	}
 	pb := make([]*pb_admin.RevenueParetoRow, len(list))
 	for i, m := range list {
-		pb[i] = &pb_admin.RevenueParetoRow{
+		row := &pb_admin.RevenueParetoRow{
 			Rank:          int32(m.Rank),
 			ProductId:     int32(m.ProductID),
 			ProductName:   m.ProductName,
 			Revenue:       &decimal.Decimal{Value: m.Revenue.String()},
 			CumulativePct: m.CumulativePct,
+			HasCost:       m.HasCost,
 		}
+		// Emit margin only when the product has a cost — otherwise leave the fields unset so
+		// the client shows N/A rather than a misleading 100% margin.
+		if m.HasCost {
+			row.UnitCost = &decimal.Decimal{Value: m.UnitCost.String()}
+			row.RevenueCost = &decimal.Decimal{Value: m.RevenueCost.String()}
+			row.GrossMargin = &decimal.Decimal{Value: m.GrossMargin.String()}
+			row.GrossMarginPct = m.GrossMarginPct
+		}
+		pb[i] = row
 	}
 	return pb
 }
@@ -1017,7 +1028,7 @@ func ConvertSlowMoversToPb(list []entity.SlowMoverRow) []*pb_admin.SlowMoverRow 
 	}
 	pb := make([]*pb_admin.SlowMoverRow, len(list))
 	for i, r := range list {
-		pb[i] = &pb_admin.SlowMoverRow{
+		row := &pb_admin.SlowMoverRow{
 			ProductId:     int32(r.ProductID),
 			ProductName:   r.ProductName,
 			Revenue:       &decimal.Decimal{Value: r.Revenue.String()},
@@ -1025,10 +1036,20 @@ func ConvertSlowMoversToPb(list []entity.SlowMoverRow) []*pb_admin.SlowMoverRow 
 			DaysInStock:   r.DaysInStock,
 			ProductHidden: r.ProductHidden,
 			TotalViews:    r.TotalViews,
+			HasCost:       r.HasCost,
 		}
 		if r.LastSaleDate != nil {
-			pb[i].LastSaleDate = timestamppb.New(*r.LastSaleDate)
+			row.LastSaleDate = timestamppb.New(*r.LastSaleDate)
 		}
+		// Emit margin only when the product has a cost — otherwise leave the fields unset so
+		// the client shows N/A rather than a misleading 100% margin.
+		if r.HasCost {
+			row.UnitCost = &decimal.Decimal{Value: r.UnitCost.String()}
+			row.RevenueCost = &decimal.Decimal{Value: r.RevenueCost.String()}
+			row.GrossMargin = &decimal.Decimal{Value: r.GrossMargin.String()}
+			row.GrossMarginPct = r.GrossMarginPct
+		}
+		pb[i] = row
 	}
 	return pb
 }

--- a/internal/entity/metrics.go
+++ b/internal/entity/metrics.go
@@ -110,7 +110,8 @@ type BusinessMetrics struct {
 	RevenueCost        MetricWithComparison // COGS: Σ(cost × qty), refund-adjusted
 	GrossMargin        MetricWithComparison // costed net revenue − COGS
 	GrossMarginPct     MetricWithComparison // GrossMargin / costed net revenue × 100
-	ContributionMargin MetricWithComparison // GrossMargin − TotalShippingCost
+	PaymentFees        MetricWithComparison // Σ Stripe processing fees (base ccy), not refund-adjusted
+	ContributionMargin MetricWithComparison // GrossMargin − TotalShippingCost − PaymentFees
 	CostCoveragePct    float64              // % of net product revenue with a cost set
 	// Product IDs sold in the period with no cost_price set, ranked by period revenue desc —
 	// the products darkening the margins above. Empty when cost coverage is 100%.

--- a/internal/entity/metrics.go
+++ b/internal/entity/metrics.go
@@ -192,6 +192,12 @@ type MetricWithComparison struct {
 	CompareValue *decimal.Decimal
 	ChangePct    *float64
 	Caveat       string
+	// SampleSize is the number of observations behind the metric (orders, sessions, customers…).
+	// 0 = not populated for this metric. Lets the UI gate a metric on n instead of an arbitrary
+	// display floor. MarginOfError is the 95% CI half-width in the metric's own units, populated
+	// only for true count-proportions (e.g. conversion, promo usage); 0 = not computed.
+	SampleSize    int
+	MarginOfError float64
 }
 
 type GeographyMetric struct {

--- a/internal/entity/metrics.go
+++ b/internal/entity/metrics.go
@@ -588,6 +588,7 @@ type InventoryHealthRow struct {
 	// Server-side decision, computed after the query.
 	HasTarget    bool `db:"-"` // any target is set for this SKU
 	NeedsReorder bool `db:"-"` // stock at/below reorder point, or cover below lead time / target
+	IsSelling    bool `db:"-"` // sold >0 units in the window; days_on_hand is a sentinel when false
 }
 
 // InventoryTargetInsert is an admin-supplied per-SKU reorder target. A nil field leaves

--- a/internal/entity/metrics.go
+++ b/internal/entity/metrics.go
@@ -866,6 +866,10 @@ type CampaignAttributionAggregatedFull struct {
 	// Spend is zero when none is recorded; ROAS (revenue / spend) is set only when spend > 0.
 	Spend decimal.Decimal
 	ROAS  float64
+	// CAC = spend / conversions (cost to acquire a converting customer), set only when spend
+	// and conversions are both > 0. Note: attribution-based, so directional for an
+	// organic-heavy channel mix rather than an exact acquisition cost.
+	CAC float64
 }
 
 // ChannelSpendInsert is an operator-entered marketing spend row for one channel on one day.

--- a/internal/entity/metrics.go
+++ b/internal/entity/metrics.go
@@ -632,6 +632,25 @@ const (
 	AlertSeverityCritical AlertSeverity = "critical"
 )
 
+// AlertThresholds are the operator-tunable thresholds behind the dashboard alerts, loaded
+// from the alert_setting table (with DefaultAlertThresholds as the fallback).
+type AlertThresholds struct {
+	CoverageWarnPct      float64 // warn when cost coverage (% of revenue with a cost) is below this
+	RefundRateWarnPct    float64 // warn when refund rate is at/above this
+	RateFloorN           int     // min orders before any rate-based alert fires (significance floor)
+	ContributionTrustPct float64 // only trust the contribution-margin sign at/above this coverage
+}
+
+// DefaultAlertThresholds returns the built-in defaults (also the seed values of alert_setting).
+func DefaultAlertThresholds() AlertThresholds {
+	return AlertThresholds{
+		CoverageWarnPct:      70,
+		RefundRateWarnPct:    10,
+		RateFloorN:           30,
+		ContributionTrustPct: 50,
+	}
+}
+
 // DashboardAlert is a server-computed, threshold-driven alert for the dashboard.
 type DashboardAlert struct {
 	Severity AlertSeverity

--- a/internal/entity/metrics.go
+++ b/internal/entity/metrics.go
@@ -112,6 +112,9 @@ type BusinessMetrics struct {
 	GrossMarginPct     MetricWithComparison // GrossMargin / costed net revenue × 100
 	ContributionMargin MetricWithComparison // GrossMargin − TotalShippingCost
 	CostCoveragePct    float64              // % of net product revenue with a cost set
+	// Product IDs sold in the period with no cost_price set, ranked by period revenue desc —
+	// the products darkening the margins above. Empty when cost coverage is 100%.
+	UncostedProductIds []int
 
 	// Promo
 	RevenueByPromo []PromoMetric
@@ -519,6 +522,13 @@ type RevenueParetoRow struct {
 	ProductName   string          `db:"product_name"`
 	Revenue       decimal.Decimal `db:"revenue"`
 	CumulativePct float64         `db:"cumulative_pct"`
+	// Margin fields (mirror ProductMetric), computed in Go after the query — not scanned.
+	// HasCost=false ⇒ no cost_price, so margins are N/A rather than a misleading 100%.
+	HasCost        bool            `db:"-"`
+	UnitCost       decimal.Decimal `db:"-"`
+	RevenueCost    decimal.Decimal `db:"-"`
+	GrossMargin    decimal.Decimal `db:"-"`
+	GrossMarginPct float64         `db:"-"`
 }
 
 type SpendingCurvePoint struct {
@@ -602,6 +612,13 @@ type SlowMoverRow struct {
 	LastSaleDate  *time.Time      `db:"last_sale_date"`
 	ProductHidden bool            `db:"product_hidden"`
 	TotalViews    int64           `db:"total_views"`
+	// Margin fields (mirror ProductMetric), computed in Go after the query — not scanned.
+	// HasCost=false ⇒ no cost_price, so margins are N/A rather than a misleading 100%.
+	HasCost        bool            `db:"-"`
+	UnitCost       decimal.Decimal `db:"-"`
+	RevenueCost    decimal.Decimal `db:"-"`
+	GrossMargin    decimal.Decimal `db:"-"`
+	GrossMarginPct float64         `db:"-"`
 }
 
 // --- Return Analysis ---

--- a/internal/entity/metrics.go
+++ b/internal/entity/metrics.go
@@ -620,6 +620,45 @@ type SellThroughByDropRow struct {
 	Revenue        decimal.Decimal `db:"revenue"`
 }
 
+// --- Dashboard (decision-grade summary) ---
+
+// AlertSeverity ranks a dashboard alert. Kept as small string codes so the store can emit
+// them without importing the proto enum.
+type AlertSeverity string
+
+const (
+	AlertSeverityInfo     AlertSeverity = "info"
+	AlertSeverityWarning  AlertSeverity = "warning"
+	AlertSeverityCritical AlertSeverity = "critical"
+)
+
+// DashboardAlert is a server-computed, threshold-driven alert for the dashboard.
+type DashboardAlert struct {
+	Severity AlertSeverity
+	Code     string // stable machine key, e.g. "low_cost_coverage"
+	Title    string
+	Detail   string
+}
+
+// Dashboard is the small, DB-trusted decision payload: headline figures + server alerts +
+// short action lists. It is intentionally cheap (no ~90-field BusinessMetrics god-object).
+type Dashboard struct {
+	Period             TimeRange
+	Revenue            decimal.Decimal
+	Orders             int
+	GrossMargin        decimal.Decimal
+	GrossMarginPct     float64
+	ContributionMargin decimal.Decimal
+	CostCoveragePct    float64
+	Caveat             string
+	UncostedProductIds []int
+	Alerts             []DashboardAlert
+	TopByMargin        []ProductMetric      // top revenue products re-ranked by gross margin €
+	Reorder            []InventoryHealthRow // SKUs flagged needs_reorder, most urgent first
+	Clear              []SlowMoverRow       // slow movers to clear
+	Drops              []SellThroughByDropRow
+}
+
 // --- Slow Movers ---
 
 type SlowMoverRow struct {

--- a/internal/entity/metrics.go
+++ b/internal/entity/metrics.go
@@ -609,6 +609,17 @@ type SizeRunEfficiencyRow struct {
 	EfficiencyPct    float64 `db:"efficiency_pct"`
 }
 
+// SellThroughByDropRow rolls a release/drop cohort (product.collection) into decision-grade
+// totals. Lifetime (current-state), not windowed: sell-through is inherently cumulative.
+type SellThroughByDropRow struct {
+	Collection     string          `db:"collection"`
+	ProductCount   int             `db:"product_count"`
+	UnitsSold      int64           `db:"units_sold"`
+	UnitsRemaining int64           `db:"units_remaining"`
+	SellThroughPct float64         `db:"sell_through_pct"`
+	Revenue        decimal.Decimal `db:"revenue"`
+}
+
 // --- Slow Movers ---
 
 type SlowMoverRow struct {

--- a/internal/payment/stripe/payment.go
+++ b/internal/payment/stripe/payment.go
@@ -330,13 +330,19 @@ func (p *Processor) captureSettledBase(ctx context.Context, rep dependency.Repos
 		return
 	}
 	settledBase := AmountFromSmallestUnit(bt.Amount, baseCurrency)
-	if err := rep.Order().UpdateTotalSettledBase(ctx, orderUUID, settledBase); err != nil {
+	// The processing fee rides on the same balance transaction (same base currency, already
+	// expanded above), so capture it here for free. Stripe keeps the fee even on refunds, so
+	// it is the full fee actually paid — a real contribution-margin cost.
+	paymentFee := AmountFromSmallestUnit(bt.Fee, baseCurrency)
+	if err := rep.Order().UpdateSettledBaseAndFee(ctx, orderUUID, settledBase, paymentFee); err != nil {
 		slog.Default().ErrorContext(ctx, "settled-base: can't persist",
 			slog.String("orderUUID", orderUUID), slog.String("err", err.Error()))
 		return
 	}
 	slog.Default().InfoContext(ctx, "settled-base captured",
-		slog.String("orderUUID", orderUUID), slog.String("amount_base", settledBase.String()))
+		slog.String("orderUUID", orderUUID),
+		slog.String("amount_base", settledBase.String()),
+		slog.String("payment_fee_base", paymentFee.String()))
 }
 
 // flagUnderpaidForReview records a persistent, admin-visible marker on the order

--- a/internal/store/metrics/analytics.go
+++ b/internal/store/metrics/analytics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
 	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
+	"github.com/shopspring/decimal"
 )
 
 // returnByProductRawRow is the raw DB row before aggregation.
@@ -40,6 +41,10 @@ func (as *analyticsStore) GetSlowMovers(ctx context.Context, from, to time.Time,
 	// Revenue is the actual settled base apportioned across line items (order_factors /
 	// itemAdjExpr); all order currencies are included (no co.currency filter) and prices
 	// come from product_price in base currency rather than the order-currency snapshot.
+	// revenue_cost mirrors the product breakdowns: Σ(cost × qty) prorated by the same
+	// refund ratio as revenue (costAdj), so a refunded unit drops out of both. unit_cost is
+	// the product's current per-unit cost_price. computeRowMargin turns these into the
+	// margin fields after the query (leaving them N/A when the product has no cost).
 	query := fmt.Sprintf(`
 		WITH %s,
 		product_sales AS (
@@ -47,9 +52,11 @@ func (as *analyticsStore) GetSlowMovers(ctx context.Context, from, to time.Time,
 				oi.product_id,
 				COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity * %s), 0) AS revenue,
 				SUM(oi.quantity)     AS units_sold,
-				MAX(ofac.placed)     AS last_sale_date
+				MAX(ofac.placed)     AS last_sale_date,
+				COALESCE(SUM(CASE WHEN cp.cost_price IS NOT NULL THEN cp.cost_price * oi.quantity * %s ELSE 0 END), 0) AS revenue_cost
 			FROM order_item oi
 			JOIN order_factors ofac ON ofac.order_id = oi.order_id
+			JOIN product cp ON cp.id = oi.product_id
 			LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
 			GROUP BY oi.product_id
 		),
@@ -72,15 +79,21 @@ func (as *analyticsStore) GetSlowMovers(ctx context.Context, from, to time.Time,
 			DATEDIFF(NOW(), p.created_at) AS days_in_stock,
 			ps.last_sale_date,
 			COALESCE(p.hidden, 0) AS product_hidden,
-			COALESCE(gv.total_views, 0) AS total_views
+			COALESCE(gv.total_views, 0) AS total_views,
+			p.cost_price AS unit_cost,
+			COALESCE(ps.revenue_cost, 0) AS revenue_cost
 		FROM product p
 		LEFT JOIN product_sales ps ON ps.product_id = p.id
 		LEFT JOIN ga4_views gv ON gv.product_id = p.id
 		ORDER BY revenue ASC, days_in_stock DESC
 		LIMIT :limit
-	`, orderFactorsCTE, itemAdjExpr)
+	`, orderFactorsCTE, itemAdjExpr, costAdjExpr)
 
-	result, err := storeutil.QueryListNamed[entity.SlowMoverRow](ctx, as.DB, query, map[string]any{
+	rows, err := storeutil.QueryListNamed[struct {
+		entity.SlowMoverRow
+		UnitCostRaw    decimal.NullDecimal `db:"unit_cost"`
+		RevenueCostRaw decimal.Decimal     `db:"revenue_cost"`
+	}](ctx, as.DB, query, map[string]any{
 		"baseCurrency": baseCurrency,
 		"statusIds":    cache.OrderStatusIDsForNetRevenue(),
 		"from":         from,
@@ -91,6 +104,14 @@ func (as *analyticsStore) GetSlowMovers(ctx context.Context, from, to time.Time,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get slow movers: %w", err)
+	}
+	result := make([]entity.SlowMoverRow, len(rows))
+	for i, r := range rows {
+		row := r.SlowMoverRow
+		rm := computeRowMargin(row.Revenue, r.UnitCostRaw, r.RevenueCostRaw)
+		row.HasCost, row.UnitCost, row.RevenueCost = rm.HasCost, rm.UnitCost, rm.RevenueCost
+		row.GrossMargin, row.GrossMarginPct = rm.GrossMargin, rm.GrossMarginPct
+		result[i] = row
 	}
 	return result, nil
 }

--- a/internal/store/metrics/business.go
+++ b/internal/store/metrics/business.go
@@ -47,6 +47,7 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 		costedRev, cCostedRev                    decimal.Decimal
 		cogs, cCogs                              decimal.Decimal
 		totalItemRev                             decimal.Decimal
+		paymentFees, cPaymentFees                decimal.Decimal
 	)
 
 	g, gctx := errgroup.WithContext(ctx)
@@ -100,6 +101,11 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 		m.UncostedProductIds, err = s.getUncostedSoldProductIDs(gctx, period.From, period.To)
 		return err
 	})
+	g.Go(func() error {
+		var err error
+		paymentFees, err = s.getPaymentFees(gctx, period.From, period.To)
+		return err
+	})
 
 	// Core sales (compare)
 	if hasCompare {
@@ -146,6 +152,11 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 		g.Go(func() error {
 			var err error
 			cCostedRev, cCogs, _, err = s.getMarginMetrics(gctx, comparePeriod.From, comparePeriod.To)
+			return err
+		})
+		g.Go(func() error {
+			var err error
+			cPaymentFees, err = s.getPaymentFees(gctx, comparePeriod.From, comparePeriod.To)
 			return err
 		})
 	}
@@ -634,7 +645,8 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 	grossMargin := costedRev.Sub(cogs)
 	m.RevenueCost.Value = cogs
 	m.GrossMargin.Value = grossMargin
-	m.ContributionMargin.Value = grossMargin.Sub(totalShipCost)
+	m.PaymentFees.Value = paymentFees
+	m.ContributionMargin.Value = grossMargin.Sub(totalShipCost).Sub(paymentFees)
 	if costedRev.GreaterThan(decimal.Zero) {
 		m.GrossMarginPct.Value = grossMargin.Div(costedRev).Mul(decimal.NewFromInt(100)).Round(2)
 	}
@@ -653,7 +665,7 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 		m.GrossMargin.Caveat = note
 		m.GrossMarginPct.Caveat = note
 	}
-	m.ContributionMargin.Caveat = "Gross margin minus total shipping cost; meaningful when cost coverage is high."
+	m.ContributionMargin.Caveat = "Gross margin minus total shipping cost and Stripe payment fees; meaningful when cost coverage is high."
 
 	// GA4 aggregate metrics (totalSessions etc. computed above)
 	m.Sessions.Value = decimal.NewFromInt(int64(totalSessions))
@@ -762,7 +774,9 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 		m.RevenueCost.ChangePct = changePct(cogs, cCogs)
 		m.GrossMargin.CompareValue = &cGrossMargin
 		m.GrossMargin.ChangePct = changePct(grossMargin, cGrossMargin)
-		cContribution := cGrossMargin.Sub(cTotalShipCost)
+		m.PaymentFees.CompareValue = &cPaymentFees
+		m.PaymentFees.ChangePct = changePct(paymentFees, cPaymentFees)
+		cContribution := cGrossMargin.Sub(cTotalShipCost).Sub(cPaymentFees)
 		m.ContributionMargin.CompareValue = &cContribution
 		m.ContributionMargin.ChangePct = changePct(m.ContributionMargin.Value, cContribution)
 		if cCostedRev.GreaterThan(decimal.Zero) {

--- a/internal/store/metrics/business.go
+++ b/internal/store/metrics/business.go
@@ -624,6 +624,9 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 	if grossRev.GreaterThan(decimal.Zero) {
 		m.RefundRate.Value = revRefund.Div(grossRev).Mul(decimal.NewFromInt(100))
 	}
+	// Gate refund rate on the order count (a money ratio, so no proportion CI). n lets the UI
+	// suppress a noisy rate at low volume instead of applying a hardcoded floor.
+	m.RefundRate.SampleSize = placedOrders
 	m.GrossRevenue.Value = grossRev
 	m.TotalRefunded.Value = revRefund
 	m.TotalDiscount.Value = totalDiscount
@@ -631,6 +634,9 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 	m.PromoCodeDiscount.Value = promoCodeDiscount
 	if orders > 0 {
 		m.PromoUsageRate.Value = decimal.NewFromInt(int64(promoOrders)).Div(decimal.NewFromInt(int64(orders))).Mul(decimal.NewFromInt(100))
+		// True count-proportion (promo orders / orders): expose n and a 95% CI half-width.
+		m.PromoUsageRate.SampleSize = orders
+		m.PromoUsageRate.MarginOfError = proportionMarginOfError(m.PromoUsageRate.Value.InexactFloat64(), orders)
 	}
 	m.NewSubscribers.Value = decimal.NewFromInt(int64(newSubs))
 	m.RepeatCustomersRate.Value = repeatRate
@@ -675,6 +681,9 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 	if totalSessions > 0 {
 		// Session-weighted averages: divide weighted sums by total sessions
 		m.BounceRate.Value = decimal.NewFromFloat(weightedBounceRate / float64(totalSessions))
+		// Bounce is a session-level proportion: n = sessions, with a 95% CI half-width.
+		m.BounceRate.SampleSize = totalSessions
+		m.BounceRate.MarginOfError = proportionMarginOfError(m.BounceRate.Value.InexactFloat64(), totalSessions)
 		// Prefer total foreground engagement / total sessions (column from GA4 sync).
 		// Falls back to weighted avg_session_duration when engagement was not stored (pre-migration / legacy rows).
 		if totalUserEngagementSeconds > 0 {
@@ -689,6 +698,9 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 	if totalSessions > 0 {
 		m.ConversionRate.Value = decimal.NewFromInt(int64(orders)).Div(decimal.NewFromInt(int64(totalSessions))).Mul(decimal.NewFromInt(100))
 		m.RevenuePerSession.Value = rev.Div(decimal.NewFromInt(int64(totalSessions)))
+		// Conversion is a session-level proportion (orders / sessions): n + 95% CI half-width.
+		m.ConversionRate.SampleSize = totalSessions
+		m.ConversionRate.MarginOfError = proportionMarginOfError(m.ConversionRate.Value.InexactFloat64(), totalSessions)
 	}
 
 	// Compute conversion rate by day

--- a/internal/store/metrics/business.go
+++ b/internal/store/metrics/business.go
@@ -95,6 +95,11 @@ func (s *Store) GetBusinessMetrics(ctx context.Context, period, comparePeriod en
 		costedRev, cogs, totalItemRev, err = s.getMarginMetrics(gctx, period.From, period.To)
 		return err
 	})
+	g.Go(func() error {
+		var err error
+		m.UncostedProductIds, err = s.getUncostedSoldProductIDs(gctx, period.From, period.To)
+		return err
+	})
 
 	// Core sales (compare)
 	if hasCompare {

--- a/internal/store/metrics/dashboard.go
+++ b/internal/store/metrics/dashboard.go
@@ -1,0 +1,189 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/shopspring/decimal"
+)
+
+// Server-side alert thresholds. These live on the backend (not the frontend) so alerting is
+// consistent across clients and gated on real sample size. Rate-based alerts only fire once
+// there are at least alertRateFloorN orders, so a 1-order period can't trip a "100% refund
+// rate" alarm.
+const (
+	alertCoverageWarnPct      = 70.0 // warn when cost coverage (% of revenue with a cost) is below this
+	alertRefundRateWarnPct    = 10.0 // warn when refund rate is at/above this
+	alertRateFloorN           = 30   // min orders before any rate-based alert fires (the significance floor)
+	alertContributionTrustPct = 50.0 // only trust the contribution-margin sign when coverage is at least this
+	dashboardReorderScanLimit = 500  // inventory rows scanned to collect the reorder list
+)
+
+// GetDashboard assembles the decision-grade dashboard payload: a small set of DB-trusted
+// headline figures, server-computed alerts, and the short action lists (top products by
+// margin, SKUs to reorder, slow movers to clear, drop sell-through). It deliberately does NOT
+// build the ~90-field BusinessMetrics god-object — each figure comes from a targeted query,
+// so the dashboard stays cheap. Use the sectioned GetMetrics for deep drill-down.
+func (s *Store) GetDashboard(ctx context.Context, from, to time.Time, limit int) (*entity.Dashboard, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	rev, orders, _, err := s.getCoreSalesMetrics(ctx, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard core sales: %w", err)
+	}
+	costedRev, cogs, totalItemRev, err := s.getMarginMetrics(ctx, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard margin: %w", err)
+	}
+	_, totalShip, err := s.getShippingCostMetrics(ctx, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard shipping: %w", err)
+	}
+	fees, err := s.getPaymentFees(ctx, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard fees: %w", err)
+	}
+	placedOrders, err := s.getPlacedOrdersCount(ctx, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard placed orders: %w", err)
+	}
+	grossRev, err := s.getGrossRevenueTotal(ctx, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard gross revenue: %w", err)
+	}
+	revRefund, _, err := s.getRefundMetrics(ctx, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard refunds: %w", err)
+	}
+	uncosted, err := s.getUncostedSoldProductIDs(ctx, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard uncosted: %w", err)
+	}
+	topProducts, err := s.getTopProductsByRevenue(ctx, from, to, limit)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard top products: %w", err)
+	}
+	health, err := s.inventory().GetInventoryHealth(ctx, from, to, dashboardReorderScanLimit)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard inventory: %w", err)
+	}
+	slow, err := s.analytics().GetSlowMovers(ctx, from, to, limit)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard slow movers: %w", err)
+	}
+	drops, err := s.inventory().GetSellThroughByDrop(ctx, from, to, limit)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard drops: %w", err)
+	}
+
+	grossMargin := costedRev.Sub(cogs).Round(2)
+	d := &entity.Dashboard{
+		Period:             entity.TimeRange{From: from, To: to},
+		Revenue:            rev,
+		Orders:             orders,
+		GrossMargin:        grossMargin,
+		ContributionMargin: grossMargin.Sub(totalShip).Sub(fees).Round(2),
+		UncostedProductIds: uncosted,
+		Clear:              slow,
+		Drops:              drops,
+	}
+	if costedRev.GreaterThan(decimal.Zero) {
+		d.GrossMarginPct = grossMargin.Div(costedRev).Mul(decimal.NewFromInt(100)).Round(2).InexactFloat64()
+	}
+	if totalItemRev.GreaterThan(decimal.Zero) {
+		d.CostCoveragePct = costedRev.Div(totalItemRev).Mul(decimal.NewFromInt(100)).Round(2).InexactFloat64()
+	}
+	if d.CostCoveragePct > 0 && d.CostCoveragePct < 99.5 {
+		d.Caveat = fmt.Sprintf("Margins cover %.0f%% of product revenue (only items with a cost set).", d.CostCoveragePct)
+	} else if totalItemRev.GreaterThan(decimal.Zero) && costedRev.LessThanOrEqual(decimal.Zero) {
+		d.Caveat = "No product cost data in this period — set product cost_price to compute margins."
+	}
+
+	// Top by margin €: the highest-revenue products re-ranked by gross margin €, keeping only
+	// costed ones (margins are N/A without a cost). Shows where the € margin actually is.
+	topByMargin := make([]entity.ProductMetric, 0, len(topProducts))
+	for _, p := range topProducts {
+		if p.HasCost {
+			topByMargin = append(topByMargin, p)
+		}
+	}
+	sort.SliceStable(topByMargin, func(i, j int) bool {
+		return topByMargin[i].GrossMargin.GreaterThan(topByMargin[j].GrossMargin)
+	})
+	d.TopByMargin = topByMargin
+
+	// Reorder list: SKUs the server flagged (needs_reorder), most urgent first (GetInventoryHealth
+	// already orders by days-on-hand asc), capped at limit.
+	reorder := make([]entity.InventoryHealthRow, 0, limit)
+	for _, r := range health {
+		if r.NeedsReorder {
+			reorder = append(reorder, r)
+			if len(reorder) >= limit {
+				break
+			}
+		}
+	}
+	d.Reorder = reorder
+
+	var refundRatePct float64
+	if grossRev.GreaterThan(decimal.Zero) {
+		refundRatePct = revRefund.Div(grossRev).Mul(decimal.NewFromInt(100)).InexactFloat64()
+	}
+	d.Alerts = buildDashboardAlerts(d, refundRatePct, placedOrders, len(reorder), totalItemRev)
+
+	return d, nil
+}
+
+// buildDashboardAlerts derives the server-side alert list from the headline figures using the
+// backend thresholds. Rate-based alerts (refund rate) are gated on alertRateFloorN so they
+// never fire on a statistically meaningless handful of orders.
+func buildDashboardAlerts(d *entity.Dashboard, refundRatePct float64, placedOrders, reorderCount int, totalItemRev decimal.Decimal) []entity.DashboardAlert {
+	var out []entity.DashboardAlert
+
+	if d.CostCoveragePct >= alertContributionTrustPct && d.ContributionMargin.IsNegative() {
+		out = append(out, entity.DashboardAlert{
+			Severity: entity.AlertSeverityCritical,
+			Code:     "negative_contribution_margin",
+			Title:    "Negative contribution margin",
+			Detail:   fmt.Sprintf("Contribution margin is %s after COGS, shipping and payment fees.", d.ContributionMargin.StringFixed(2)),
+		})
+	}
+	if totalItemRev.GreaterThan(decimal.Zero) && d.CostCoveragePct > 0 && d.CostCoveragePct < alertCoverageWarnPct {
+		out = append(out, entity.DashboardAlert{
+			Severity: entity.AlertSeverityWarning,
+			Code:     "low_cost_coverage",
+			Title:    "Low cost coverage",
+			Detail:   fmt.Sprintf("Margins cover only %.0f%% of product revenue; set costs to see true margin.", d.CostCoveragePct),
+		})
+	}
+	if n := len(d.UncostedProductIds); n > 0 {
+		out = append(out, entity.DashboardAlert{
+			Severity: entity.AlertSeverityWarning,
+			Code:     "uncosted_products",
+			Title:    "Products missing cost",
+			Detail:   fmt.Sprintf("%d product(s) sold this period have no cost set.", n),
+		})
+	}
+	if reorderCount > 0 {
+		out = append(out, entity.DashboardAlert{
+			Severity: entity.AlertSeverityWarning,
+			Code:     "reorder_needed",
+			Title:    "Reorder needed",
+			Detail:   fmt.Sprintf("%d SKU(s) at or below their reorder point.", reorderCount),
+		})
+	}
+	if placedOrders >= alertRateFloorN && refundRatePct >= alertRefundRateWarnPct {
+		out = append(out, entity.DashboardAlert{
+			Severity: entity.AlertSeverityWarning,
+			Code:     "high_refund_rate",
+			Title:    "High refund rate",
+			Detail:   fmt.Sprintf("Refund rate is %.1f%% over %d orders.", refundRatePct, placedOrders),
+		})
+	}
+	return out
+}

--- a/internal/store/metrics/dashboard.go
+++ b/internal/store/metrics/dashboard.go
@@ -10,17 +10,11 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// Server-side alert thresholds. These live on the backend (not the frontend) so alerting is
-// consistent across clients and gated on real sample size. Rate-based alerts only fire once
-// there are at least alertRateFloorN orders, so a 1-order period can't trip a "100% refund
-// rate" alarm.
-const (
-	alertCoverageWarnPct      = 70.0 // warn when cost coverage (% of revenue with a cost) is below this
-	alertRefundRateWarnPct    = 10.0 // warn when refund rate is at/above this
-	alertRateFloorN           = 30   // min orders before any rate-based alert fires (the significance floor)
-	alertContributionTrustPct = 50.0 // only trust the contribution-margin sign when coverage is at least this
-	dashboardReorderScanLimit = 500  // inventory rows scanned to collect the reorder list
-)
+// dashboardReorderScanLimit bounds how many inventory rows we scan to collect the reorder
+// list. The alert thresholds themselves are operator-tunable and loaded from alert_setting
+// (see settings.go / entity.AlertThresholds); rate-based alerts are still gated on a minimum
+// order count so a 1-order period can't trip a "100% refund rate" alarm.
+const dashboardReorderScanLimit = 500 // inventory rows scanned to collect the reorder list
 
 // GetDashboard assembles the decision-grade dashboard payload: a small set of DB-trusted
 // headline figures, server-computed alerts, and the short action lists (top products by
@@ -80,6 +74,10 @@ func (s *Store) GetDashboard(ctx context.Context, from, to time.Time, limit int)
 	if err != nil {
 		return nil, fmt.Errorf("dashboard drops: %w", err)
 	}
+	thresholds, err := s.GetAlertThresholds(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard alert thresholds: %w", err)
+	}
 
 	grossMargin := costedRev.Sub(cogs).Round(2)
 	d := &entity.Dashboard{
@@ -134,18 +132,18 @@ func (s *Store) GetDashboard(ctx context.Context, from, to time.Time, limit int)
 	if grossRev.GreaterThan(decimal.Zero) {
 		refundRatePct = revRefund.Div(grossRev).Mul(decimal.NewFromInt(100)).InexactFloat64()
 	}
-	d.Alerts = buildDashboardAlerts(d, refundRatePct, placedOrders, len(reorder), totalItemRev)
+	d.Alerts = buildDashboardAlerts(d, thresholds, refundRatePct, placedOrders, len(reorder), totalItemRev)
 
 	return d, nil
 }
 
 // buildDashboardAlerts derives the server-side alert list from the headline figures using the
-// backend thresholds. Rate-based alerts (refund rate) are gated on alertRateFloorN so they
-// never fire on a statistically meaningless handful of orders.
-func buildDashboardAlerts(d *entity.Dashboard, refundRatePct float64, placedOrders, reorderCount int, totalItemRev decimal.Decimal) []entity.DashboardAlert {
+// operator-tunable thresholds. Rate-based alerts (refund rate) are gated on t.RateFloorN so
+// they never fire on a statistically meaningless handful of orders.
+func buildDashboardAlerts(d *entity.Dashboard, t entity.AlertThresholds, refundRatePct float64, placedOrders, reorderCount int, totalItemRev decimal.Decimal) []entity.DashboardAlert {
 	var out []entity.DashboardAlert
 
-	if d.CostCoveragePct >= alertContributionTrustPct && d.ContributionMargin.IsNegative() {
+	if d.CostCoveragePct >= t.ContributionTrustPct && d.ContributionMargin.IsNegative() {
 		out = append(out, entity.DashboardAlert{
 			Severity: entity.AlertSeverityCritical,
 			Code:     "negative_contribution_margin",
@@ -153,7 +151,7 @@ func buildDashboardAlerts(d *entity.Dashboard, refundRatePct float64, placedOrde
 			Detail:   fmt.Sprintf("Contribution margin is %s after COGS, shipping and payment fees.", d.ContributionMargin.StringFixed(2)),
 		})
 	}
-	if totalItemRev.GreaterThan(decimal.Zero) && d.CostCoveragePct > 0 && d.CostCoveragePct < alertCoverageWarnPct {
+	if totalItemRev.GreaterThan(decimal.Zero) && d.CostCoveragePct > 0 && d.CostCoveragePct < t.CoverageWarnPct {
 		out = append(out, entity.DashboardAlert{
 			Severity: entity.AlertSeverityWarning,
 			Code:     "low_cost_coverage",
@@ -177,7 +175,7 @@ func buildDashboardAlerts(d *entity.Dashboard, refundRatePct float64, placedOrde
 			Detail:   fmt.Sprintf("%d SKU(s) at or below their reorder point.", reorderCount),
 		})
 	}
-	if placedOrders >= alertRateFloorN && refundRatePct >= alertRefundRateWarnPct {
+	if placedOrders >= t.RateFloorN && refundRatePct >= t.RefundRateWarnPct {
 		out = append(out, entity.DashboardAlert{
 			Severity: entity.AlertSeverityWarning,
 			Code:     "high_refund_rate",

--- a/internal/store/metrics/dashboard_test.go
+++ b/internal/store/metrics/dashboard_test.go
@@ -22,15 +22,15 @@ func TestBuildDashboardAlerts_RefundRateNGate(t *testing.T) {
 	rev := decimal.NewFromInt(1000)
 
 	// 20% refund rate but only 10 orders (< floor of 30): no rate alert — too small a sample.
-	got := buildDashboardAlerts(d, 20, 10, 0, rev)
+	got := buildDashboardAlerts(d, entity.DefaultAlertThresholds(), 20, 10, 0, rev)
 	assert.False(t, hasAlert(got, "high_refund_rate"), "should suppress refund alert below the n floor")
 
 	// Same rate at 50 orders: alert fires.
-	got = buildDashboardAlerts(d, 20, 50, 0, rev)
+	got = buildDashboardAlerts(d, entity.DefaultAlertThresholds(), 20, 50, 0, rev)
 	assert.True(t, hasAlert(got, "high_refund_rate"), "should fire refund alert above the n floor")
 
 	// Above the floor but below the rate threshold: no alert.
-	got = buildDashboardAlerts(d, 5, 50, 0, rev)
+	got = buildDashboardAlerts(d, entity.DefaultAlertThresholds(), 5, 50, 0, rev)
 	assert.False(t, hasAlert(got, "high_refund_rate"))
 }
 
@@ -39,12 +39,12 @@ func TestBuildDashboardAlerts_ContributionTrustGate(t *testing.T) {
 
 	// Negative contribution with trustworthy coverage -> critical.
 	d := &entity.Dashboard{CostCoveragePct: 90, ContributionMargin: decimal.NewFromInt(-5)}
-	got := buildDashboardAlerts(d, 0, 0, 0, rev)
+	got := buildDashboardAlerts(d, entity.DefaultAlertThresholds(), 0, 0, 0, rev)
 	assert.True(t, hasAlert(got, "negative_contribution_margin"))
 
 	// Same negative figure but coverage too low to trust the sign -> no critical.
 	d = &entity.Dashboard{CostCoveragePct: 30, ContributionMargin: decimal.NewFromInt(-5)}
-	got = buildDashboardAlerts(d, 0, 0, 0, rev)
+	got = buildDashboardAlerts(d, entity.DefaultAlertThresholds(), 0, 0, 0, rev)
 	assert.False(t, hasAlert(got, "negative_contribution_margin"), "don't trust contribution sign at low coverage")
 	// Low coverage should instead surface the coverage warning.
 	assert.True(t, hasAlert(got, "low_cost_coverage"))
@@ -52,11 +52,11 @@ func TestBuildDashboardAlerts_ContributionTrustGate(t *testing.T) {
 
 func TestBuildDashboardAlerts_UncostedAndReorder(t *testing.T) {
 	d := &entity.Dashboard{CostCoveragePct: 100, UncostedProductIds: []int{7, 8}}
-	got := buildDashboardAlerts(d, 0, 0, 3, decimal.NewFromInt(1000))
+	got := buildDashboardAlerts(d, entity.DefaultAlertThresholds(), 0, 0, 3, decimal.NewFromInt(1000))
 	assert.True(t, hasAlert(got, "uncosted_products"))
 	assert.True(t, hasAlert(got, "reorder_needed"))
 
 	// Clean state: no alerts.
 	clean := &entity.Dashboard{CostCoveragePct: 100}
-	assert.Empty(t, buildDashboardAlerts(clean, 0, 0, 0, decimal.NewFromInt(1000)))
+	assert.Empty(t, buildDashboardAlerts(clean, entity.DefaultAlertThresholds(), 0, 0, 0, decimal.NewFromInt(1000)))
 }

--- a/internal/store/metrics/dashboard_test.go
+++ b/internal/store/metrics/dashboard_test.go
@@ -1,0 +1,62 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func hasAlert(alerts []entity.DashboardAlert, code string) bool {
+	for _, a := range alerts {
+		if a.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildDashboardAlerts_RefundRateNGate(t *testing.T) {
+	d := &entity.Dashboard{CostCoveragePct: 100}
+	rev := decimal.NewFromInt(1000)
+
+	// 20% refund rate but only 10 orders (< floor of 30): no rate alert — too small a sample.
+	got := buildDashboardAlerts(d, 20, 10, 0, rev)
+	assert.False(t, hasAlert(got, "high_refund_rate"), "should suppress refund alert below the n floor")
+
+	// Same rate at 50 orders: alert fires.
+	got = buildDashboardAlerts(d, 20, 50, 0, rev)
+	assert.True(t, hasAlert(got, "high_refund_rate"), "should fire refund alert above the n floor")
+
+	// Above the floor but below the rate threshold: no alert.
+	got = buildDashboardAlerts(d, 5, 50, 0, rev)
+	assert.False(t, hasAlert(got, "high_refund_rate"))
+}
+
+func TestBuildDashboardAlerts_ContributionTrustGate(t *testing.T) {
+	rev := decimal.NewFromInt(1000)
+
+	// Negative contribution with trustworthy coverage -> critical.
+	d := &entity.Dashboard{CostCoveragePct: 90, ContributionMargin: decimal.NewFromInt(-5)}
+	got := buildDashboardAlerts(d, 0, 0, 0, rev)
+	assert.True(t, hasAlert(got, "negative_contribution_margin"))
+
+	// Same negative figure but coverage too low to trust the sign -> no critical.
+	d = &entity.Dashboard{CostCoveragePct: 30, ContributionMargin: decimal.NewFromInt(-5)}
+	got = buildDashboardAlerts(d, 0, 0, 0, rev)
+	assert.False(t, hasAlert(got, "negative_contribution_margin"), "don't trust contribution sign at low coverage")
+	// Low coverage should instead surface the coverage warning.
+	assert.True(t, hasAlert(got, "low_cost_coverage"))
+}
+
+func TestBuildDashboardAlerts_UncostedAndReorder(t *testing.T) {
+	d := &entity.Dashboard{CostCoveragePct: 100, UncostedProductIds: []int{7, 8}}
+	got := buildDashboardAlerts(d, 0, 0, 3, decimal.NewFromInt(1000))
+	assert.True(t, hasAlert(got, "uncosted_products"))
+	assert.True(t, hasAlert(got, "reorder_needed"))
+
+	// Clean state: no alerts.
+	clean := &entity.Dashboard{CostCoveragePct: 100}
+	assert.Empty(t, buildDashboardAlerts(clean, 0, 0, 0, decimal.NewFromInt(1000)))
+}

--- a/internal/store/metrics/inventory.go
+++ b/internal/store/metrics/inventory.go
@@ -88,6 +88,9 @@ func (is *inventoryStore) GetInventoryHealth(ctx context.Context, from, to time.
 // supplier lead time or fall short of the target cover. The no-sales sentinel (days_on_hand
 // = 99999) is excluded from the cover checks, so a dead SKU only trips via the reorder point.
 func applyReorderDecision(r *entity.InventoryHealthRow) {
+	// Always set from the sales velocity so the client never has to detect the days_on_hand
+	// sentinel to know whether the SKU moved in the window.
+	r.IsSelling = r.AvgDailySales > 0
 	r.HasTarget = r.ReorderPoint.Valid || r.TargetDaysCover.Valid || r.LeadTimeDays.Valid
 	if !r.HasTarget {
 		return

--- a/internal/store/metrics/inventory.go
+++ b/internal/store/metrics/inventory.go
@@ -132,6 +132,64 @@ func (is *inventoryStore) UpsertInventoryTargets(ctx context.Context, targets []
 	return nil
 }
 
+// GetSellThroughByDrop rolls each release/drop cohort (product.collection) into
+// decision-grade totals: distinct products, lifetime net units sold, current on-hand units,
+// sell-through % (sold / (sold + remaining)), and lifetime net revenue. Sell-through is
+// inherently cumulative, so it is computed lifetime (current state) — the from/to window is
+// intentionally NOT applied to the sold/revenue aggregation. Products with an empty
+// collection (untagged) are excluded. Sorted by revenue desc, limited.
+func (is *inventoryStore) GetSellThroughByDrop(ctx context.Context, from, to time.Time, limit int) ([]entity.SellThroughByDropRow, error) {
+	statusIDs := storeutil.JoinInts(cache.OrderStatusIDsForNetRevenue())
+	baseCurrency := strings.ToUpper(cache.GetBaseCurrency())
+
+	query := fmt.Sprintf(`
+		WITH sold AS (
+			SELECT
+				oi.product_id,
+				SUM(oi.quantity) AS units_sold,
+				COALESCE(SUM(pp_base.price * oi.quantity), 0) AS revenue
+			FROM order_item oi
+			JOIN customer_order co ON oi.order_id = co.id
+			LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
+			WHERE co.order_status_id IN (%s)
+			GROUP BY oi.product_id
+		),
+		stock AS (
+			SELECT product_id, SUM(quantity) AS units_remaining
+			FROM product_size
+			GROUP BY product_id
+		)
+		SELECT
+			p.collection,
+			COUNT(DISTINCT p.id) AS product_count,
+			COALESCE(SUM(s.units_sold), 0) AS units_sold,
+			COALESCE(SUM(st.units_remaining), 0) AS units_remaining,
+			COALESCE(SUM(s.revenue), 0) AS revenue,
+			CASE
+				WHEN COALESCE(SUM(s.units_sold), 0) + COALESCE(SUM(st.units_remaining), 0) > 0
+				THEN COALESCE(SUM(s.units_sold), 0) * 100.0 / (COALESCE(SUM(s.units_sold), 0) + COALESCE(SUM(st.units_remaining), 0))
+				ELSE 0
+			END AS sell_through_pct
+		FROM product p
+		LEFT JOIN sold s ON s.product_id = p.id
+		LEFT JOIN stock st ON st.product_id = p.id
+		WHERE p.deleted_at IS NULL
+			AND p.collection IS NOT NULL AND p.collection <> ''
+		GROUP BY p.collection
+		ORDER BY revenue DESC
+		LIMIT :limit
+	`, statusIDs)
+
+	result, err := storeutil.QueryListNamed[entity.SellThroughByDropRow](ctx, is.DB, query, map[string]any{
+		"baseCurrency": baseCurrency,
+		"limit":        limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get sell-through by drop: %w", err)
+	}
+	return result, nil
+}
+
 // GetSizeRunEfficiency returns the percentage of sizes that have any sales activity
 // for each product. Sell-through is computed from initial stock vs current stock.
 func (is *inventoryStore) GetSizeRunEfficiency(ctx context.Context, from, to time.Time, limit int) ([]entity.SizeRunEfficiencyRow, error) {

--- a/internal/store/metrics/margin.go
+++ b/internal/store/metrics/margin.go
@@ -12,21 +12,40 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// rowMargin holds the derived per-row margin fields shared by ProductMetric, SlowMoverRow
+// and RevenueParetoRow. All zero (and HasCost=false) when the product has no cost set.
+type rowMargin struct {
+	HasCost        bool
+	UnitCost       decimal.Decimal
+	RevenueCost    decimal.Decimal
+	GrossMargin    decimal.Decimal
+	GrossMarginPct float64
+}
+
+// computeRowMargin derives a row's margin from its matched revenue and cost inputs. When
+// unitCost is NULL the product has no cost set, so every field stays zero and HasCost is
+// false — the API can then render "N/A" rather than a misleading 100% margin. revenueCost
+// is Σ(cost × qty) on the same basis as `revenue` (the caller matches the two).
+func computeRowMargin(revenue decimal.Decimal, unitCost decimal.NullDecimal, revenueCost decimal.Decimal) rowMargin {
+	if !unitCost.Valid {
+		return rowMargin{}
+	}
+	rm := rowMargin{HasCost: true, UnitCost: unitCost.Decimal, RevenueCost: revenueCost.Round(2)}
+	rm.GrossMargin = revenue.Sub(rm.RevenueCost).Round(2)
+	if revenue.GreaterThan(decimal.Zero) {
+		rm.GrossMarginPct = rm.GrossMargin.Div(revenue).Mul(decimal.NewFromInt(100)).Round(2).InexactFloat64()
+	}
+	return rm
+}
+
 // applyProductMargin fills the margin fields of a product breakdown row from its current
 // cost. When the product has no cost set the fields stay zero and HasCost is false, so the
 // API can render "N/A" rather than a misleading 100% margin. revenueCost is Σ(cost × net
 // qty); the caller's Value is the matched net revenue.
 func applyProductMargin(pm *entity.ProductMetric, unitCost decimal.NullDecimal, revenueCost decimal.Decimal) {
-	if !unitCost.Valid {
-		return
-	}
-	pm.HasCost = true
-	pm.UnitCost = unitCost.Decimal
-	pm.RevenueCost = revenueCost.Round(2)
-	pm.GrossMargin = pm.Value.Sub(pm.RevenueCost).Round(2)
-	if pm.Value.GreaterThan(decimal.Zero) {
-		pm.GrossMarginPct = pm.GrossMargin.Div(pm.Value).Mul(decimal.NewFromInt(100)).Round(2).InexactFloat64()
-	}
+	rm := computeRowMargin(pm.Value, unitCost, revenueCost)
+	pm.HasCost, pm.UnitCost, pm.RevenueCost = rm.HasCost, rm.UnitCost, rm.RevenueCost
+	pm.GrossMargin, pm.GrossMarginPct = rm.GrossMargin, rm.GrossMarginPct
 }
 
 // getMarginMetrics computes cost of goods (COGS) and the revenue it is matched against,
@@ -72,4 +91,38 @@ func (s *Store) getMarginMetrics(ctx context.Context, from, to time.Time) (coste
 		return decimal.Zero, decimal.Zero, decimal.Zero, err
 	}
 	return r.CostedRevenue.Round(2), r.Cogs.Round(2), r.TotalRevenue.Round(2), nil
+}
+
+// getUncostedSoldProductIDs returns the IDs of products that sold in [from, to) over the
+// net-revenue statuses but have NO cost_price set, ordered by their period revenue
+// descending. These are exactly the products darkening the margin coverage figure — the
+// operator should set a cost (via a tech card) for the top entries first. Products that
+// already have a cost, or that had no sales in the window, are excluded, so the slice is
+// empty when cost coverage is 100%.
+func (s *Store) getUncostedSoldProductIDs(ctx context.Context, from, to time.Time) ([]int, error) {
+	baseCurrency := strings.ToUpper(cache.GetBaseCurrency())
+	query := fmt.Sprintf(`
+		WITH %s
+		SELECT oi.product_id
+		FROM order_item oi
+		JOIN product p ON p.id = oi.product_id
+		JOIN order_factors ofac ON ofac.order_id = oi.order_id
+		LEFT JOIN product_price pp_base ON oi.product_id = pp_base.product_id AND UPPER(pp_base.currency) = UPPER(:baseCurrency)
+		WHERE p.cost_price IS NULL AND p.deleted_at IS NULL
+		GROUP BY oi.product_id
+		ORDER BY COALESCE(SUM(pp_base.price * (1 - COALESCE(oi.product_sale_percentage, 0) / 100.0) * oi.quantity * %s), 0) DESC
+	`, orderFactorsCTE, itemAdjExpr)
+	rows, err := storeutil.QueryListNamed[struct {
+		ProductID int `db:"product_id"`
+	}](ctx, s.DB, query, map[string]any{
+		"from": from, "to": to, "baseCurrency": baseCurrency, "statusIds": cache.OrderStatusIDsForNetRevenue(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int, len(rows))
+	for i, r := range rows {
+		ids[i] = r.ProductID
+	}
+	return ids, nil
 }

--- a/internal/store/metrics/margin_test.go
+++ b/internal/store/metrics/margin_test.go
@@ -1,0 +1,100 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+// nd is a small helper to build a valid NullDecimal from a float.
+func nd(v float64) decimal.NullDecimal {
+	return decimal.NullDecimal{Valid: true, Decimal: decimal.NewFromFloat(v)}
+}
+
+func TestComputeRowMargin(t *testing.T) {
+	tests := []struct {
+		name        string
+		revenue     float64
+		unitCost    decimal.NullDecimal
+		revenueCost float64
+		wantHasCost bool
+		wantUnit    float64
+		wantRevCost float64
+		wantMargin  float64
+		wantPct     float64
+	}{
+		{
+			// The whole point of has_cost: no cost set ⇒ everything N/A (zero), NOT a 100% margin.
+			name:        "no cost is N/A not 100pct",
+			revenue:     100,
+			unitCost:    decimal.NullDecimal{}, // invalid = no cost_price
+			revenueCost: 0,
+			wantHasCost: false,
+		},
+		{
+			name:        "normal margin",
+			revenue:     100,
+			unitCost:    nd(3),
+			revenueCost: 30,
+			wantHasCost: true,
+			wantUnit:    3,
+			wantRevCost: 30,
+			wantMargin:  70,
+			wantPct:     70,
+		},
+		{
+			// Costed product with no sales in the window: cost known, but no revenue/margin.
+			name:        "cost set but zero revenue",
+			revenue:     0,
+			unitCost:    nd(5),
+			revenueCost: 0,
+			wantHasCost: true,
+			wantUnit:    5,
+			wantRevCost: 0,
+			wantMargin:  0,
+			wantPct:     0, // guarded: revenue not > 0
+		},
+		{
+			// Sold below cost (deep discount) ⇒ honest negative margin, not clamped.
+			name:        "negative margin when sold below cost",
+			revenue:     50,
+			unitCost:    nd(6),
+			revenueCost: 60,
+			wantHasCost: true,
+			wantUnit:    6,
+			wantRevCost: 60,
+			wantMargin:  -10,
+			wantPct:     -20,
+		},
+		{
+			name:        "rounds to two places",
+			revenue:     99.999,
+			unitCost:    nd(1.111),
+			revenueCost: 33.335,
+			wantHasCost: true,
+			wantUnit:    1.111, // unit cost is passed through unrounded
+			wantRevCost: 33.34, // Round(2)
+			wantMargin:  66.66, // 99.999 - 33.34 = 66.659 -> 66.66
+			wantPct:     66.66, // 66.66 / 99.999 * 100 = 66.66
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rm := computeRowMargin(decimal.NewFromFloat(tt.revenue), tt.unitCost, decimal.NewFromFloat(tt.revenueCost))
+			assert.Equal(t, tt.wantHasCost, rm.HasCost)
+			if !tt.wantHasCost {
+				// N/A: all money fields stay zero so the API can render "N/A".
+				assert.True(t, rm.UnitCost.IsZero(), "unit cost")
+				assert.True(t, rm.RevenueCost.IsZero(), "revenue cost")
+				assert.True(t, rm.GrossMargin.IsZero(), "gross margin")
+				assert.Zero(t, rm.GrossMarginPct, "gross margin pct")
+				return
+			}
+			assert.True(t, decimal.NewFromFloat(tt.wantUnit).Equal(rm.UnitCost), "unit cost: got %s", rm.UnitCost)
+			assert.True(t, decimal.NewFromFloat(tt.wantRevCost).Equal(rm.RevenueCost), "revenue cost: got %s", rm.RevenueCost)
+			assert.True(t, decimal.NewFromFloat(tt.wantMargin).Equal(rm.GrossMargin), "gross margin: got %s", rm.GrossMargin)
+			assert.InDelta(t, tt.wantPct, rm.GrossMarginPct, 0.01)
+		})
+	}
+}

--- a/internal/store/metrics/metrics.go
+++ b/internal/store/metrics/metrics.go
@@ -77,6 +77,10 @@ func (s *Store) UpsertInventoryTargets(ctx context.Context, targets []entity.Inv
 	return s.inventory().UpsertInventoryTargets(ctx, targets)
 }
 
+func (s *Store) GetSellThroughByDrop(ctx context.Context, from, to time.Time, limit int) ([]entity.SellThroughByDropRow, error) {
+	return s.inventory().GetSellThroughByDrop(ctx, from, to, limit)
+}
+
 // --- Metrics interface: Analytics methods ---
 
 func (s *Store) GetSlowMovers(ctx context.Context, from, to time.Time, limit int) ([]entity.SlowMoverRow, error) {

--- a/internal/store/metrics/retention.go
+++ b/internal/store/metrics/retention.go
@@ -270,7 +270,9 @@ func (rs *retentionStore) GetRevenuePareto(ctx context.Context, from, to time.Ti
 					(SELECT pt.name FROM product_translation pt WHERE pt.product_id = p.id ORDER BY pt.language_id LIMIT 1),
 					p.brand
 				) AS product_name,
-				SUM(pp_base.price * oi.quantity) AS revenue
+				SUM(pp_base.price * oi.quantity) AS revenue,
+				MAX(p.cost_price) AS unit_cost,
+				COALESCE(SUM(CASE WHEN p.cost_price IS NOT NULL THEN p.cost_price * oi.quantity ELSE 0 END), 0) AS revenue_cost
 			FROM order_item oi
 			JOIN customer_order co ON oi.order_id = co.id
 			JOIN product p ON p.id = oi.product_id
@@ -286,6 +288,8 @@ func (rs *retentionStore) GetRevenuePareto(ctx context.Context, from, to time.Ti
 				product_id,
 				product_name,
 				revenue,
+				unit_cost,
+				revenue_cost,
 				ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rank_num
 			FROM product_revenue
 		),
@@ -297,6 +301,8 @@ func (rs *retentionStore) GetRevenuePareto(ctx context.Context, from, to time.Ti
 			r.product_id,
 			r.product_name,
 			r.revenue,
+			r.unit_cost,
+			r.revenue_cost,
 			SUM(r.revenue) OVER (ORDER BY r.rank_num ROWS UNBOUNDED PRECEDING) / t.total_revenue * 100 AS cumulative_pct
 		FROM ranked r
 		CROSS JOIN total t
@@ -304,7 +310,14 @@ func (rs *retentionStore) GetRevenuePareto(ctx context.Context, from, to time.Ti
 		LIMIT :limit
 	`, statusIDs)
 
-	result, err := storeutil.QueryListNamed[entity.RevenueParetoRow](ctx, rs.DB, query, map[string]any{
+	// Pareto revenue is gross list revenue (Σ price×qty, no refund/discount adjustment), so
+	// revenue_cost is Σ(cost×qty) on the same un-adjusted basis — the margin ties out to this
+	// row's own `revenue`. computeRowMargin leaves the fields N/A when there is no cost_price.
+	rows, err := storeutil.QueryListNamed[struct {
+		entity.RevenueParetoRow
+		UnitCostRaw    decimal.NullDecimal `db:"unit_cost"`
+		RevenueCostRaw decimal.Decimal     `db:"revenue_cost"`
+	}](ctx, rs.DB, query, map[string]any{
 		"baseCurrency": baseCurrency,
 		"from":         from,
 		"to":           to,
@@ -312,6 +325,14 @@ func (rs *retentionStore) GetRevenuePareto(ctx context.Context, from, to time.Ti
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get revenue pareto: %w", err)
+	}
+	result := make([]entity.RevenueParetoRow, len(rows))
+	for i, r := range rows {
+		row := r.RevenueParetoRow
+		rm := computeRowMargin(row.Revenue, r.UnitCostRaw, r.RevenueCostRaw)
+		row.HasCost, row.UnitCost, row.RevenueCost = rm.HasCost, rm.UnitCost, rm.RevenueCost
+		row.GrossMargin, row.GrossMarginPct = rm.GrossMargin, rm.GrossMarginPct
+		result[i] = row
 	}
 	return result, nil
 }

--- a/internal/store/metrics/settings.go
+++ b/internal/store/metrics/settings.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
+	"github.com/shopspring/decimal"
+)
+
+const (
+	alertKeyCoverageWarnPct      = "coverage_warn_pct"
+	alertKeyRefundRateWarnPct    = "refund_rate_warn_pct"
+	alertKeyRateFloorN           = "rate_floor_n"
+	alertKeyContributionTrustPct = "contribution_trust_pct"
+)
+
+// GetAlertThresholds loads the dashboard alert thresholds from alert_setting, falling back to
+// entity.DefaultAlertThresholds for any key that is missing — so a partially-seeded (or
+// not-yet-migrated) table still yields sane, unchanged behaviour.
+func (s *Store) GetAlertThresholds(ctx context.Context) (entity.AlertThresholds, error) {
+	rows, err := storeutil.QueryListNamed[struct {
+		Key   string          `db:"setting_key"`
+		Value decimal.Decimal `db:"value"`
+	}](ctx, s.DB, `SELECT setting_key, value FROM alert_setting`, nil)
+	if err != nil {
+		return entity.AlertThresholds{}, fmt.Errorf("get alert thresholds: %w", err)
+	}
+	t := entity.DefaultAlertThresholds()
+	for _, r := range rows {
+		switch r.Key {
+		case alertKeyCoverageWarnPct:
+			t.CoverageWarnPct = r.Value.InexactFloat64()
+		case alertKeyRefundRateWarnPct:
+			t.RefundRateWarnPct = r.Value.InexactFloat64()
+		case alertKeyRateFloorN:
+			t.RateFloorN = int(r.Value.IntPart())
+		case alertKeyContributionTrustPct:
+			t.ContributionTrustPct = r.Value.InexactFloat64()
+		}
+	}
+	return t, nil
+}
+
+// UpsertAlertThresholds writes all four thresholds back to alert_setting.
+func (s *Store) UpsertAlertThresholds(ctx context.Context, t entity.AlertThresholds) error {
+	vals := []struct {
+		key string
+		val decimal.Decimal
+	}{
+		{alertKeyCoverageWarnPct, decimal.NewFromFloat(t.CoverageWarnPct)},
+		{alertKeyRefundRateWarnPct, decimal.NewFromFloat(t.RefundRateWarnPct)},
+		{alertKeyRateFloorN, decimal.NewFromInt(int64(t.RateFloorN))},
+		{alertKeyContributionTrustPct, decimal.NewFromFloat(t.ContributionTrustPct)},
+	}
+	for _, v := range vals {
+		if err := storeutil.ExecNamed(ctx, s.DB, `
+			INSERT INTO alert_setting (setting_key, value) VALUES (:k, :v)
+			ON DUPLICATE KEY UPDATE value = VALUES(value)`,
+			map[string]any{"k": v.key, "v": v.val}); err != nil {
+			return fmt.Errorf("upsert alert threshold %s: %w", v.key, err)
+		}
+	}
+	return nil
+}

--- a/internal/store/metrics/shipping.go
+++ b/internal/store/metrics/shipping.go
@@ -41,3 +41,28 @@ func (s *Store) getShippingCostMetrics(ctx context.Context, from, to time.Time) 
 	}
 	return rows[0].AvgCost, rows[0].TotalCost, nil
 }
+
+// getPaymentFees sums the Stripe processing fees (base currency) captured on orders placed
+// in [from, to) over the net-revenue statuses. Unlike revenue and COGS it is NOT
+// refund-adjusted: Stripe keeps the fee even when an order is refunded, so the full captured
+// fee is the real contribution-margin cost. Orders without a captured fee (payment_fee NULL:
+// pre-feature, non-Stripe, unpaid) contribute nothing.
+func (s *Store) getPaymentFees(ctx context.Context, from, to time.Time) (decimal.Decimal, error) {
+	query := `
+		SELECT COALESCE(SUM(co.payment_fee), 0) AS total_fees
+		FROM customer_order co
+		WHERE co.placed >= :from AND co.placed < :to
+		AND co.order_status_id IN (:statusIds)
+	`
+	row, err := storeutil.QueryNamedOne[struct {
+		TotalFees decimal.Decimal `db:"total_fees"`
+	}](ctx, s.DB, query, map[string]any{
+		"from":      from,
+		"to":        to,
+		"statusIds": cache.OrderStatusIDsForNetRevenue(),
+	})
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("getPaymentFees: %w", err)
+	}
+	return row.TotalFees, nil
+}

--- a/internal/store/metrics/stats.go
+++ b/internal/store/metrics/stats.go
@@ -1,0 +1,21 @@
+package metrics
+
+import "math"
+
+// proportionMarginOfError returns the 95% Wald confidence-interval half-width for a
+// proportion, expressed in the same 0–100 percentage units as ratePct. For a rate p over n
+// independent trials the half-width is 1.96·√(p(1−p)/n); this is what lets the UI render
+// "12.0% ± 2.4" and decide significance from the data rather than an arbitrary display floor.
+// Returns 0 when n <= 0 (no sample) so callers can treat 0 as "not computed".
+func proportionMarginOfError(ratePct float64, n int) float64 {
+	if n <= 0 {
+		return 0
+	}
+	p := ratePct / 100
+	if p < 0 {
+		p = 0
+	} else if p > 1 {
+		p = 1
+	}
+	return 1.96 * math.Sqrt(p*(1-p)/float64(n)) * 100
+}

--- a/internal/store/metrics/stats_test.go
+++ b/internal/store/metrics/stats_test.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProportionMarginOfError(t *testing.T) {
+	tests := []struct {
+		name    string
+		ratePct float64
+		n       int
+		want    float64
+	}{
+		{"no sample -> 0", 12, 0, 0},
+		{"negative n -> 0", 12, -5, 0},
+		{"p=0 -> 0", 0, 100, 0},
+		{"p=100 -> 0", 100, 100, 0},
+		{"over 100 clamps to p=1 -> 0", 150, 100, 0},
+		{"50pct over 100 -> 9.8", 50, 100, 9.8}, // 1.96*sqrt(.25/100)*100
+		{"50pct over 400 halves -> 4.9", 50, 400, 4.9},
+		{"larger n shrinks the interval", 20, 10000, 0.784}, // 1.96*sqrt(.16/10000)*100
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := proportionMarginOfError(tt.ratePct, tt.n)
+			assert.InDelta(t, tt.want, got, 0.01)
+			assert.GreaterOrEqual(t, got, 0.0)
+		})
+	}
+}

--- a/internal/store/order/payment.go
+++ b/internal/store/order/payment.go
@@ -196,20 +196,23 @@ func (s *Store) UpdateTotalPaymentCurrency(ctx context.Context, orderUUID string
 	return nil
 }
 
-// UpdateTotalSettledBase records the actual Stripe-settled amount for an order,
-// converted to the base currency (EUR). Captured once at payment confirmation.
-func (s *Store) UpdateTotalSettledBase(ctx context.Context, orderUUID string, settledBase decimal.Decimal) error {
+// UpdateSettledBaseAndFee records the actual Stripe-settled amount and the Stripe processing
+// fee for an order, both converted to the base currency (EUR) from the charge's balance
+// transaction. Captured together, once, at payment confirmation.
+func (s *Store) UpdateSettledBaseAndFee(ctx context.Context, orderUUID string, settledBase, paymentFee decimal.Decimal) error {
 	query := `
 	UPDATE customer_order
-	SET total_settled_base = :settledBase
+	SET total_settled_base = :settledBase,
+	    payment_fee = :paymentFee
 	WHERE uuid = :orderUUID`
 
 	err := storeutil.ExecNamed(ctx, s.DB, query, map[string]any{
 		"settledBase": settledBase,
+		"paymentFee":  paymentFee,
 		"orderUUID":   orderUUID,
 	})
 	if err != nil {
-		return fmt.Errorf("can't update total settled base: %w", err)
+		return fmt.Errorf("can't update settled base and fee: %w", err)
 	}
 	return nil
 }

--- a/internal/store/sql/0088_add_order_payment_fee.sql
+++ b/internal/store/sql/0088_add_order_payment_fee.sql
@@ -1,0 +1,14 @@
+-- +migrate Up
+-- Store the Stripe processing fee for an order in the base currency (EUR), taken from the
+-- charge's balance transaction (BalanceTransaction.Fee) at capture time — the same source
+-- and FX as total_settled_base. Payment fees are a real contribution-margin cost that gross
+-- margin ignores (the documented 2-3pp leak). NULL = not captured (orders placed before this
+-- feature, non-Stripe payment methods, or still-unpaid orders). Stripe keeps the processing
+-- fee even when an order is refunded, so this is the full fee actually paid, NOT refund-adjusted.
+ALTER TABLE customer_order
+  ADD COLUMN payment_fee DECIMAL(10, 2) NULL DEFAULT NULL
+    COMMENT 'Stripe processing fee in base currency (EUR) from the charge balance transaction; NULL = not captured';
+
+-- +migrate Down
+ALTER TABLE customer_order
+  DROP COLUMN payment_fee;

--- a/internal/store/sql/0089_add_alert_setting.sql
+++ b/internal/store/sql/0089_add_alert_setting.sql
@@ -1,0 +1,20 @@
+-- +migrate Up
+-- Operator-tunable thresholds for the server-computed dashboard alerts (#6/#7). Moving these
+-- off the frontend keeps alerting consistent across clients and lets an admin adjust them
+-- without a deploy. Key/value (numeric) so new thresholds can be added without a schema change.
+-- Seeded with the same defaults hardcoded in entity.DefaultAlertThresholds so behaviour is
+-- unchanged until an operator edits them.
+CREATE TABLE alert_setting (
+  setting_key VARCHAR(191) NOT NULL PRIMARY KEY,
+  value DECIMAL(12, 4) NOT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+INSERT INTO alert_setting (setting_key, value) VALUES
+  ('coverage_warn_pct', 70.0),
+  ('refund_rate_warn_pct', 10.0),
+  ('rate_floor_n', 30),
+  ('contribution_trust_pct', 50.0);
+
+-- +migrate Down
+DROP TABLE IF EXISTS alert_setting;

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -856,6 +856,7 @@ enum MetricsSection {
   METRICS_SECTION_GEOGRAPHY = 42;
   METRICS_SECTION_CUSTOMER_SEGMENTATION = 43;
   METRICS_SECTION_RFM = 44;
+  METRICS_SECTION_SELL_THROUGH_BY_DROP = 45;
 }
 
 message GetMetricsRequest {
@@ -914,6 +915,7 @@ message GetMetricsResponse {
   GeographySection geography = 45;
   repeated CustomerSegmentRow customer_segments = 46;
   repeated RFMSegmentRow rfm_analysis = 47;
+  repeated SellThroughByDropRow sell_through_by_drop = 48;
 }
 
 message FunnelSection {
@@ -1878,6 +1880,22 @@ message UpsertInventoryTargetsRequest {
 }
 
 message UpsertInventoryTargetsResponse {}
+
+// --- Analytics: Sell-through by Drop ---
+
+// SellThroughByDropRow aggregates a release/drop cohort (product.collection) into
+// decision-grade totals, so tiny per-day/per-SKU samples roll up to a statistically
+// meaningful drop-level view. sell_through_pct = units_sold / (units_sold +
+// units_remaining) × 100 over the whole drop, computed lifetime (current state), not
+// windowed — sell-through is inherently cumulative. Sorted by revenue desc.
+message SellThroughByDropRow {
+  string collection = 1; // the drop identifier (product.collection)
+  int32 product_count = 2; // distinct products in the drop
+  int64 units_sold = 3; // lifetime net units sold across the drop
+  int64 units_remaining = 4; // current on-hand units across the drop
+  double sell_through_pct = 5; // units_sold / (units_sold + units_remaining) × 100
+  google.type.Decimal revenue = 6; // lifetime net revenue (base currency) for the drop
+}
 
 // --- Analytics: Size Run Efficiency ---
 

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -1844,15 +1844,23 @@ message InventoryHealthRow {
   int32 size_id = 3;
   string size_name = 4;
   int32 quantity = 5;
-  double avg_daily_sales = 6;
-  double days_on_hand = 7; // days of cover at the current sales rate
-  // Optional per-SKU targets (0 = unset) and the server-side reorder decision derived
-  // from them. needs_reorder is meaningful only when has_target is true.
+  double avg_daily_sales = 6; // units/day over the requested (trailing) window
+  // Days of cover at the current sales rate. When is_selling is false there were no sales in
+  // the window, so this carries a large sentinel (sorts dead stock last) — read is_selling,
+  // not a magic number, and render days of cover as N/A in that case.
+  double days_on_hand = 7;
+  // Optional per-SKU targets (0 = unset) and the server-side reorder decision derived from
+  // them. needs_reorder is meaningful only when has_target is true; setting a target is the
+  // operator's opt-in that this SKU is continuity stock (limited drops get no target, hence
+  // no reorder noise — days of cover is misleading for them).
   int32 reorder_point = 8;
   int32 target_days_cover = 9;
   int32 lead_time_days = 10;
   bool needs_reorder = 11;
   bool has_target = 12;
+  // True when the SKU sold at least one unit in the window. Replaces the client-side
+  // qty/avgDailySales sentinel check: gate any days-of-cover display on this.
+  bool is_selling = 13;
 }
 
 // InventoryTargetInsert is an admin-supplied per-SKU reorder target. Each threshold is

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -1060,7 +1060,12 @@ message BusinessMetrics {
   MetricWithComparison revenue_cost = 85; // COGS: Σ(cost × qty), refund-adjusted
   MetricWithComparison gross_margin = 86; // costed net revenue − COGS
   MetricWithComparison gross_margin_pct = 87; // gross_margin / costed net revenue × 100
-  MetricWithComparison contribution_margin = 88; // gross_margin − total_shipping_cost
+  MetricWithComparison contribution_margin = 88; // gross_margin − total_shipping_cost − payment_fees
+  // Σ Stripe processing fees (base currency) captured from each order's charge balance
+  // transaction. NOT refund-adjusted — Stripe keeps the fee on refunds, so it is the full
+  // fee actually paid. A real contribution-margin cost that gross_margin ignores. Only
+  // orders with a captured fee contribute (pre-feature / non-Stripe orders are excluded).
+  MetricWithComparison payment_fees = 91;
   // Share (%) of net product revenue (base currency) whose product has a cost set — the
   // fraction the margin figures above are computed over. 100 = full cost coverage.
   double cost_coverage_pct = 89;

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -1098,6 +1098,14 @@ message MetricWithComparison {
   double change_absolute = 5;
   // Optional tooltip/caveat text to clarify metric interpretation (e.g., data limitations, calculation notes).
   string caveat = 6;
+  // Number of observations behind the metric (orders, sessions, customers…). 0 = not
+  // populated. Prefer gating a metric on this (e.g. hide/greytext when sample_size < 30)
+  // over an arbitrary display floor.
+  int32 sample_size = 7;
+  // 95% confidence-interval half-width in the metric's own units (e.g. ±2.4 for a 12.0%
+  // rate). Populated only for true count-proportions (conversion, promo usage); 0 = not
+  // computed. Frontend can render "12.0% ± 2.4" instead of guessing significance from a floor.
+  double margin_of_error = 8;
 }
 
 message GeographyMetric {

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -1064,6 +1064,11 @@ message BusinessMetrics {
   // Share (%) of net product revenue (base currency) whose product has a cost set — the
   // fraction the margin figures above are computed over. 100 = full cost coverage.
   double cost_coverage_pct = 89;
+  // Product IDs that sold in the period but have NO cost_price set, ordered by their period
+  // revenue descending — the products darkening the margin figures above. This is the
+  // actionable companion to cost_coverage_pct: set a cost (via a tech card) for the top
+  // entries first to raise coverage. Empty when coverage is already 100%.
+  repeated int32 uncosted_product_ids = 90;
 }
 
 message PaymentMethodMetric {
@@ -1790,6 +1795,16 @@ message RevenueParetoRow {
   string product_name = 3;
   google.type.Decimal revenue = 4;
   double cumulative_pct = 5;
+  // Margin fields (mirror ProductMetric). Populated only when the product has a cost_price;
+  // has_cost=false ⇒ the cost is unknown, so treat margins as N/A, not as 100%. Note the
+  // margin here is computed on this row's own `revenue` basis (gross list revenue, Σ price×qty),
+  // so revenue_cost is Σ(cost × qty) on the same un-adjusted basis — internally consistent
+  // with `revenue`, but not directly comparable to the refund/discount-adjusted BusinessMetrics margin.
+  google.type.Decimal unit_cost = 6; // current per-unit COGS (base currency)
+  google.type.Decimal revenue_cost = 7; // Σ(cost × qty) matched to `revenue`
+  google.type.Decimal gross_margin = 8; // revenue − revenue_cost
+  double gross_margin_pct = 9; // gross_margin / revenue × 100
+  bool has_cost = 10;
 }
 
 // --- Analytics: Customer Spending Curve ---
@@ -1864,6 +1879,15 @@ message SlowMoverRow {
   google.protobuf.Timestamp last_sale_date = 6;
   bool product_hidden = 7; // Product visibility flag (from product.hidden)
   int64 total_views = 8; // GA4 page views for period (from ga4_product_page_metrics)
+  // Margin fields (mirror ProductMetric). Populated only when the product has a cost_price;
+  // has_cost=false ⇒ the cost is unknown, so treat margins as N/A, not as 100%. Computed on
+  // this row's `revenue` (the refund/FX/discount-adjusted net revenue), so revenue_cost is the
+  // refund-adjusted COGS — the same basis as the BusinessMetrics and product-breakdown margins.
+  google.type.Decimal unit_cost = 9; // current per-unit COGS (base currency)
+  google.type.Decimal revenue_cost = 10; // Σ(cost × net qty), refund-adjusted
+  google.type.Decimal gross_margin = 11; // revenue − revenue_cost
+  double gross_margin_pct = 12; // gross_margin / revenue × 100
+  bool has_cost = 13;
 }
 
 // --- Analytics: Return Analysis ---

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -2135,6 +2135,9 @@ message CampaignAttributionRow {
   // zero when none is recorded for the channel; roas is 0 unless spend > 0.
   google.type.Decimal spend = 10;
   double roas = 11;
+  // CAC = spend / conversions (0 unless both > 0). Attribution-based, so directional for an
+  // organic-heavy channel mix rather than an exact acquisition cost.
+  double cac = 12;
 }
 
 // ChannelSpendInsert is one operator-entered marketing spend row for a channel on a day.

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -982,151 +982,129 @@ message FunnelSection {
   string caveat = 5;
 }
 
+// BusinessMetrics groups the overview metrics by data provenance so consumers can tell
+// DB-trusted figures from GA4-estimated ones at a glance. BREAKING: replaces the former
+// ~90-field flat message — read metrics from commerce / margin / traffic / email instead.
 message BusinessMetrics {
   TimeRange period = 1;
   TimeRange compare_period = 2;
+  CommerceCoreMetrics commerce = 3; // DB-trusted sales, customers, discounts, shipping
+  MarginMetrics margin = 4; // DB-trusted COGS / margin (from product.cost_price)
+  TrafficMetrics traffic = 5; // GA4-estimated sessions / engagement / conversion
+  EmailMetrics email = 6; // Resend email-delivery metrics
+}
 
-  MetricWithComparison revenue = 3;
-  MetricWithComparison orders_count = 4;
-  MetricWithComparison avg_order_value = 5;
-  MetricWithComparison items_per_order = 25;
+// CommerceCoreMetrics is the DB-authoritative commerce view: sales, customers, discounts,
+// shipping, plus their breakdowns and daily series.
+message CommerceCoreMetrics {
+  MetricWithComparison revenue = 1;
+  MetricWithComparison orders_count = 2; // net-revenue statuses only
+  MetricWithComparison total_placed_orders = 3; // all placed, any status (status-share denominator)
+  MetricWithComparison avg_order_value = 4;
+  MetricWithComparison items_per_order = 5;
   MetricWithComparison refund_rate = 6;
-  // Share of orders with a promo_code attached (customer_order.promo_id). Unrelated to total_discount
-  // when discounts come only from product sale percentages — see product_sale_discount / promo_code_discount.
   MetricWithComparison promo_usage_rate = 7;
-  // Gross revenue at list prices (before any discounts or refunds) + shipping.
-  // Includes original order value of fully refunded orders (status=Refunded).
-  // Revenue = GrossRevenue - ProductSaleDiscount - PromoCodeDiscount - TotalRefunded.
-  MetricWithComparison gross_revenue = 39;
-  MetricWithComparison total_refunded = 40;
-  // Sum of product_sale_discount + promo_code_discount (base currency, net-revenue order statuses).
-  MetricWithComparison total_discount = 41;
-  // Line-item sale % off list price (not from promo codes).
-  MetricWithComparison product_sale_discount = 78;
-  // Extra % off subtotal from an applied promo_code (orders with promo_id only).
-  MetricWithComparison promo_code_discount = 79;
+  MetricWithComparison gross_revenue = 8;
+  MetricWithComparison total_refunded = 9;
+  MetricWithComparison total_discount = 10;
+  MetricWithComparison product_sale_discount = 11;
+  MetricWithComparison promo_code_discount = 12;
+  MetricWithComparison new_subscribers = 13;
+  MetricWithComparison new_customers = 14;
+  MetricWithComparison repeat_customers_rate = 15;
+  MetricWithComparison avg_orders_per_customer = 16;
+  MetricWithComparison avg_days_between_orders = 17;
+  MetricWithComparison avg_shipping_cost = 18;
+  MetricWithComparison total_shipping_cost = 19;
+  CLVStats clv_distribution = 20;
 
-  repeated GeographyMetric revenue_by_country = 8;
-  repeated GeographyMetric revenue_by_city = 9;
-  repeated RegionMetric revenue_by_region = 26;
-  repeated GeographyMetric avg_order_by_country = 10;
+  repeated GeographyMetric revenue_by_country = 21;
+  repeated GeographyMetric revenue_by_city = 22;
+  repeated RegionMetric revenue_by_region = 23;
+  repeated GeographyMetric avg_order_by_country = 24;
+  repeated CurrencyMetric revenue_by_currency = 25;
+  repeated PaymentMethodMetric revenue_by_payment_method = 26;
+  repeated ProductMetric top_products_by_revenue = 27;
+  repeated ProductMetric top_products_by_quantity = 28;
+  repeated CategoryMetric revenue_by_category = 29;
+  repeated CrossSellPair cross_sell_pairs = 30;
+  repeated PromoMetric revenue_by_promo = 31;
+  // Every order PLACED in the period bucketed by its current status (one per bucket); sums to
+  // total_placed_orders, not orders_count.
+  repeated StatusCount orders_by_status = 32;
 
-  repeated CurrencyMetric revenue_by_currency = 27;
-  repeated PaymentMethodMetric revenue_by_payment_method = 42;
+  repeated TimeSeriesPoint revenue_by_day = 33;
+  repeated TimeSeriesPoint orders_by_day = 34;
+  repeated TimeSeriesPoint subscribers_by_day = 35;
+  repeated TimeSeriesPoint gross_revenue_by_day = 36;
+  repeated TimeSeriesPoint refunds_by_day = 37;
+  repeated TimeSeriesPoint avg_order_value_by_day = 38;
+  repeated TimeSeriesPoint units_sold_by_day = 39;
+  repeated TimeSeriesPoint new_customers_by_day = 40;
+  repeated TimeSeriesPoint returning_customers_by_day = 41;
+  repeated TimeSeriesPoint shipped_by_day = 42;
+  repeated TimeSeriesPoint delivered_by_day = 43;
+  repeated TimeSeriesPoint revenue_by_day_compare = 44;
+  repeated TimeSeriesPoint orders_by_day_compare = 45;
+  repeated TimeSeriesPoint subscribers_by_day_compare = 46;
+  repeated TimeSeriesPoint gross_revenue_by_day_compare = 47;
+  repeated TimeSeriesPoint refunds_by_day_compare = 48;
+  repeated TimeSeriesPoint avg_order_value_by_day_compare = 49;
+  repeated TimeSeriesPoint units_sold_by_day_compare = 50;
+  repeated TimeSeriesPoint new_customers_by_day_compare = 51;
+  repeated TimeSeriesPoint returning_customers_by_day_compare = 52;
+  repeated TimeSeriesPoint shipped_by_day_compare = 53;
+  repeated TimeSeriesPoint delivered_by_day_compare = 54;
+}
 
-  repeated ProductMetric top_products_by_revenue = 11;
-  repeated ProductMetric top_products_by_quantity = 12;
-  repeated CategoryMetric revenue_by_category = 13;
-  repeated CrossSellPair cross_sell_pairs = 14;
+// MarginMetrics is the DB-trusted COGS / margin view (from product.cost_price), computed over
+// the "costed" revenue subset; cost_coverage_pct says how much of revenue that subset is.
+message MarginMetrics {
+  MetricWithComparison revenue_cost = 1; // COGS: Σ(cost × qty), refund-adjusted
+  MetricWithComparison gross_margin = 2; // costed net revenue − COGS
+  MetricWithComparison gross_margin_pct = 3; // gross_margin / costed net revenue × 100
+  MetricWithComparison payment_fees = 4; // Σ Stripe processing fees, NOT refund-adjusted
+  MetricWithComparison contribution_margin = 5; // gross_margin − shipping − payment_fees
+  double cost_coverage_pct = 6; // % of product revenue with a cost set (trust gate for margins)
+  repeated int32 uncosted_product_ids = 7; // sold this period with no cost, ranked by revenue
+}
 
-  MetricWithComparison new_subscribers = 15;
-  MetricWithComparison repeat_customers_rate = 16;
-  MetricWithComparison avg_orders_per_customer = 17;
-  MetricWithComparison avg_days_between_orders = 18;
-  CLVStats clv_distribution = 19;
+// TrafficMetrics is the GA4-estimated traffic / engagement / conversion view. These figures
+// are sampled/modelled by GA4 — treat as directional, not DB-exact.
+message TrafficMetrics {
+  MetricWithComparison sessions = 1;
+  MetricWithComparison users = 2;
+  MetricWithComparison new_users = 3;
+  MetricWithComparison page_views = 4;
+  MetricWithComparison bounce_rate = 5;
+  MetricWithComparison avg_session_duration = 6;
+  MetricWithComparison pages_per_session = 7;
+  MetricWithComparison conversion_rate = 8;
+  MetricWithComparison revenue_per_session = 9;
 
-  repeated PromoMetric revenue_by_promo = 20;
-  // orders_by_status is every order PLACED in the period bucketed by its current status
-  // (one order per bucket), so it sums to total_placed_orders, NOT to orders_count.
-  // orders_count counts only net-revenue statuses (confirmed/shipped/delivered/partially_refunded),
-  // so cancelled/refunded/pending_return orders are excluded from it. Use total_placed_orders
-  // as the denominator for status shares such as cancellation% / refund%.
-  repeated StatusCount orders_by_status = 21;
+  repeated GeographySessionMetric sessions_by_country = 10;
+  repeated ProductViewMetric top_products_by_views = 11;
+  repeated TrafficSourceMetric traffic_by_source = 12;
+  repeated DeviceMetric traffic_by_device = 13;
 
-  repeated TimeSeriesPoint revenue_by_day = 22;
-  repeated TimeSeriesPoint orders_by_day = 23;
-  repeated TimeSeriesPoint subscribers_by_day = 24;
-  repeated TimeSeriesPoint gross_revenue_by_day = 28;
-  repeated TimeSeriesPoint refunds_by_day = 29;
-  repeated TimeSeriesPoint avg_order_value_by_day = 30;
-  repeated TimeSeriesPoint units_sold_by_day = 31;
-  repeated TimeSeriesPoint new_customers_by_day = 43;
-  repeated TimeSeriesPoint returning_customers_by_day = 44;
-  repeated TimeSeriesPoint shipped_by_day = 45;
-  repeated TimeSeriesPoint delivered_by_day = 46;
-  repeated TimeSeriesPoint revenue_by_day_compare = 32;
-  repeated TimeSeriesPoint orders_by_day_compare = 33;
-  repeated TimeSeriesPoint subscribers_by_day_compare = 34;
-  repeated TimeSeriesPoint gross_revenue_by_day_compare = 35;
-  repeated TimeSeriesPoint refunds_by_day_compare = 36;
-  repeated TimeSeriesPoint avg_order_value_by_day_compare = 37;
-  repeated TimeSeriesPoint units_sold_by_day_compare = 38;
-  repeated TimeSeriesPoint new_customers_by_day_compare = 47;
-  repeated TimeSeriesPoint returning_customers_by_day_compare = 48;
-  repeated TimeSeriesPoint shipped_by_day_compare = 49;
-  repeated TimeSeriesPoint delivered_by_day_compare = 50;
+  repeated TimeSeriesPoint sessions_by_day = 14;
+  repeated TimeSeriesPoint users_by_day = 15;
+  repeated TimeSeriesPoint page_views_by_day = 16;
+  repeated TimeSeriesPoint conversion_rate_by_day = 17;
+  repeated TimeSeriesPoint sessions_by_day_compare = 18;
+  repeated TimeSeriesPoint users_by_day_compare = 19;
+  repeated TimeSeriesPoint page_views_by_day_compare = 20;
+  repeated TimeSeriesPoint conversion_rate_by_day_compare = 21;
+}
 
-  // GA4 Traffic & Engagement
-  MetricWithComparison sessions = 51;
-  MetricWithComparison users = 52;
-  MetricWithComparison new_users = 53;
-  MetricWithComparison page_views = 54;
-  MetricWithComparison bounce_rate = 55;
-  // Average engagement time per session (seconds), derived from GA4
-  // userEngagementDuration / sessions at sync — not raw averageSessionDuration
-  // (wall-clock first-to-last event, often inflated by background tabs).
-  MetricWithComparison avg_session_duration = 56;
-  MetricWithComparison pages_per_session = 57;
-  MetricWithComparison conversion_rate = 58;
-  MetricWithComparison revenue_per_session = 59;
-
-  repeated GeographySessionMetric sessions_by_country = 60;
-  repeated ProductViewMetric top_products_by_views = 61;
-  repeated TrafficSourceMetric traffic_by_source = 62;
-  repeated DeviceMetric traffic_by_device = 63;
-
-  repeated TimeSeriesPoint sessions_by_day = 64;
-  repeated TimeSeriesPoint users_by_day = 65;
-  repeated TimeSeriesPoint page_views_by_day = 66;
-  repeated TimeSeriesPoint conversion_rate_by_day = 67;
-  repeated TimeSeriesPoint sessions_by_day_compare = 68;
-  repeated TimeSeriesPoint users_by_day_compare = 69;
-  repeated TimeSeriesPoint page_views_by_day_compare = 70;
-  repeated TimeSeriesPoint conversion_rate_by_day_compare = 71;
-
-  // Email delivery metrics (from Resend webhooks)
-  MetricWithComparison emails_sent = 72;
-  MetricWithComparison emails_delivered = 73;
-  MetricWithComparison email_delivery_rate = 74;
-  MetricWithComparison email_open_rate = 75;
-  MetricWithComparison email_click_rate = 76;
-  MetricWithComparison email_bounce_rate = 77;
-
-  // Customer acquisition aggregate (sum of new_customers_by_day series)
-  MetricWithComparison new_customers = 80;
-
-  // Shipping / logistics metrics
-  MetricWithComparison avg_shipping_cost = 82;
-  MetricWithComparison total_shipping_cost = 83;
-
-  // Total orders PLACED in the period, regardless of status (sum of orders_by_status).
-  // Distinct from orders_count, which counts only net-revenue statuses. Use this as the
-  // denominator when deriving status shares (cancellation rate, refund rate, etc.).
-  MetricWithComparison total_placed_orders = 84;
-
-  // Margin metrics, derived from product.cost_price (per-unit COGS in base currency).
-  // Computed ONLY over line items whose product has a cost set, so revenue_cost and the
-  // margins are on the "costed" subset of revenue — gross_margin_pct.caveat and
-  // cost_coverage_pct report how much of revenue that subset is. COGS is net of the
-  // refund proration but NOT reduced by promo/sale discounts (a discount lowers revenue,
-  // not the cost of the goods).
-  MetricWithComparison revenue_cost = 85; // COGS: Σ(cost × qty), refund-adjusted
-  MetricWithComparison gross_margin = 86; // costed net revenue − COGS
-  MetricWithComparison gross_margin_pct = 87; // gross_margin / costed net revenue × 100
-  MetricWithComparison contribution_margin = 88; // gross_margin − total_shipping_cost − payment_fees
-  // Σ Stripe processing fees (base currency) captured from each order's charge balance
-  // transaction. NOT refund-adjusted — Stripe keeps the fee on refunds, so it is the full
-  // fee actually paid. A real contribution-margin cost that gross_margin ignores. Only
-  // orders with a captured fee contribute (pre-feature / non-Stripe orders are excluded).
-  MetricWithComparison payment_fees = 91;
-  // Share (%) of net product revenue (base currency) whose product has a cost set — the
-  // fraction the margin figures above are computed over. 100 = full cost coverage.
-  double cost_coverage_pct = 89;
-  // Product IDs that sold in the period but have NO cost_price set, ordered by their period
-  // revenue descending — the products darkening the margin figures above. This is the
-  // actionable companion to cost_coverage_pct: set a cost (via a tech card) for the top
-  // entries first to raise coverage. Empty when coverage is already 100%.
-  repeated int32 uncosted_product_ids = 90;
+// EmailMetrics is the Resend email-delivery view.
+message EmailMetrics {
+  MetricWithComparison emails_sent = 1;
+  MetricWithComparison emails_delivered = 2;
+  MetricWithComparison email_delivery_rate = 3;
+  MetricWithComparison email_open_rate = 4;
+  MetricWithComparison email_click_rate = 5;
+  MetricWithComparison email_bounce_rate = 6;
 }
 
 message PaymentMethodMetric {

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -197,6 +197,19 @@ service AdminService {
     option (google.api.http) = {get: "/api/admin/dashboard"};
   }
 
+  // Reads the operator-tunable thresholds behind the dashboard alerts.
+  rpc GetAlertSettings(GetAlertSettingsRequest) returns (GetAlertSettingsResponse) {
+    option (google.api.http) = {get: "/api/admin/dashboard/alert-settings"};
+  }
+
+  // Updates the operator-tunable dashboard alert thresholds.
+  rpc UpsertAlertSettings(UpsertAlertSettingsRequest) returns (UpsertAlertSettingsResponse) {
+    option (google.api.http) = {
+      post: "/api/admin/dashboard/alert-settings/upsert"
+      body: "*"
+    };
+  }
+
   // Sets per-SKU inventory reorder targets used by the inventory-health metrics.
   rpc UpsertInventoryTargets(UpsertInventoryTargetsRequest) returns (UpsertInventoryTargetsResponse) {
     option (google.api.http) = {
@@ -968,6 +981,26 @@ message GetDashboardResponse {
   repeated SlowMoverRow clear = 13; // slow movers to clear
   repeated SellThroughByDropRow drops = 14; // drop sell-through
 }
+
+// AlertSettings are the operator-tunable thresholds behind the dashboard alerts.
+message AlertSettings {
+  double coverage_warn_pct = 1; // warn when cost coverage (% of revenue with a cost) is below this
+  double refund_rate_warn_pct = 2; // warn when refund rate is at/above this
+  int32 rate_floor_n = 3; // min orders before any rate-based alert fires (significance floor)
+  double contribution_trust_pct = 4; // trust the contribution-margin sign only at/above this coverage
+}
+
+message GetAlertSettingsRequest {}
+
+message GetAlertSettingsResponse {
+  AlertSettings settings = 1;
+}
+
+message UpsertAlertSettingsRequest {
+  AlertSettings settings = 1;
+}
+
+message UpsertAlertSettingsResponse {}
 
 message FunnelSection {
   FunnelAggregate aggregate = 1;

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -190,6 +190,13 @@ service AdminService {
     option (google.api.http) = {get: "/api/admin/metrics"};
   }
 
+  // GetDashboard returns a small, DB-trusted decision payload: headline revenue/orders/margin
+  // (+ caveat), server-computed alerts, and short action lists (top by margin €, reorder,
+  // clear, drop sell-through). Use GetMetrics for deep, sectioned drill-down.
+  rpc GetDashboard(GetDashboardRequest) returns (GetDashboardResponse) {
+    option (google.api.http) = {get: "/api/admin/dashboard"};
+  }
+
   // Sets per-SKU inventory reorder targets used by the inventory-health metrics.
   rpc UpsertInventoryTargets(UpsertInventoryTargetsRequest) returns (UpsertInventoryTargetsResponse) {
     option (google.api.http) = {
@@ -916,6 +923,50 @@ message GetMetricsResponse {
   repeated CustomerSegmentRow customer_segments = 46;
   repeated RFMSegmentRow rfm_analysis = 47;
   repeated SellThroughByDropRow sell_through_by_drop = 48;
+}
+
+// --- Dashboard (decision-grade summary) ---
+
+message GetDashboardRequest {
+  // Period spec, same grammar as GetMetrics (7d, 30d, 90d, today, WTD, MTD, QTD, YTD).
+  string period = 1;
+  // Optional window end (defaults to now). The period is measured back from here.
+  google.protobuf.Timestamp end_at = 2;
+  // Max rows per action list (top-by-margin, reorder, clear, drops). 0 = server default.
+  int32 limit = 3;
+}
+
+enum AlertSeverity {
+  ALERT_SEVERITY_UNSPECIFIED = 0;
+  ALERT_SEVERITY_INFO = 1;
+  ALERT_SEVERITY_WARNING = 2;
+  ALERT_SEVERITY_CRITICAL = 3;
+}
+
+// DashboardAlert is a server-computed, threshold-driven alert. Rate-based alerts are gated on
+// a minimum order count, so they never fire on a statistically meaningless sample.
+message DashboardAlert {
+  AlertSeverity severity = 1;
+  string code = 2; // stable machine key, e.g. "low_cost_coverage"
+  string title = 3;
+  string detail = 4;
+}
+
+message GetDashboardResponse {
+  TimeRange period = 1;
+  google.type.Decimal revenue = 2; // net revenue (base currency)
+  int32 orders = 3; // net-revenue order count
+  google.type.Decimal gross_margin = 4; // costed net revenue − COGS
+  double gross_margin_pct = 5;
+  google.type.Decimal contribution_margin = 6; // gross_margin − shipping − payment_fees
+  double cost_coverage_pct = 7; // % of product revenue with a cost set (trust gate for margins)
+  string caveat = 8; // set when coverage is low, so margins are only partial
+  repeated int32 uncosted_product_ids = 9; // products sold this period with no cost, ranked by revenue
+  repeated DashboardAlert alerts = 10;
+  repeated ProductMetric top_by_margin = 11; // top revenue products re-ranked by gross margin €
+  repeated InventoryHealthRow reorder = 12; // SKUs flagged needs_reorder, most urgent first
+  repeated SlowMoverRow clear = 13; // slow movers to clear
+  repeated SellThroughByDropRow drops = 14; // drop sell-through
 }
 
 message FunnelSection {


### PR DESCRIPTION
Second margin/analytics backlog (12 items). **Breaking proto change** — `BusinessMetrics` is split by provenance and several messages gain fields.

## What's in it
- **#4 Payment fees → contribution margin** — capture Stripe `balance_transaction.fee` at settle time (`0088_add_order_payment_fee`), fold into `ContributionMargin = grossMargin − shipping − paymentFees`. Zero extra Stripe calls.
- **#6/#7 GetDashboard + tunable alerts** — one decision RPC (core sales, margin, shipping, fees, reorder list, slow movers, sell-through, uncosted products) with **server-computed alerts** (negative contribution, low cost coverage, uncosted products, reorder needed, high refund rate). Thresholds live in an `alert_setting` table (`0089_add_alert_setting`) editable via `GetAlertSettings`/`UpsertAlertSettings`; alerts are trust-gated (contribution sign ignored below coverage floor) and n-gated (rate alerts suppressed below a sample floor).
- **#9 Confidence** — `sample_size` + `margin_of_error` (95% CI) on rate metrics.
- **#1 Per-row margin** — gross margin on Pareto/SlowMover rows; `uncosted_product_ids` (sold, no cost_price, ranked by revenue) so gaps are actionable.
- **#3 Sell-through by drop** — sold/(sold+remaining) per collection cohort.
- **#8 is_selling** — explicit flag on InventoryHealthRow (no more inferring from avg daily sales).
- **#12 CAC** — cost-per-acquisition on CampaignAttribution rows.
- **#10 BusinessMetrics split** (breaking) — flat god-object → `commerce` / `margin` / `traffic` / `email` sub-messages. Internal entity stays flat; only proto + DTO restructured.

## Migrations
`0088_add_order_payment_fee` (nullable column, backfill-safe) and `0089_add_alert_setting` (key/value table seeded with defaults). Both safe against existing prod data; contiguous after RBAC's `0087`.

## RBAC
New RPCs classified in `internal/rbac/rbac.go` (GetDashboard/GetAlertSettings read, UpsertAlertSettings write — analytics section); fail-closed completeness test passes.

## Verification
`go build ./...`, `go vet`, and the metrics/admin/auth/dto/rbac/payment/order test suites are green. Merged current master (RBAC / 0087) in cleanly.

Flow: this PR → **beta** (auto-deploy, verify migrations on grbpwr_beta) → then → master (prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)