### PR TITLE
Finish drop margin, true size sell-through, cross-sell lift (#4/#6/#7)

### DIFF
--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -414,6 +414,9 @@ func crossSellPairsToPb(list []entity.CrossSellPair) []*pb_admin.CrossSellPair {
 			ProductAName: c.ProductAName,
 			ProductBName: c.ProductBName,
 			Count:        int32(c.Count),
+			Support:      c.Support,
+			Confidence:   c.Confidence,
+			Lift:         c.Lift,
 		}
 	}
 	return pb
@@ -1053,6 +1056,9 @@ func ConvertSizeRunEfficiencyToPb(list []entity.SizeRunEfficiencyRow) []*pb_admi
 			TotalSizes:       int32(r.TotalSizes),
 			SoldThroughSizes: int32(r.SoldThroughSizes),
 			EfficiencyPct:    r.EfficiencyPct,
+			UnitsBought:      r.UnitsBought,
+			UnitsSold:        r.UnitsSold,
+			SellThroughPct:   r.SellThroughPct,
 		}
 	}
 	return pb
@@ -1064,14 +1070,25 @@ func ConvertSellThroughByDropToPb(list []entity.SellThroughByDropRow) []*pb_admi
 	}
 	pb := make([]*pb_admin.SellThroughByDropRow, len(list))
 	for i, r := range list {
-		pb[i] = &pb_admin.SellThroughByDropRow{
+		row := &pb_admin.SellThroughByDropRow{
 			Collection:     r.Collection,
 			ProductCount:   int32(r.ProductCount),
 			UnitsSold:      r.UnitsSold,
 			UnitsRemaining: r.UnitsRemaining,
+			UnitsBought:    r.UnitsBought,
 			SellThroughPct: r.SellThroughPct,
 			Revenue:        &decimal.Decimal{Value: r.Revenue.String()},
+			HasCost:        r.HasCost,
 		}
+		if r.HasCost {
+			row.GrossMargin = &decimal.Decimal{Value: r.GrossMargin.String()}
+			row.GrossMarginPct = r.GrossMarginPct
+		}
+		if r.DaysTo50Pct.Valid {
+			v := r.DaysTo50Pct.Int64
+			row.DaysTo_50Pct = &v
+		}
+		pb[i] = row
 	}
 	return pb
 }

--- a/internal/entity/metrics.go
+++ b/internal/entity/metrics.go
@@ -255,7 +255,10 @@ type CrossSellPair struct {
 	ProductBId   int
 	ProductAName string
 	ProductBName string
-	Count        int
+	Count        int     // orders containing both A and B (distinct orders)
+	Support      float64 // P(A∧B): Count / total orders
+	Confidence   float64 // P(B|A): Count / orders containing A
+	Lift         float64 // Support / (P(A)·P(B)); >1 ⇒ bought together more than chance
 }
 
 type PromoMetric struct {
@@ -606,7 +609,11 @@ type SizeRunEfficiencyRow struct {
 	ProductName      string  `db:"product_name"`
 	TotalSizes       int     `db:"total_sizes"`
 	SoldThroughSizes int     `db:"sold_through_sizes"`
-	EfficiencyPct    float64 `db:"efficiency_pct"`
+	EfficiencyPct    float64 `db:"efficiency_pct"` // size-run coverage: % of sizes with any sale
+	// True unit sell-through (distinct from the size-coverage EfficiencyPct above).
+	UnitsBought    int64   `db:"units_bought"`     // Σ initial stock across sizes (on-hand + net sold)
+	UnitsSold      int64   `db:"units_sold"`       // Σ net units sold across sizes
+	SellThroughPct float64 `db:"sell_through_pct"` // UnitsSold / UnitsBought × 100
 }
 
 // SellThroughByDropRow rolls a release/drop cohort (product.collection) into decision-grade
@@ -616,8 +623,21 @@ type SellThroughByDropRow struct {
 	ProductCount   int             `db:"product_count"`
 	UnitsSold      int64           `db:"units_sold"`
 	UnitsRemaining int64           `db:"units_remaining"`
+	UnitsBought    int64           `db:"units_bought"` // units_sold + units_remaining (initial-stock proxy)
 	SellThroughPct float64         `db:"sell_through_pct"`
 	Revenue        decimal.Decimal `db:"revenue"`
+	// Margin over the costed subset (products with a cost_price). RevenueCost/CostedRevenue are
+	// scanned; HasCost/GrossMargin/GrossMarginPct are derived in Go (mirrors SlowMoverRow). When
+	// nothing in the drop has a cost, HasCost=false and the margins are N/A rather than a
+	// misleading 0/100.
+	RevenueCost    decimal.Decimal `db:"revenue_cost"`   // Σ(cost_price × units_sold) over costed products
+	CostedRevenue  decimal.Decimal `db:"costed_revenue"` // Σ(revenue) over costed products
+	HasCost        bool            `db:"-"`
+	GrossMargin    decimal.Decimal `db:"-"`
+	GrossMarginPct float64         `db:"-"`
+	// DaysTo50Pct is the whole days from the drop's first sale to 50% sell-through; invalid when
+	// the drop hasn't reached 50% yet (or has no sales).
+	DaysTo50Pct sql.NullInt64 `db:"-"`
 }
 
 // --- Dashboard (decision-grade summary) ---

--- a/internal/store/metrics/breakdown.go
+++ b/internal/store/metrics/breakdown.go
@@ -251,40 +251,83 @@ func (s *Store) getRevenueByCategory(ctx context.Context, from, to time.Time) ([
 }
 
 func (s *Store) getCrossSellPairs(ctx context.Context, from, to time.Time, limit int) ([]entity.CrossSellPair, error) {
-	query := `
-		SELECT oi1.product_id AS product_a_id, oi2.product_id AS product_b_id,
-			COALESCE((SELECT pt.name FROM product_translation pt WHERE pt.product_id = p1.id ORDER BY pt.language_id LIMIT 1), p1.brand) AS product_a_name,
-			COALESCE((SELECT pt.name FROM product_translation pt WHERE pt.product_id = p2.id ORDER BY pt.language_id LIMIT 1), p2.brand) AS product_b_name,
-			COUNT(*) AS cnt
-		FROM order_item oi1
-		JOIN order_item oi2 ON oi1.order_id = oi2.order_id AND oi1.product_id < oi2.product_id
-		JOIN product p1 ON oi1.product_id = p1.id
-		JOIN product p2 ON oi2.product_id = p2.id
-		JOIN customer_order co ON oi1.order_id = co.id
+	statusIDs := storeutil.JoinInts(cache.OrderStatusIDsForNetRevenue())
+	baseArgs := map[string]any{"from": from, "to": to}
+
+	// totalOrders: distinct orders in the same universe as the co-occurrence (net-revenue,
+	// in period) — the denominator for support and lift.
+	total, err := storeutil.QueryNamedOne[struct {
+		Count int `db:"cnt"`
+	}](ctx, s.DB, fmt.Sprintf(`
+		SELECT COUNT(DISTINCT co.id) AS cnt
+		FROM customer_order co
 		WHERE co.placed >= :from AND co.placed < :to
-		AND co.order_status_id IN (:statusIds)
-		GROUP BY oi1.product_id, oi2.product_id, p1.brand, p2.brand
-		ORDER BY cnt DESC
-		LIMIT :limit
-	`
+			AND co.order_status_id IN (%s)
+	`, statusIDs), baseArgs)
+	if err != nil {
+		return nil, fmt.Errorf("cross-sell total orders: %w", err)
+	}
+
+	// ordersByProduct: distinct orders containing each product — the marginal P(A), P(B)
+	// denominators for confidence and lift.
+	prodRows, err := storeutil.QueryListNamed[struct {
+		ProductID int `db:"product_id"`
+		Count     int `db:"cnt"`
+	}](ctx, s.DB, fmt.Sprintf(`
+		SELECT oi.product_id, COUNT(DISTINCT oi.order_id) AS cnt
+		FROM order_item oi
+		JOIN customer_order co ON oi.order_id = co.id
+		WHERE co.placed >= :from AND co.placed < :to
+			AND co.order_status_id IN (%s)
+		GROUP BY oi.product_id
+	`, statusIDs), baseArgs)
+	if err != nil {
+		return nil, fmt.Errorf("cross-sell product orders: %w", err)
+	}
+	ordersByProduct := make(map[int]int, len(prodRows))
+	for _, r := range prodRows {
+		ordersByProduct[r.ProductID] = r.Count
+	}
+
+	// top co-occurring pairs — COUNT(DISTINCT order_id) so multiple sizes/lines of the same
+	// product in one order count that order once, not once per line.
 	rows, err := storeutil.QueryListNamed[struct {
 		ProductAId   int    `db:"product_a_id"`
 		ProductBId   int    `db:"product_b_id"`
 		ProductAName string `db:"product_a_name"`
 		ProductBName string `db:"product_b_name"`
 		Count        int    `db:"cnt"`
-	}](ctx, s.DB, query, map[string]any{"from": from, "to": to, "limit": limit, "statusIds": cache.OrderStatusIDsForNetRevenue()})
+	}](ctx, s.DB, fmt.Sprintf(`
+		SELECT oi1.product_id AS product_a_id, oi2.product_id AS product_b_id,
+			COALESCE((SELECT pt.name FROM product_translation pt WHERE pt.product_id = p1.id ORDER BY pt.language_id LIMIT 1), p1.brand) AS product_a_name,
+			COALESCE((SELECT pt.name FROM product_translation pt WHERE pt.product_id = p2.id ORDER BY pt.language_id LIMIT 1), p2.brand) AS product_b_name,
+			COUNT(DISTINCT oi1.order_id) AS cnt
+		FROM order_item oi1
+		JOIN order_item oi2 ON oi1.order_id = oi2.order_id AND oi1.product_id < oi2.product_id
+		JOIN product p1 ON oi1.product_id = p1.id
+		JOIN product p2 ON oi2.product_id = p2.id
+		JOIN customer_order co ON oi1.order_id = co.id
+		WHERE co.placed >= :from AND co.placed < :to
+			AND co.order_status_id IN (%s)
+		GROUP BY oi1.product_id, oi2.product_id, p1.brand, p2.brand
+		ORDER BY cnt DESC
+		LIMIT :limit
+	`, statusIDs), map[string]any{"from": from, "to": to, "limit": limit})
 	if err != nil {
 		return nil, err
 	}
 	result := make([]entity.CrossSellPair, len(rows))
 	for i, r := range rows {
+		support, confidence, lift := associationMetrics(r.Count, ordersByProduct[r.ProductAId], ordersByProduct[r.ProductBId], total.Count)
 		result[i] = entity.CrossSellPair{
 			ProductAId:   r.ProductAId,
 			ProductBId:   r.ProductBId,
 			ProductAName: r.ProductAName,
 			ProductBName: r.ProductBName,
 			Count:        r.Count,
+			Support:      support,
+			Confidence:   confidence,
+			Lift:         lift,
 		}
 	}
 	return result, nil

--- a/internal/store/metrics/inventory.go
+++ b/internal/store/metrics/inventory.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
 	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
+	"github.com/shopspring/decimal"
 )
 
 type inventoryStore struct {
@@ -164,7 +166,10 @@ func (is *inventoryStore) GetSellThroughByDrop(ctx context.Context, from, to tim
 			COUNT(DISTINCT p.id) AS product_count,
 			COALESCE(SUM(s.units_sold), 0) AS units_sold,
 			COALESCE(SUM(st.units_remaining), 0) AS units_remaining,
+			COALESCE(SUM(s.units_sold), 0) + COALESCE(SUM(st.units_remaining), 0) AS units_bought,
 			COALESCE(SUM(s.revenue), 0) AS revenue,
+			COALESCE(SUM(CASE WHEN p.cost_price IS NOT NULL THEN p.cost_price * COALESCE(s.units_sold, 0) ELSE 0 END), 0) AS revenue_cost,
+			COALESCE(SUM(CASE WHEN p.cost_price IS NOT NULL THEN COALESCE(s.revenue, 0) ELSE 0 END), 0) AS costed_revenue,
 			CASE
 				WHEN COALESCE(SUM(s.units_sold), 0) + COALESCE(SUM(st.units_remaining), 0) > 0
 				THEN COALESCE(SUM(s.units_sold), 0) * 100.0 / (COALESCE(SUM(s.units_sold), 0) + COALESCE(SUM(st.units_remaining), 0))
@@ -187,7 +192,91 @@ func (is *inventoryStore) GetSellThroughByDrop(ctx context.Context, from, to tim
 	if err != nil {
 		return nil, fmt.Errorf("get sell-through by drop: %w", err)
 	}
+	if len(result) == 0 {
+		return result, nil
+	}
+
+	// days_to_50pct needs a per-drop daily sales timeline. Fetch it once (lifetime, same
+	// net-revenue universe as the aggregate above) and compute the crossing in Go.
+	timeline, err := is.sellThroughTimeline(ctx, statusIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	hundred := decimal.NewFromInt(100)
+	for i := range result {
+		r := &result[i]
+		// Margin over the costed subset. HasCost=false ⇒ no costed sales, so N/A not 0.
+		r.HasCost = r.CostedRevenue.IsPositive()
+		if r.HasCost {
+			r.GrossMargin = r.CostedRevenue.Sub(r.RevenueCost)
+			pct, _ := r.GrossMargin.Div(r.CostedRevenue).Mul(hundred).Float64()
+			r.GrossMarginPct = pct
+		}
+		// days_to_50pct is only defined once the drop has actually reached 50% sell-through.
+		if r.SellThroughPct >= 50 {
+			r.DaysTo50Pct = daysToSellThrough(timeline[r.Collection], r.UnitsBought, 50)
+		}
+	}
 	return result, nil
+}
+
+// dropSalePoint is one day's net units sold for a drop, used to find the 50%-sell-through date.
+type dropSalePoint struct {
+	Date  time.Time `db:"d"`
+	Units int64     `db:"units"`
+}
+
+// sellThroughTimeline returns, per collection, the daily net units sold over all time (same
+// net-revenue statuses as the aggregate), ascending by date — the input to daysToSellThrough.
+func (is *inventoryStore) sellThroughTimeline(ctx context.Context, statusIDs string) (map[string][]dropSalePoint, error) {
+	rows, err := storeutil.QueryListNamed[struct {
+		Collection string    `db:"collection"`
+		Date       time.Time `db:"d"`
+		Units      int64     `db:"units"`
+	}](ctx, is.DB, fmt.Sprintf(`
+		SELECT p.collection AS collection, DATE(co.placed) AS d, SUM(oi.quantity) AS units
+		FROM order_item oi
+		JOIN customer_order co ON oi.order_id = co.id
+		JOIN product p ON oi.product_id = p.id
+		WHERE co.order_status_id IN (%s)
+			AND p.deleted_at IS NULL
+			AND p.collection IS NOT NULL AND p.collection <> ''
+		GROUP BY p.collection, DATE(co.placed)
+		ORDER BY p.collection, d
+	`, statusIDs), map[string]any{})
+	if err != nil {
+		return nil, fmt.Errorf("sell-through timeline: %w", err)
+	}
+	m := make(map[string][]dropSalePoint)
+	for _, r := range rows {
+		m[r.Collection] = append(m[r.Collection], dropSalePoint{Date: r.Date, Units: r.Units})
+	}
+	return m, nil
+}
+
+// daysToSellThrough returns the whole days from the first sale to the day cumulative units sold
+// first reached targetPct percent of initialUnits. It is invalid (null) when there are no
+// sales, the inputs are degenerate, or the target is never reached (the drop hasn't sold that
+// share yet). points must be sorted ascending by date.
+func daysToSellThrough(points []dropSalePoint, initialUnits int64, targetPct float64) sql.NullInt64 {
+	if len(points) == 0 || initialUnits <= 0 || targetPct <= 0 {
+		return sql.NullInt64{}
+	}
+	threshold := targetPct / 100 * float64(initialUnits)
+	first := points[0].Date
+	var cumulative int64
+	for _, pt := range points {
+		cumulative += pt.Units
+		if float64(cumulative) >= threshold {
+			days := int64(pt.Date.Sub(first).Hours() / 24)
+			if days < 0 {
+				days = 0
+			}
+			return sql.NullInt64{Int64: days, Valid: true}
+		}
+	}
+	return sql.NullInt64{}
 }
 
 // GetSizeRunEfficiency returns the percentage of sizes that have any sales activity
@@ -231,7 +320,14 @@ func (is *inventoryStore) GetSizeRunEfficiency(ctx context.Context, from, to tim
 			) AS product_name,
 			COUNT(*) AS total_sizes,
 			SUM(CASE WHEN sa.sell_through_pct > 0 THEN 1 ELSE 0 END) AS sold_through_sizes,
-			SUM(CASE WHEN sa.sell_through_pct > 0 THEN 1 ELSE 0 END) * 100 / COUNT(*) AS efficiency_pct
+			SUM(CASE WHEN sa.sell_through_pct > 0 THEN 1 ELSE 0 END) * 100 / COUNT(*) AS efficiency_pct,
+			COALESCE(SUM(sa.initial_qty), 0) AS units_bought,
+			COALESCE(SUM(sa.sold), 0) AS units_sold,
+			CASE
+				WHEN COALESCE(SUM(sa.initial_qty), 0) > 0
+				THEN SUM(sa.sold) * 100.0 / SUM(sa.initial_qty)
+				ELSE 0
+			END AS sell_through_pct
 		FROM size_analysis sa
 		JOIN product p ON p.id = sa.product_id
 		WHERE sa.initial_qty > 0

--- a/internal/store/metrics/inventory_test.go
+++ b/internal/store/metrics/inventory_test.go
@@ -1,0 +1,98 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDaysToSellThrough(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	day := func(n int) time.Time { return base.AddDate(0, 0, n) }
+
+	tests := []struct {
+		name         string
+		points       []dropSalePoint
+		initialUnits int64
+		targetPct    float64
+		wantValid    bool
+		wantDays     int64
+	}{
+		{
+			name:         "no points -> invalid",
+			points:       nil,
+			initialUnits: 100,
+			targetPct:    50,
+			wantValid:    false,
+		},
+		{
+			name:         "zero initial -> invalid",
+			points:       []dropSalePoint{{Date: day(0), Units: 10}},
+			initialUnits: 0,
+			targetPct:    50,
+			wantValid:    false,
+		},
+		{
+			name:         "reached on the first sale day -> 0 days",
+			points:       []dropSalePoint{{Date: day(0), Units: 60}},
+			initialUnits: 100,
+			targetPct:    50,
+			wantValid:    true,
+			wantDays:     0,
+		},
+		{
+			name: "crosses 50% on day 10",
+			points: []dropSalePoint{
+				{Date: day(0), Units: 20},
+				{Date: day(5), Units: 20},
+				{Date: day(10), Units: 20}, // cumulative 60 >= 50 here
+			},
+			initialUnits: 100,
+			targetPct:    50,
+			wantValid:    true,
+			wantDays:     10,
+		},
+		{
+			name: "exact threshold counts as reached",
+			points: []dropSalePoint{
+				{Date: day(0), Units: 25},
+				{Date: day(3), Units: 25}, // cumulative exactly 50
+			},
+			initialUnits: 100,
+			targetPct:    50,
+			wantValid:    true,
+			wantDays:     3,
+		},
+		{
+			name: "never reaches 50% -> invalid",
+			points: []dropSalePoint{
+				{Date: day(0), Units: 20},
+				{Date: day(9), Units: 20}, // cumulative 40 < 50
+			},
+			initialUnits: 100,
+			targetPct:    50,
+			wantValid:    false,
+		},
+		{
+			name: "days measured from first sale, not from epoch",
+			points: []dropSalePoint{
+				{Date: day(30), Units: 40},
+				{Date: day(37), Units: 40}, // cumulative 80 >= 50 -> 7 days after first sale
+			},
+			initialUnits: 100,
+			targetPct:    50,
+			wantValid:    true,
+			wantDays:     7,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := daysToSellThrough(tt.points, tt.initialUnits, tt.targetPct)
+			assert.Equal(t, tt.wantValid, got.Valid)
+			if tt.wantValid {
+				assert.Equal(t, tt.wantDays, got.Int64)
+			}
+		})
+	}
+}

--- a/internal/store/metrics/stats.go
+++ b/internal/store/metrics/stats.go
@@ -19,3 +19,27 @@ func proportionMarginOfError(ratePct float64, n int) float64 {
 	}
 	return 1.96 * math.Sqrt(p*(1-p)/float64(n)) * 100
 }
+
+// associationMetrics turns a co-occurrence count into the standard market-basket association
+// measures for a product pair (A,B), so the client gets a normalized signal instead of a raw
+// count it has to threshold arbitrarily:
+//
+//   - support    = P(A∧B)  = coCount / totalOrders          — how common the pair is overall
+//   - confidence = P(B|A)  = coCount / ordersWithA          — given A, how often B is added too
+//   - lift       = support / (P(A)·P(B)) = coCount·total / (ordersWithA·ordersWithB)
+//     lift > 1 ⇒ bought together more than independent chance; = 1 ⇒ independent; < 1 ⇒ less.
+//
+// Any degenerate denominator (no orders, or a product that never sold on its own) yields 0 for
+// the affected measure so callers can treat 0 as "not computable" rather than a real signal.
+func associationMetrics(coCount, ordersWithA, ordersWithB, totalOrders int) (support, confidence, lift float64) {
+	if totalOrders > 0 {
+		support = float64(coCount) / float64(totalOrders)
+	}
+	if ordersWithA > 0 {
+		confidence = float64(coCount) / float64(ordersWithA)
+	}
+	if ordersWithA > 0 && ordersWithB > 0 && totalOrders > 0 {
+		lift = float64(coCount) * float64(totalOrders) / (float64(ordersWithA) * float64(ordersWithB))
+	}
+	return support, confidence, lift
+}

--- a/internal/store/metrics/stats_test.go
+++ b/internal/store/metrics/stats_test.go
@@ -30,3 +30,30 @@ func TestProportionMarginOfError(t *testing.T) {
 		})
 	}
 }
+
+func TestAssociationMetrics(t *testing.T) {
+	tests := []struct {
+		name                             string
+		coCount, ordersA, ordersB, total int
+		wantSupport, wantConf, wantLift  float64
+	}{
+		// 100 orders; A in 20, B in 10, both in 5.
+		// support=5/100=.05, confidence=5/20=.25, lift=5*100/(20*10)=2.5 (co-bought 2.5× chance).
+		{"positive association", 5, 20, 10, 100, 0.05, 0.25, 2.5},
+		// independence: P(A∧B)=P(A)P(B) ⇒ lift=1. A=50,B=40,both=20,total=100 → 20*100/(50*40)=1.
+		{"independent -> lift 1", 20, 50, 40, 100, 0.20, 0.40, 1.0},
+		// negative association: lift<1. A=50,B=50,both=10,total=100 → 10*100/(50*50)=0.4.
+		{"negative association", 10, 50, 50, 100, 0.10, 0.20, 0.4},
+		{"no orders -> all 0", 0, 0, 0, 0, 0, 0, 0},
+		// degenerate marginal (product never sold alone) must not divide by zero.
+		{"zero marginal -> lift 0", 3, 0, 5, 100, 0.03, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			support, conf, lift := associationMetrics(tt.coCount, tt.ordersA, tt.ordersB, tt.total)
+			assert.InDelta(t, tt.wantSupport, support, 1e-9, "support")
+			assert.InDelta(t, tt.wantConf, conf, 1e-9, "confidence")
+			assert.InDelta(t, tt.wantLift, lift, 1e-9, "lift")
+		})
+	}
+}

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -1294,7 +1294,10 @@ message CrossSellPair {
   int32 product_b_id = 2;
   string product_a_name = 3;
   string product_b_name = 4;
-  int32 count = 5;
+  int32 count = 5; // orders containing both A and B (distinct orders)
+  double support = 6; // P(A∧B): count / total orders
+  double confidence = 7; // P(B|A): count / orders containing A
+  double lift = 8; // support / (P(A)·P(B)); >1 ⇒ bought together more than chance, so the client can rank/threshold on strength instead of raw count
 }
 
 message PromoMetric {
@@ -2020,6 +2023,11 @@ message SellThroughByDropRow {
   int64 units_remaining = 4; // current on-hand units across the drop
   double sell_through_pct = 5; // units_sold / (units_sold + units_remaining) × 100
   google.type.Decimal revenue = 6; // lifetime net revenue (base currency) for the drop
+  int64 units_bought = 7; // initial-stock proxy: units_sold + units_remaining
+  google.type.Decimal gross_margin = 8; // costed-subset gross margin (base ccy): Σ over the drop's costed products of (revenue − cost_price×units_sold). Meaningful only when has_cost.
+  double gross_margin_pct = 9; // gross_margin / costed_revenue × 100
+  bool has_cost = 10; // at least one product in the drop has a cost_price (else gross_margin is N/A, not 0)
+  optional int64 days_to_50pct = 11; // days from the drop's first sale to 50% sell-through; unset when the drop hasn't reached 50% yet
 }
 
 // --- Analytics: Size Run Efficiency ---
@@ -2029,7 +2037,10 @@ message SizeRunEfficiencyRow {
   string product_name = 2;
   int32 total_sizes = 3;
   int32 sold_through_sizes = 4; // Count of sizes with any sales activity (>0 units sold)
-  double efficiency_pct = 5; // (sold_through_sizes / total_sizes) * 100
+  double efficiency_pct = 5; // size-run coverage: (sold_through_sizes / total_sizes) * 100
+  int64 units_bought = 6; // Σ initial stock across sizes (current on-hand + net units sold)
+  int64 units_sold = 7; // Σ net units sold across sizes
+  double sell_through_pct = 8; // true unit sell-through: units_sold / units_bought * 100 (distinct from the size-coverage efficiency_pct)
 }
 
 // --- Analytics: Slow Movers ---


### PR DESCRIPTION
Completes the three margin/analytics-v2 backlog items that had shipped only partially. All **additive proto fields, no migration** (cost_price already exists from 0083).

- **#6 SizeRunEfficiencyRow** — true unit sell-through (`units_bought`, `units_sold`, `sell_through_pct`) next to the existing size-coverage `efficiency_pct`. The `size_analysis` CTE already computed per-size `sold`/`initial_qty`; now aggregated instead of discarded.
- **#7 CrossSellPair** — `support`/`confidence`/`lift` so the client ranks on normalized association strength instead of thresholding a raw count. Co-count is now `COUNT(DISTINCT order_id)`; lift computed in Go (unit-tested).
- **#4 SellThroughByDropRow** — `units_bought`, costed-subset `gross_margin`/`gross_margin_pct`/`has_cost`, and `days_to_50pct` (whole days from a drop's first sale to 50% sell-through, Go-computed from a per-drop daily sales timeline, unit-tested).

`#9` (order status counted once per order, not per transition) was verified **already correct** and needs no change.

Green: `go build ./...`, `go vet ./...`, `go test ./internal/...` (incl. rbac fail-closed completeness + new `associationMetrics` / `daysToSellThrough` unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)