### PR TITLE
feat: fitting link + start times, fitting callouts, tech-card media split, costing redo

### DIFF
--- a/internal/apisrv/admin/task.go
+++ b/internal/apisrv/admin/task.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const taskFKViolationMsg = "tech_card_id, product_id, archive_id, or media_id does not reference an existing record"
+const taskFKViolationMsg = "tech_card_id, product_id, archive_id, fitting_id, or media_id does not reference an existing record"
 
 // AddTask creates a new kanban task from its content + placement. created_by is
 // stamped from the caller's JWT; the card is appended to its (board,status) column.

--- a/internal/dto/fitting.go
+++ b/internal/dto/fitting.go
@@ -126,6 +126,44 @@ func ConvertPbFittingInsertToEntity(pb *pb_common.FittingInsert) (*entity.Fittin
 		})
 	}
 
+	callouts := make([]entity.FittingCallout, 0, len(pb.Callouts))
+	for _, c := range pb.Callouts {
+		if c.Number < 0 {
+			return nil, fmt.Errorf("fitting callout number must not be negative")
+		}
+		note := strings.TrimSpace(c.Note)
+		if note == "" {
+			return nil, fmt.Errorf("fitting callout note is required")
+		}
+		if len(note) > maxTaskText {
+			return nil, fmt.Errorf("fitting callout note must be at most %d characters", maxTaskText)
+		}
+		if c.MediaId < 0 {
+			return nil, fmt.Errorf("fitting callout media_id must not be negative")
+		}
+		posX, err := nullDecimalFromPb(c.PosX)
+		if err != nil {
+			return nil, fmt.Errorf("fitting callout pos_x: %w", err)
+		}
+		posY, err := nullDecimalFromPb(c.PosY)
+		if err != nil {
+			return nil, fmt.Errorf("fitting callout pos_y: %w", err)
+		}
+		if err := validateUnitInterval(posX, "fitting callout pos_x"); err != nil {
+			return nil, err
+		}
+		if err := validateUnitInterval(posY, "fitting callout pos_y"); err != nil {
+			return nil, err
+		}
+		callouts = append(callouts, entity.FittingCallout{
+			Number:  int(c.Number),
+			Note:    nullStringFromPb(note),
+			MediaId: nullInt32FromPb(c.MediaId),
+			PosX:    posX,
+			PosY:    posY,
+		})
+	}
+
 	// Normalize to a UTC calendar date so storage into the DATE column is
 	// deterministic regardless of the incoming timestamp's time-of-day.
 	// (Clients should send the fitting date at UTC midnight.)
@@ -144,6 +182,7 @@ func ConvertPbFittingInsertToEntity(pb *pb_common.FittingInsert) (*entity.Fittin
 		Sizes:       sizes,
 		MediaIds:    mediaIds,
 		Patterns:    patterns,
+		Callouts:    callouts,
 	}, nil
 }
 
@@ -183,11 +222,27 @@ func ConvertEntityFittingToPb(f *entity.Fitting) *pb_common.Fitting {
 			Sizes:       sizes,
 			MediaIds:    mediaIds,
 			Patterns:    fittingPatternsToPb(f.Patterns),
+			Callouts:    fittingCalloutsToPb(f.Callouts),
 		},
 		Media:     media,
 		CreatedAt: timestamppb.New(f.CreatedAt),
 		UpdatedAt: timestamppb.New(f.UpdatedAt),
 	}
+}
+
+// fittingCalloutsToPb emits a fitting's photo callouts for display.
+func fittingCalloutsToPb(cs []entity.FittingCallout) []*pb_common.FittingCallout {
+	out := make([]*pb_common.FittingCallout, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, &pb_common.FittingCallout{
+			Number:  int32(c.Number),
+			Note:    pbStringFromNull(c.Note),
+			MediaId: pbInt32FromNull(c.MediaId),
+			PosX:    pbDecimalFromNull(c.PosX),
+			PosY:    pbDecimalFromNull(c.PosY),
+		})
+	}
+	return out
 }
 
 // fittingPatternsToPb emits a fitting's PDF выкройка iterations for display.

--- a/internal/dto/fitting_test.go
+++ b/internal/dto/fitting_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jekabolt/grbpwr-manager/internal/entity"
 	pb_common "github.com/jekabolt/grbpwr-manager/proto/gen/common"
+	pb_decimal "google.golang.org/genproto/googleapis/type/decimal"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -115,5 +116,58 @@ func TestConvertEntityFittingToPb(t *testing.T) {
 	}
 	if len(pb.Media) != 2 || len(pb.Fitting.MediaIds) != 2 || pb.Fitting.MediaIds[1] != 12 {
 		t.Errorf("media mismatch: media=%d ids=%+v", len(pb.Media), pb.Fitting.MediaIds)
+	}
+}
+
+// TestFittingCalloutsRoundTrip covers parsing, validating and re-emitting fitting photo
+// callouts (pin + note), plus the validation rejections.
+func TestFittingCalloutsRoundTrip(t *testing.T) {
+	date := timestamppb.New(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	in := &pb_common.FittingInsert{
+		ProductId:   42,
+		FittingDate: date,
+		Callouts: []*pb_common.FittingCallout{
+			{Number: 1, Note: "shoulder too tight", MediaId: 11, PosX: &pb_decimal.Decimal{Value: "0.25"}, PosY: &pb_decimal.Decimal{Value: "0.5"}},
+			{Number: 2, Note: "hem uneven"}, // unanchored, no position
+		},
+	}
+	got, err := ConvertPbFittingInsertToEntity(in)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(got.Callouts) != 2 {
+		t.Fatalf("callouts not parsed: %+v", got.Callouts)
+	}
+	if got.Callouts[0].Number != 1 || got.Callouts[0].Note.String != "shoulder too tight" ||
+		got.Callouts[0].MediaId.Int32 != 11 || !got.Callouts[0].PosX.Valid || got.Callouts[0].PosX.Decimal.String() != "0.25" {
+		t.Errorf("callout[0] mismatch: %+v", got.Callouts[0])
+	}
+	if got.Callouts[1].MediaId.Valid || got.Callouts[1].PosX.Valid {
+		t.Errorf("callout[1] should be unanchored with no position: %+v", got.Callouts[1])
+	}
+
+	pb := ConvertEntityFittingToPb(&entity.Fitting{FittingInsert: *got})
+	if len(pb.Fitting.Callouts) != 2 || pb.Fitting.Callouts[0].Note != "shoulder too tight" ||
+		pb.Fitting.Callouts[0].MediaId != 11 || pb.Fitting.Callouts[0].PosX == nil || pb.Fitting.Callouts[0].PosX.Value != "0.25" ||
+		pb.Fitting.Callouts[0].PosY == nil || pb.Fitting.Callouts[0].PosY.Value != "0.5" {
+		t.Errorf("anchored callout round-trip mismatch: %+v", pb.Fitting.Callouts)
+	}
+	// the unanchored callout emits with no media/position.
+	if pb.Fitting.Callouts[1].Note != "hem uneven" || pb.Fitting.Callouts[1].MediaId != 0 ||
+		pb.Fitting.Callouts[1].PosX != nil || pb.Fitting.Callouts[1].PosY != nil {
+		t.Errorf("unanchored callout round-trip mismatch: %+v", pb.Fitting.Callouts[1])
+	}
+
+	bad := map[string]*pb_common.FittingInsert{
+		"note required":   {ProductId: 1, FittingDate: date, Callouts: []*pb_common.FittingCallout{{Number: 1, Note: "  "}}},
+		"note too long":   {ProductId: 1, FittingDate: date, Callouts: []*pb_common.FittingCallout{{Number: 1, Note: string(make([]byte, maxTaskText+1))}}},
+		"negative number": {ProductId: 1, FittingDate: date, Callouts: []*pb_common.FittingCallout{{Number: -1, Note: "x"}}},
+		"negative media":  {ProductId: 1, FittingDate: date, Callouts: []*pb_common.FittingCallout{{Note: "x", MediaId: -1}}},
+		"pos_x over 1":    {ProductId: 1, FittingDate: date, Callouts: []*pb_common.FittingCallout{{Note: "x", PosX: &pb_decimal.Decimal{Value: "1.5"}}}},
+	}
+	for name, bi := range bad {
+		if _, err := ConvertPbFittingInsertToEntity(bi); err == nil {
+			t.Errorf("case %q: expected error, got nil", name)
+		}
 	}
 }

--- a/internal/dto/task.go
+++ b/internal/dto/task.go
@@ -109,7 +109,7 @@ func ConvertPbTaskInsertToEntity(pb *pb_common.TaskInsert) (*entity.TaskInsert, 
 	if len(pb.Assignee) > maxVarchar255 {
 		return nil, fmt.Errorf("task assignee must be at most %d characters", maxVarchar255)
 	}
-	if pb.TechCardId < 0 || pb.ProductId < 0 || pb.ArchiveId < 0 {
+	if pb.TechCardId < 0 || pb.ProductId < 0 || pb.ArchiveId < 0 || pb.FittingId < 0 {
 		return nil, fmt.Errorf("task deep-link ids must not be negative")
 	}
 	orderUUID := strings.TrimSpace(pb.OrderUuid)
@@ -130,6 +130,10 @@ func ConvertPbTaskInsertToEntity(pb *pb_common.TaskInsert) (*entity.TaskInsert, 
 	var dueDate sql.NullTime
 	if pb.DueDate != nil {
 		dueDate = sql.NullTime{Time: pb.DueDate.AsTime().UTC(), Valid: true}
+	}
+	var startDate sql.NullTime
+	if pb.StartDate != nil {
+		startDate = sql.NullTime{Time: pb.StartDate.AsTime().UTC(), Valid: true}
 	}
 
 	labels := make([]string, 0, len(pb.Labels))
@@ -168,10 +172,12 @@ func ConvertPbTaskInsertToEntity(pb *pb_common.TaskInsert) (*entity.TaskInsert, 
 		Assignee:    strings.TrimSpace(pb.Assignee),
 		Priority:    priority,
 		DueDate:     dueDate,
+		StartDate:   startDate,
 		TechCardId:  nullInt32FromPb(pb.TechCardId),
 		ProductId:   nullInt32FromPb(pb.ProductId),
 		OrderUuid:   nullStringFromPb(orderUUID),
 		ArchiveId:   nullInt32FromPb(pb.ArchiveId),
+		FittingId:   nullInt32FromPb(pb.FittingId),
 		Labels:      labels,
 		MediaIds:    mediaIds,
 	}, nil
@@ -199,12 +205,14 @@ func ConvertEntityTaskToPb(t *entity.Task) *pb_common.Task {
 			Assignee:    t.Assignee,
 			Priority:    taskPriorityEntityToPb[t.Priority],
 			DueDate:     pbTimestampFromNullTime(t.DueDate),
+			StartDate:   pbTimestampFromNullTime(t.StartDate),
 			Labels:      t.Labels,
 			MediaIds:    mediaIds,
 			TechCardId:  pbInt32FromNull(t.TechCardId),
 			ProductId:   pbInt32FromNull(t.ProductId),
 			OrderUuid:   pbStringFromNull(t.OrderUuid),
 			ArchiveId:   pbInt32FromNull(t.ArchiveId),
+			FittingId:   pbInt32FromNull(t.FittingId),
 		},
 		Board:      taskBoardEntityToPb[t.Board],
 		Status:     taskStatusEntityToPb[t.Status],
@@ -214,6 +222,7 @@ func ConvertEntityTaskToPb(t *entity.Task) *pb_common.Task {
 		CreatedAt:  timestamppb.New(t.CreatedAt),
 		UpdatedAt:  timestamppb.New(t.UpdatedAt),
 		ArchivedAt: pbTimestampFromNullTime(t.ArchivedAt),
+		StartedAt:  pbTimestampFromNullTime(t.StartedAt),
 		Checklist:  ConvertEntityTaskChecklistToPb(t.Checklist),
 	}
 }

--- a/internal/dto/task_test.go
+++ b/internal/dto/task_test.go
@@ -12,18 +12,21 @@ import (
 
 func TestConvertPbTaskInsertToEntity(t *testing.T) {
 	due := timestamppb.New(time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC))
+	start := timestamppb.New(time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC))
 	valid := &pb_common.TaskInsert{
 		Title:       "  Sew the sample  ",
 		Description: "cut + assemble",
 		Assignee:    "olya",
 		Priority:    pb_common.TaskPriority_TASK_PRIORITY_HIGH,
 		DueDate:     due,
+		StartDate:   start,
 		Labels:      []string{"urgent", "urgent", " sample ", ""},
 		MediaIds:    []int32{11, 12, 11},
 		TechCardId:  8,
 		ProductId:   0,
 		OrderUuid:   "  ",
 		ArchiveId:   3,
+		FittingId:   5,
 	}
 
 	got, err := ConvertPbTaskInsertToEntity(valid)
@@ -39,8 +42,12 @@ func TestConvertPbTaskInsertToEntity(t *testing.T) {
 	if !got.DueDate.Valid || !got.DueDate.Time.Equal(time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)) {
 		t.Errorf("due date mismatch: %+v", got.DueDate)
 	}
-	if !got.TechCardId.Valid || got.TechCardId.Int32 != 8 || got.ProductId.Valid || !got.ArchiveId.Valid {
+	if !got.TechCardId.Valid || got.TechCardId.Int32 != 8 || got.ProductId.Valid || !got.ArchiveId.Valid ||
+		!got.FittingId.Valid || got.FittingId.Int32 != 5 {
 		t.Errorf("deep-link ids mismatch: %+v", got)
+	}
+	if !got.StartDate.Valid || !got.StartDate.Time.Equal(time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC)) {
+		t.Errorf("start date mismatch: %+v", got.StartDate)
 	}
 	if got.OrderUuid.Valid {
 		t.Errorf("blank order_uuid should be NULL, got %+v", got.OrderUuid)
@@ -75,6 +82,7 @@ func TestConvertPbTaskInsertToEntity(t *testing.T) {
 		{"long title", &pb_common.TaskInsert{Title: string(make([]byte, 256))}},
 		{"negative tech_card", &pb_common.TaskInsert{Title: "x", TechCardId: -1}},
 		{"negative product", &pb_common.TaskInsert{Title: "x", ProductId: -2}},
+		{"negative fitting", &pb_common.TaskInsert{Title: "x", FittingId: -1}},
 		{"zero media id", &pb_common.TaskInsert{Title: "x", MediaIds: []int32{0}}},
 		{"long label", &pb_common.TaskInsert{Title: "x", Labels: []string{string(make([]byte, 65))}}},
 		{"long order_uuid", &pb_common.TaskInsert{Title: "x", OrderUuid: string(make([]byte, 37))}},
@@ -95,6 +103,8 @@ func TestConvertEntityTaskToPb(t *testing.T) {
 			Priority:   entity.TaskPriorityMedium,
 			Labels:     []string{"content"},
 			TechCardId: nullInt32FromPb(2),
+			FittingId:  nullInt32FromPb(7),
+			StartDate:  sql.NullTime{Time: now, Valid: true},
 		},
 		Board:     entity.TaskBoardContent,
 		Status:    entity.TaskStatusInProgress,
@@ -102,6 +112,7 @@ func TestConvertEntityTaskToPb(t *testing.T) {
 		CreatedBy: "max",
 		CreatedAt: now,
 		UpdatedAt: now,
+		StartedAt: sql.NullTime{Time: now, Valid: true},
 		Media: []entity.MediaFull{
 			{Id: 9, MediaItem: entity.MediaItem{FullSizeMediaURL: "https://x/9.jpg"}},
 		},
@@ -113,6 +124,9 @@ func TestConvertEntityTaskToPb(t *testing.T) {
 	}
 	if pb.Task.Title != "Shoot the drop" || pb.Task.Priority != pb_common.TaskPriority_TASK_PRIORITY_MEDIUM {
 		t.Errorf("content mismatch: %+v", pb.Task)
+	}
+	if pb.Task.FittingId != 7 || pb.Task.StartDate == nil || pb.StartedAt == nil {
+		t.Errorf("fitting/start fields mismatch: fitting=%d start_date=%v started_at=%v", pb.Task.FittingId, pb.Task.StartDate, pb.StartedAt)
 	}
 	if len(pb.Media) != 1 || pb.Media[0].Id != 9 || len(pb.Task.MediaIds) != 1 || pb.Task.MediaIds[0] != 9 {
 		t.Errorf("media mismatch: media=%+v ids=%+v", pb.Media, pb.Task.MediaIds)

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -108,6 +108,45 @@ var techCardMediaKindEntityToPb = func() map[entity.TechCardMediaKind]pb_common.
 	return m
 }()
 
+// defaultTechCardMediaKind is the fallback kind for an item whose kind is unset, chosen
+// per list so a moodboard item doesn't default to a technical "preview".
+func defaultTechCardMediaKind(cat entity.TechCardMediaCategory) entity.TechCardMediaKind {
+	if cat == entity.TechCardMediaCategoryMoodboard {
+		return entity.TechCardMediaMoodboard
+	}
+	return entity.TechCardMediaPreview
+}
+
+// parseTechCardMediaItems validates one sketch-media list (moodboard or technical) and
+// tags each item with its category. Media in the two lists share the same shape; the
+// category is implied by which list the item arrived in.
+func parseTechCardMediaItems(items []*pb_common.TechCardMediaItem, cat entity.TechCardMediaCategory) ([]entity.TechCardMediaItem, error) {
+	out := make([]entity.TechCardMediaItem, 0, len(items))
+	for _, m := range items {
+		if m.MediaId <= 0 {
+			return nil, fmt.Errorf("tech card media media_id must be positive")
+		}
+		kind := defaultTechCardMediaKind(cat)
+		if m.Kind != pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_UNKNOWN {
+			k, ok := techCardMediaKindPbToEntity[m.Kind]
+			if !ok {
+				return nil, fmt.Errorf("unknown tech card media kind: %v", m.Kind)
+			}
+			kind = k
+		}
+		if len(m.Caption) > maxVarchar255 {
+			return nil, fmt.Errorf("media caption must be at most %d characters", maxVarchar255)
+		}
+		out = append(out, entity.TechCardMediaItem{
+			MediaId:  int(m.MediaId),
+			Category: cat,
+			Kind:     kind,
+			Caption:  nullStringFromPb(m.Caption),
+		})
+	}
+	return out, nil
+}
+
 var techCardBomSectionPbToEntity = map[pb_common.TechCardBomSection]entity.TechCardBomSection{
 	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_FABRIC:      entity.BomSectionFabric,
 	pb_common.TechCardBomSection_TECH_CARD_BOM_SECTION_LINING:      entity.BomSectionLining,
@@ -233,24 +272,19 @@ func ConvertPbTechCardInsertToEntity(pb *pb_common.TechCardInsert) (*entity.Tech
 		return nil, fmt.Errorf("base_sample_size_id %d must be one of size_ids", pb.BaseSampleSizeId)
 	}
 
-	media := make([]entity.TechCardMediaItem, 0, len(pb.Media))
-	for _, m := range pb.Media {
-		if m.MediaId <= 0 {
-			return nil, fmt.Errorf("tech card media media_id must be positive")
-		}
-		kind := entity.TechCardMediaPreview
-		if m.Kind != pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_UNKNOWN {
-			k, ok := techCardMediaKindPbToEntity[m.Kind]
-			if !ok {
-				return nil, fmt.Errorf("unknown tech card media kind: %v", m.Kind)
-			}
-			kind = k
-		}
-		if len(m.Caption) > maxVarchar255 {
-			return nil, fmt.Errorf("media caption must be at most %d characters", maxVarchar255)
-		}
-		media = append(media, entity.TechCardMediaItem{MediaId: int(m.MediaId), Kind: kind, Caption: nullStringFromPb(m.Caption)})
+	// Sketch media arrives as two independent lists; concat into one internal slice,
+	// each item tagged by its category (moodboard vs technical).
+	moodboardMedia, err := parseTechCardMediaItems(pb.MoodboardMedia, entity.TechCardMediaCategoryMoodboard)
+	if err != nil {
+		return nil, err
 	}
+	technicalMedia, err := parseTechCardMediaItems(pb.TechnicalMedia, entity.TechCardMediaCategoryTechnical)
+	if err != nil {
+		return nil, err
+	}
+	media := make([]entity.TechCardMediaItem, 0, len(moodboardMedia)+len(technicalMedia))
+	media = append(media, moodboardMedia...)
+	media = append(media, technicalMedia...)
 
 	callouts := make([]entity.TechCardCallout, 0, len(pb.Callouts))
 	for _, c := range pb.Callouts {
@@ -494,21 +528,33 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 		return nil
 	}
 
-	media := make([]*pb_common.TechCardMediaItem, 0, len(tc.Media))
+	// Split the single internal media slice back into the two contract lists by category.
+	var moodboardMedia, technicalMedia []*pb_common.TechCardMediaItem
 	for _, m := range tc.Media {
-		media = append(media, &pb_common.TechCardMediaItem{
+		item := &pb_common.TechCardMediaItem{
 			MediaId: int32(m.MediaId),
 			Kind:    pbTechCardMediaKind(m.Kind),
 			Caption: pbStringFromNull(m.Caption),
-		})
+		}
+		if m.Category == entity.TechCardMediaCategoryMoodboard {
+			moodboardMedia = append(moodboardMedia, item)
+		} else {
+			technicalMedia = append(technicalMedia, item)
+		}
 	}
 
-	resolved := make([]*pb_common.TechCardMediaFull, 0, len(tc.ResolvedMedia))
+	var resolvedMoodboard, resolvedTechnical []*pb_common.TechCardMediaFull
 	for i := range tc.ResolvedMedia {
-		resolved = append(resolved, &pb_common.TechCardMediaFull{
-			Media: ConvertEntityToCommonMedia(&tc.ResolvedMedia[i].Media),
-			Kind:  pbTechCardMediaKind(tc.ResolvedMedia[i].Kind),
-		})
+		item := &pb_common.TechCardMediaFull{
+			Media:   ConvertEntityToCommonMedia(&tc.ResolvedMedia[i].Media),
+			Kind:    pbTechCardMediaKind(tc.ResolvedMedia[i].Kind),
+			Caption: pbStringFromNull(tc.ResolvedMedia[i].Caption),
+		}
+		if tc.ResolvedMedia[i].Category == entity.TechCardMediaCategoryMoodboard {
+			resolvedMoodboard = append(resolvedMoodboard, item)
+		} else {
+			resolvedTechnical = append(resolvedTechnical, item)
+		}
 	}
 
 	callouts := make([]*pb_common.TechCardCallout, 0, len(tc.Callouts))
@@ -575,7 +621,8 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Notes:            pbStringFromNull(tc.Notes),
 			SizeIds:          sizeIds,
 			ProductIds:       productIds,
-			Media:            media,
+			MoodboardMedia:   moodboardMedia,
+			TechnicalMedia:   technicalMedia,
 			Callouts:         callouts,
 			Revisions:        revisions,
 			Details:          techCardDetailsToPb(tc.Details),
@@ -591,7 +638,8 @@ func ConvertEntityTechCardToPb(tc *entity.TechCard) *pb_common.TechCard {
 			Signoffs:         techCardSignoffsToPb(tc.Signoffs),
 			Patterns:         techCardPatternsToPb(tc.Patterns),
 		},
-		ResolvedMedia: resolved,
+		ResolvedMoodboardMedia: resolvedMoodboard,
+		ResolvedTechnicalMedia: resolvedTechnical,
 	}
 }
 

--- a/internal/dto/techcard_patterns_test.go
+++ b/internal/dto/techcard_patterns_test.go
@@ -88,10 +88,11 @@ func TestColorwayCostRollup(t *testing.T) {
 		{BomItemIndex: idx(1), Quantity: ndFrom("1")}, // 3 USD
 		{BomItemIndex: idx(2), Quantity: ndFrom("4")}, // 20 currency-less
 	}}
-	res := colorwayCost(&cw, bomItems, "EUR", map[int]int{})
-	// materials_cost = EUR(20) + currency-less(20) = 40; USD excluded.
-	if !res.materialsCost.Equal(decimal.RequireFromString("40")) {
-		t.Fatalf("materials_cost = %v, want 40", res.materialsCost)
+	res := colorwayCost(&cw, bomItems, "EUR", map[int]int{}, 0)
+	// materials_per_unit = EUR(20) + currency-less(20) = 40; USD excluded. All usages are
+	// per-garment (countable Quantity), so totalOrderQty is irrelevant here.
+	if !res.materialsPerUnit.Equal(decimal.RequireFromString("40")) {
+		t.Fatalf("materials_per_unit = %v, want 40", res.materialsPerUnit)
 	}
 	if !res.hasUnconverted {
 		t.Fatalf("expected has_unconverted_currencies (USD usage vs EUR costing)")

--- a/internal/dto/techcard_production.go
+++ b/internal/dto/techcard_production.go
@@ -16,8 +16,6 @@ const (
 
 	costMaxFrac = 2 // cost articles DECIMAL(12,2)
 	costLimit   = 10_000_000_000
-	markupFrac  = 3 // markup_multiplier DECIMAL(6,3)
-	markupLimit = 1_000
 	weightFrac  = 3 // weight DECIMAL(8,3)
 	weightLimit = 100_000
 	stitchFrac  = 2 // stitches_per_cm DECIMAL(5,2)
@@ -316,14 +314,6 @@ func parseTechCardCosting(pb *pb_common.TechCardCosting) (*entity.TechCardCostin
 	if err != nil {
 		return nil, err
 	}
-	wholesale, err := cost(pb.WholesalePrice, "wholesale_price")
-	if err != nil {
-		return nil, err
-	}
-	retail, err := cost(pb.RetailPrice, "retail_price")
-	if err != nil {
-		return nil, err
-	}
 	defect, err := nullDecimalFromPb(pb.DefectPercent)
 	if err != nil {
 		return nil, fmt.Errorf("costing defect_percent: %w", err)
@@ -334,25 +324,15 @@ func parseTechCardCosting(pb *pb_common.TechCardCosting) (*entity.TechCardCostin
 	if defect.Valid && defect.Decimal.GreaterThan(decimal.NewFromInt(100)) {
 		return nil, fmt.Errorf("costing defect_percent must be between 0 and 100")
 	}
-	markup, err := nullDecimalFromPb(pb.MarkupMultiplier)
-	if err != nil {
-		return nil, fmt.Errorf("costing markup_multiplier: %w", err)
-	}
-	if err := validateDecimalScale(markup, "costing markup_multiplier", markupFrac, markupLimit); err != nil {
-		return nil, err
-	}
 	return &entity.TechCardCosting{
-		CmtCost:          cmt,
-		HardwareCost:     hardware,
-		PackagingCost:    packaging,
-		LogisticsCost:    logistics,
-		OverheadCost:     overhead,
-		DefectPercent:    defect,
-		MarkupMultiplier: markup,
-		WholesalePrice:   wholesale,
-		RetailPrice:      retail,
-		Currency:         nullStringFromPb(pb.Currency),
-		Notes:            nullStringFromPb(pb.Notes),
+		CmtCost:       cmt,
+		HardwareCost:  hardware,
+		PackagingCost: packaging,
+		LogisticsCost: logistics,
+		OverheadCost:  overhead,
+		DefectPercent: defect,
+		Currency:      nullStringFromPb(pb.Currency),
+		Notes:         nullStringFromPb(pb.Notes),
 	}, nil
 }
 
@@ -605,45 +585,72 @@ func techCardPackagingToPb(p *entity.TechCardPackaging) *pb_common.TechCardPacka
 	}
 }
 
-// techCardCostingToPb emits the stored costing articles plus the computed per-colourway
-// material costs and the root rollup. The root (materials_total/materials_cost/total_cost)
-// is the PRIMARY colourway = index 0 (plan Q3). Returns nil when no costing row exists.
+// techCardCostingToPb emits the stored per-unit cost articles plus the computed per-colourway
+// costs and the root rollup. Root figures are the PRIMARY colourway = index 0. Cost is built
+// per GARMENT (unit_cost = materials_per_unit + shared manual articles, × (1 + defect%)), then
+// scaled to the whole run (order_cost = unit_cost × order_qty, order_qty = Σ size_quantities).
+// Returns nil when no costing row exists.
 func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 	if tc.Costing == nil {
 		return nil
 	}
 	c := tc.Costing
 	orderQtyBySize := make(map[int]int, len(tc.SizeQuantities))
+	totalOrderQty := 0
 	for _, q := range tc.SizeQuantities {
 		orderQtyBySize[q.SizeId] = q.OrderQty
+		if q.OrderQty > 0 {
+			totalOrderQty += q.OrderQty
+		}
 	}
 	costingCcy := ""
 	if c.Currency.Valid {
 		costingCcy = c.Currency.String
 	}
 
-	// Per-colourway material cost (OUTPUT-ONLY), resolving each usage against its BOM
-	// article. The root rollup is the primary colourway (index 0).
+	// Manual per-unit articles are shared across colourways; each colourway's unit cost is
+	// its own materials plus these, grossed up by defect%.
+	manualPerUnit := decimal.Zero
+	for _, d := range []decimal.NullDecimal{c.CmtCost, c.HardwareCost, c.PackagingCost, c.LogisticsCost, c.OverheadCost} {
+		if d.Valid {
+			manualPerUnit = manualPerUnit.Add(d.Decimal)
+		}
+	}
+	defectMul := decimal.NewFromInt(1)
+	if c.DefectPercent.Valid {
+		defectMul = decimal.NewFromInt(1).Add(c.DefectPercent.Decimal.Div(decimal.NewFromInt(100)))
+	}
+	qtyDec := decimal.NewFromInt(int64(totalOrderQty))
+	unitAndOrder := func(materialsPerUnit decimal.Decimal) (unit, order decimal.Decimal) {
+		unit = materialsPerUnit.Add(manualPerUnit).Mul(defectMul)
+		return unit, unit.Mul(qtyDec)
+	}
+
+	// Per-colourway cost (OUTPUT-ONLY). The root rollup is the primary colourway (index 0).
 	colorwayCosts := make([]*pb_common.TechCardColorwayCost, 0, len(tc.Colorways))
 	var rootMaterialsTotal []*pb_common.TechCardCostLine
-	rootMaterialsCost := decimal.Zero
+	rootMaterialsPerUnit := decimal.Zero
 	rootHasUnconverted := false
 	for ci := range tc.Colorways {
-		cc := colorwayCost(&tc.Colorways[ci], tc.BomItems, costingCcy, orderQtyBySize)
+		cc := colorwayCost(&tc.Colorways[ci], tc.BomItems, costingCcy, orderQtyBySize, totalOrderQty)
+		unit, order := unitAndOrder(cc.materialsPerUnit)
 		colorwayCosts = append(colorwayCosts, &pb_common.TechCardColorwayCost{
 			ColorwayIndex:            int32(ci),
 			MaterialsTotal:           cc.materialsTotal,
-			MaterialsCost:            pbDecimalFromDecimal(roundMoney(cc.materialsCost)),
-			SizeRunTotal:             pbDecimalFromDecimal(roundMoney(cc.sizeRunTotal)),
+			MaterialsPerUnit:         pbDecimalFromDecimal(roundMoney(cc.materialsPerUnit)),
+			UnitCost:                 pbDecimalFromDecimal(roundMoney(unit)),
+			OrderQty:                 int32(totalOrderQty),
+			OrderCost:                pbDecimalFromDecimal(roundMoney(order)),
 			HasUnconvertedCurrencies: cc.hasUnconverted,
 		})
 		if ci == 0 {
 			rootMaterialsTotal = cc.materialsTotal
-			rootMaterialsCost = cc.materialsCost
+			rootMaterialsPerUnit = cc.materialsPerUnit
 			rootHasUnconverted = cc.hasUnconverted
 		}
 	}
 
+	rootUnit, rootOrder := unitAndOrder(rootMaterialsPerUnit)
 	out := &pb_common.TechCardCosting{
 		CmtCost:                  pbDecimalFromNull(c.CmtCost),
 		HardwareCost:             pbDecimalFromNull(c.HardwareCost),
@@ -651,31 +658,18 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 		LogisticsCost:            pbDecimalFromNull(c.LogisticsCost),
 		OverheadCost:             pbDecimalFromNull(c.OverheadCost),
 		DefectPercent:            pbDecimalFromNull(c.DefectPercent),
-		MarkupMultiplier:         pbDecimalFromNull(c.MarkupMultiplier),
-		WholesalePrice:           pbDecimalFromNull(c.WholesalePrice),
-		RetailPrice:              pbDecimalFromNull(c.RetailPrice),
 		Currency:                 pbStringFromNull(c.Currency),
 		Notes:                    pbStringFromNull(c.Notes),
 		MaterialsTotal:           rootMaterialsTotal,
-		MaterialsCost:            pbDecimalFromDecimal(roundMoney(rootMaterialsCost)),
-		ColorwayCosts:            colorwayCosts,
+		MaterialsPerUnit:         pbDecimalFromDecimal(roundMoney(rootMaterialsPerUnit)),
+		UnitCost:                 pbDecimalFromDecimal(roundMoney(rootUnit)),
+		OrderQty:                 int32(totalOrderQty),
+		OrderCost:                pbDecimalFromDecimal(roundMoney(rootOrder)),
 		HasUnconvertedCurrencies: rootHasUnconverted,
+		ColorwayCosts:            colorwayCosts,
 	}
 
-	// total_cost = (materials_cost[colourway 0] + cmt + hardware + packaging + logistics
-	// + overhead) × (1 + defect/100). No labour fallback (labour pricing removed).
-	total := rootMaterialsCost
-	for _, d := range []decimal.NullDecimal{c.CmtCost, c.HardwareCost, c.PackagingCost, c.LogisticsCost, c.OverheadCost} {
-		if d.Valid {
-			total = total.Add(d.Decimal)
-		}
-	}
-	if c.DefectPercent.Valid {
-		total = total.Mul(decimal.NewFromInt(1).Add(c.DefectPercent.Decimal.Div(decimal.NewFromInt(100))))
-	}
-	out.TotalCost = pbDecimalFromDecimal(roundMoney(total))
-
-	// total_sam = Σ(operation time_norm); informative, pricing-independent (plan Q4).
+	// total_sam = Σ(operation time_norm); informative, pricing-independent.
 	totalSam := decimal.Zero
 	for i := range tc.Operations {
 		if tc.Operations[i].TimeNorm.Valid {
@@ -688,50 +682,46 @@ func techCardCostingToPb(tc *entity.TechCard) *pb_common.TechCardCosting {
 	return out
 }
 
-// ComputeTechCardUnitCost returns a tech card's per-garment total cost and its currency,
-// computed exactly as the read path renders total_cost — it reuses techCardCostingToPb so
+// ComputeTechCardUnitCost returns a tech card's per-garment unit cost and its currency,
+// computed exactly as the read path renders unit_cost — it reuses techCardCostingToPb so
 // there is a single source of truth for the math. Returns an invalid NullDecimal when there
-// is no costing row or the computed total is not positive.
+// is no costing row or the computed unit cost is not positive.
 func ComputeTechCardUnitCost(tc *entity.TechCard) (decimal.NullDecimal, string) {
 	if tc == nil {
 		return decimal.NullDecimal{}, ""
 	}
 	pb := techCardCostingToPb(tc)
-	if pb == nil || pb.TotalCost == nil {
+	if pb == nil || pb.UnitCost == nil {
 		return decimal.NullDecimal{}, ""
 	}
-	v, err := decimal.NewFromString(pb.TotalCost.Value)
+	v, err := decimal.NewFromString(pb.UnitCost.Value)
 	if err != nil || !v.IsPositive() {
 		return decimal.NullDecimal{}, ""
 	}
 	return decimal.NullDecimal{Decimal: v, Valid: true}, pb.Currency
 }
 
-// colorwayCostResult holds one colourway's computed material cost.
+// colorwayCostResult holds one colourway's computed PER-GARMENT material cost.
 type colorwayCostResult struct {
-	materialsTotal []*pb_common.TechCardCostLine // Σ usage cost grouped by article currency
-	materialsCost  decimal.Decimal               // Σ in costingCcy (and currency-less)
-	sizeRunTotal   decimal.Decimal               // Σ usage size_run_total (whole-run spend)
-	hasUnconverted bool                          // a usage currency ≠ costingCcy (excluded from materialsCost)
+	materialsTotal   []*pb_common.TechCardCostLine // per-unit material cost grouped by article currency
+	materialsPerUnit decimal.Decimal               // Σ per-garment usage cost in costingCcy (and currency-less)
+	hasUnconverted   bool                          // a usage currency ≠ costingCcy (excluded from materialsPerUnit)
 }
 
-// colorwayCost computes one colourway's material cost from its usages. Each usage
-// contributes its whole-run size_run_total (when it has per-size consumption) else its
-// per-garment line_total, resolved against the BOM article it points at. Buckets are
-// per-currency (no FX conversion); currency-less lines fold into the costing currency.
-func colorwayCost(cw *entity.TechCardColorway, bomItems []entity.TechCardBomItem, costingCcy string, orderQtyBySize map[int]int) colorwayCostResult {
+// colorwayCost computes one colourway's PER-GARMENT material cost from its usages. Each usage
+// contributes its per-garment UnitTotal (a per-size-only usage is normalised to per-garment by
+// dividing its whole-run cost by totalOrderQty), resolved against the BOM article it points at.
+// Buckets are per-currency (no FX conversion); currency-less lines fold into the costing
+// currency, and a line in another currency is flagged (and left out of materialsPerUnit).
+func colorwayCost(cw *entity.TechCardColorway, bomItems []entity.TechCardBomItem, costingCcy string, orderQtyBySize map[int]int, totalOrderQty int) colorwayCostResult {
 	byCcy := map[string]decimal.Decimal{}
 	order := make([]string, 0)
-	sizeRunTotal := decimal.Zero
 	hasUnconverted := false
 	for i := range cw.Usages {
 		u := &cw.Usages[i]
 		bom := bomItemAtIndex(bomItems, u.BomItemIndex)
-		if rt := u.SizeRunTotal(bom, orderQtyBySize); rt.Valid {
-			sizeRunTotal = sizeRunTotal.Add(rt.Decimal)
-		}
-		eff := u.EffectiveTotal(bom, orderQtyBySize)
-		if !eff.Valid {
+		ut := u.UnitTotal(bom, orderQtyBySize, totalOrderQty)
+		if !ut.Valid {
 			continue
 		}
 		ccy := ""
@@ -741,7 +731,7 @@ func colorwayCost(cw *entity.TechCardColorway, bomItems []entity.TechCardBomItem
 		if _, ok := byCcy[ccy]; !ok {
 			order = append(order, ccy)
 		}
-		byCcy[ccy] = byCcy[ccy].Add(eff.Decimal)
+		byCcy[ccy] = byCcy[ccy].Add(ut.Decimal)
 		if ccy != "" && ccy != costingCcy {
 			hasUnconverted = true
 		}
@@ -755,14 +745,14 @@ func colorwayCost(cw *entity.TechCardColorway, bomItems []entity.TechCardBomItem
 		})
 	}
 
-	materialsCost := decimal.Zero
+	materialsPerUnit := decimal.Zero
 	if v, ok := byCcy[costingCcy]; ok {
-		materialsCost = materialsCost.Add(v)
+		materialsPerUnit = materialsPerUnit.Add(v)
 	}
 	if costingCcy != "" {
 		if v, ok := byCcy[""]; ok { // currency-less lines fold into the costing currency
-			materialsCost = materialsCost.Add(v)
+			materialsPerUnit = materialsPerUnit.Add(v)
 		}
 	}
-	return colorwayCostResult{materialsTotal: lines, materialsCost: materialsCost, sizeRunTotal: sizeRunTotal, hasUnconverted: hasUnconverted}
+	return colorwayCostResult{materialsTotal: lines, materialsPerUnit: materialsPerUnit, hasUnconverted: hasUnconverted}
 }

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -33,9 +33,13 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 		RevisionDate:     revDate,
 		SizeIds:          []int32{4, 5, 6},
 		ProductIds:       []int32{100, 101},
-		Media: []*pb_common.TechCardMediaItem{
+		MoodboardMedia: []*pb_common.TechCardMediaItem{
+			{MediaId: 20, Kind: pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_REFERENCE},
+			{MediaId: 21}, // unset kind in moodboard list -> defaults to moodboard
+		},
+		TechnicalMedia: []*pb_common.TechCardMediaItem{
 			{MediaId: 11, Kind: pb_common.TechCardMediaKind_TECH_CARD_MEDIA_KIND_FRONT},
-			{MediaId: 12}, // unset kind -> defaults to preview
+			{MediaId: 12}, // unset kind in technical list -> defaults to preview
 		},
 		Callouts: []*pb_common.TechCardCallout{
 			{Number: 1, Part: "collar", Description: "two-piece", Dimensions: "h=4cm", MediaId: 11},
@@ -73,8 +77,14 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 	if len(got.SizeIds) != 3 || got.SizeIds[2] != 6 || len(got.ProductIds) != 2 {
 		t.Errorf("size/product ids mismatch: %+v %+v", got.SizeIds, got.ProductIds)
 	}
-	if len(got.Media) != 2 || got.Media[0].Kind != entity.TechCardMediaFront || got.Media[1].Kind != entity.TechCardMediaPreview {
-		t.Errorf("media mismatch: %+v", got.Media)
+	// media is concatenated moodboard-first, each tagged by category; unset kind defaults
+	// per list (moodboard list → moodboard, technical list → preview).
+	if len(got.Media) != 4 ||
+		got.Media[0].Category != entity.TechCardMediaCategoryMoodboard || got.Media[0].Kind != entity.TechCardMediaReference ||
+		got.Media[1].Category != entity.TechCardMediaCategoryMoodboard || got.Media[1].Kind != entity.TechCardMediaMoodboard ||
+		got.Media[2].Category != entity.TechCardMediaCategoryTechnical || got.Media[2].Kind != entity.TechCardMediaFront ||
+		got.Media[3].Category != entity.TechCardMediaCategoryTechnical || got.Media[3].Kind != entity.TechCardMediaPreview {
+		t.Errorf("media split mismatch: %+v", got.Media)
 	}
 	if len(got.Callouts) != 1 || got.Callouts[0].Number != 1 || got.Callouts[0].MediaId.Int32 != 11 {
 		t.Errorf("callouts mismatch: %+v", got.Callouts)
@@ -118,7 +128,8 @@ func TestConvertPbTechCardInsertToEntity(t *testing.T) {
 		"dup product":       {StyleNumber: "x", Name: "y", ProductIds: []int32{1, 1}},
 		"size id zero":      {StyleNumber: "x", Name: "y", SizeIds: []int32{0}},
 		"base not in range": {StyleNumber: "x", Name: "y", BaseSampleSizeId: 9, SizeIds: []int32{4, 5}},
-		"media id zero":     {StyleNumber: "x", Name: "y", Media: []*pb_common.TechCardMediaItem{{MediaId: 0}}},
+		"moodboard media id zero": {StyleNumber: "x", Name: "y", MoodboardMedia: []*pb_common.TechCardMediaItem{{MediaId: 0}}},
+		"technical media id zero":  {StyleNumber: "x", Name: "y", TechnicalMedia: []*pb_common.TechCardMediaItem{{MediaId: 0}}},
 		"version too long":  {StyleNumber: "x", Name: "y", Version: string(make([]byte, 65))},
 		"detail media zero": {StyleNumber: "x", Name: "y", Details: []*pb_common.TechCardDetail{{Key: "k", MediaIds: []int32{0}}}},
 		"detail media dup":  {StyleNumber: "x", Name: "y", Details: []*pb_common.TechCardDetail{{Key: "k", MediaIds: []int32{5, 5}}}},
@@ -149,14 +160,20 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 			Concept:         nullStringFromPb("intent"),
 			SizeIds:         []int{4, 5},
 			ProductIds:      []int{100},
-			Media:           []entity.TechCardMediaItem{{MediaId: 11, Kind: entity.TechCardMediaFront}},
-			Callouts:        []entity.TechCardCallout{{Number: 1, MediaId: nullInt32FromPb(11)}},
-			Revisions:       []entity.TechCardRevision{{Version: nullStringFromPb("v1")}},
-			Details:         []entity.TechCardDetail{{Key: nullStringFromPb("collar"), Text: nullStringFromPb("two-piece"), MediaIds: []int{11}}},
+			Media: []entity.TechCardMediaItem{
+				{MediaId: 11, Category: entity.TechCardMediaCategoryTechnical, Kind: entity.TechCardMediaFront},
+				{MediaId: 20, Category: entity.TechCardMediaCategoryMoodboard, Kind: entity.TechCardMediaReference},
+			},
+			Callouts:  []entity.TechCardCallout{{Number: 1, MediaId: nullInt32FromPb(11)}},
+			Revisions: []entity.TechCardRevision{{Version: nullStringFromPb("v1")}},
+			Details:   []entity.TechCardDetail{{Key: nullStringFromPb("collar"), Text: nullStringFromPb("two-piece"), MediaIds: []int{11}}},
 		},
-		CreatedAt:     time.Now(),
-		UpdatedAt:     time.Now(),
-		ResolvedMedia: []entity.TechCardMediaFull{{Media: entity.MediaFull{Id: 11}, Kind: entity.TechCardMediaFront}},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		ResolvedMedia: []entity.TechCardMediaFull{
+			{Media: entity.MediaFull{Id: 11}, Category: entity.TechCardMediaCategoryTechnical, Kind: entity.TechCardMediaFront},
+			{Media: entity.MediaFull{Id: 20}, Category: entity.TechCardMediaCategoryMoodboard, Kind: entity.TechCardMediaReference, Caption: nullStringFromPb("mood")},
+		},
 	}
 
 	pb := ConvertEntityTechCardToPb(tc)
@@ -174,8 +191,15 @@ func TestConvertEntityTechCardToPb(t *testing.T) {
 	if len(pb.TechCard.Details) != 1 || pb.TechCard.Details[0].Key != "collar" || len(pb.TechCard.Details[0].MediaIds) != 1 {
 		t.Errorf("details round-trip mismatch: %+v", pb.TechCard.Details)
 	}
-	if len(pb.ResolvedMedia) != 1 || pb.ResolvedMedia[0].Media.Id != 11 {
-		t.Errorf("resolved media mismatch: %+v", pb.ResolvedMedia)
+	// writable media splits into the two lists by category.
+	if len(pb.TechCard.TechnicalMedia) != 1 || pb.TechCard.TechnicalMedia[0].MediaId != 11 ||
+		len(pb.TechCard.MoodboardMedia) != 1 || pb.TechCard.MoodboardMedia[0].MediaId != 20 {
+		t.Errorf("writable media split mismatch: technical=%+v moodboard=%+v", pb.TechCard.TechnicalMedia, pb.TechCard.MoodboardMedia)
+	}
+	// resolved media splits the same way, carrying kind + caption.
+	if len(pb.ResolvedTechnicalMedia) != 1 || pb.ResolvedTechnicalMedia[0].Media.Id != 11 ||
+		len(pb.ResolvedMoodboardMedia) != 1 || pb.ResolvedMoodboardMedia[0].Media.Id != 20 || pb.ResolvedMoodboardMedia[0].Caption != "mood" {
+		t.Errorf("resolved media split mismatch: technical=%+v moodboard=%+v", pb.ResolvedTechnicalMedia, pb.ResolvedMoodboardMedia)
 	}
 }
 
@@ -274,7 +298,8 @@ func TestConvertTechCardCosting(t *testing.T) {
 			{Node: "collar", TimeNorm: dec("2")},
 			{Node: "side", TimeNorm: dec("3")},
 		},
-		Costing: &pb_common.TechCardCosting{CmtCost: dec("10"), DefectPercent: dec("10"), Currency: "EUR"},
+		SizeQuantities: []*pb_common.TechCardSizeQuantity{{SizeId: 4, OrderQty: 100}},
+		Costing:        &pb_common.TechCardCosting{CmtCost: dec("10"), DefectPercent: dec("10"), Currency: "EUR"},
 	}
 	got, err := ConvertPbTechCardInsertToEntity(in)
 	if err != nil {
@@ -286,22 +311,28 @@ func TestConvertTechCardCosting(t *testing.T) {
 		t.Fatalf("costing not emitted")
 	}
 
-	// per-colourway costs.
+	// per-colourway costs. materials are per-garment; unit_cost folds in the shared manual
+	// articles (× 1+defect%); order_cost = unit_cost × order_qty (Σ size_quantities = 100).
 	if len(cost.ColorwayCosts) != 2 {
 		t.Fatalf("expected 2 colorway_costs, got %d", len(cost.ColorwayCosts))
 	}
 	black := cost.ColorwayCosts[0]
-	if black.ColorwayIndex != 0 || black.MaterialsCost.Value != "20" || !black.HasUnconvertedCurrencies {
+	// Black: materials_per_unit 20 EUR (USD excluded), unit=(20+10)×1.1=33, order=33×100=3300.
+	if black.ColorwayIndex != 0 || black.MaterialsPerUnit.Value != "20" || black.UnitCost.Value != "33" ||
+		black.OrderQty != 100 || black.OrderCost.Value != "3300" || !black.HasUnconvertedCurrencies {
 		t.Errorf("black colorway cost mismatch: %+v", black)
 	}
 	white := cost.ColorwayCosts[1]
-	if white.ColorwayIndex != 1 || white.MaterialsCost.Value != "30" || white.HasUnconvertedCurrencies {
+	// White: materials_per_unit 30, unit=(30+10)×1.1=44, order=44×100=4400.
+	if white.ColorwayIndex != 1 || white.MaterialsPerUnit.Value != "30" || white.UnitCost.Value != "44" ||
+		white.OrderQty != 100 || white.OrderCost.Value != "4400" || white.HasUnconvertedCurrencies {
 		t.Errorf("white colorway cost mismatch: %+v", white)
 	}
 
 	// root rollup = primary colourway (index 0 = Black).
-	if cost.MaterialsCost.Value != "20" || !cost.HasUnconvertedCurrencies {
-		t.Errorf("root rollup should mirror colourway 0: materials=%v unconv=%v", cost.MaterialsCost, cost.HasUnconvertedCurrencies)
+	if cost.MaterialsPerUnit.Value != "20" || cost.UnitCost.Value != "33" ||
+		cost.OrderQty != 100 || cost.OrderCost.Value != "3300" || !cost.HasUnconvertedCurrencies {
+		t.Errorf("root rollup should mirror colourway 0: %+v", cost)
 	}
 	byCcy := map[string]string{}
 	for _, l := range cost.MaterialsTotal {
@@ -309,10 +340,6 @@ func TestConvertTechCardCosting(t *testing.T) {
 	}
 	if byCcy["EUR"] != "20" || byCcy["USD"] != "3" {
 		t.Errorf("root materials_total buckets mismatch: %+v", byCcy)
-	}
-	// total_cost = (20 materials + 10 cmt) × 1.1 = 33. No labour fallback.
-	if cost.TotalCost == nil || cost.TotalCost.Value != "33" {
-		t.Errorf("total_cost mismatch: %+v", cost.TotalCost)
 	}
 	// total_sam = 2 + 3 = 5.
 	if cost.TotalSam == nil || cost.TotalSam.Value != "5" {
@@ -362,13 +389,12 @@ func TestConvertTechCardPerSizeCosting(t *testing.T) {
 	pb := ConvertEntityTechCardToPb(&entity.TechCard{TechCardInsert: *got})
 	cost := pb.TechCard.Costing
 	cc := cost.ColorwayCosts[0]
-	// materials_cost = size-run 102 + per-garment 3 = 105.
-	if cc.MaterialsCost.Value != "105" {
-		t.Errorf("mixed-scale materials_cost mismatch: %+v", cc.MaterialsCost)
-	}
-	// size_run_total = just the per-size usage's run cost = 102.
-	if cc.SizeRunTotal == nil || cc.SizeRunTotal.Value != "102" {
-		t.Errorf("colorway size_run_total mismatch: %+v", cc.SizeRunTotal)
+	// Per-unit: the per-size usage normalises to 102/30 = 3.4, the per-garment zip is 3, so
+	// materials_per_unit = 6.4. With no manual articles / defect, unit_cost = 6.4 and
+	// order_cost = 6.4 × 30 = 192 — which equals size-run 102 + zip run 90, recovering the run.
+	if cc.MaterialsPerUnit.Value != "6.4" || cc.UnitCost.Value != "6.4" ||
+		cc.OrderQty != 30 || cc.OrderCost.Value != "192" {
+		t.Errorf("mixed-scale per-unit/per-order mismatch: %+v", cc)
 	}
 	// the per-size usage emits size_run_total and an absent line_total.
 	pus := pb.TechCard.Colorways[0].Usages

--- a/internal/entity/fitting.go
+++ b/internal/entity/fitting.go
@@ -3,6 +3,8 @@ package entity
 import (
 	"database/sql"
 	"time"
+
+	"github.com/shopspring/decimal"
 )
 
 // FittingStatus is the lifecycle state of a fitting session.
@@ -55,6 +57,17 @@ type FittingPattern struct {
 	SizeBytes sql.NullInt64  `db:"size_bytes"`
 }
 
+// FittingCallout is a numbered marker pinned to a fitting photo, flagging a fit
+// problem at a point on the image (a pin + a note). Simpler than TechCardCallout —
+// no part/dimensions (a fitting flags posadka, not spec geometry).
+type FittingCallout struct {
+	Number  int                 `db:"callout_number"`
+	Note    sql.NullString      `db:"note"`
+	MediaId sql.NullInt32       `db:"media_id"` // the fitting photo this callout is pinned to
+	PosX    decimal.NullDecimal `db:"pos_x"`    // normalised 0..1 marker position
+	PosY    decimal.NullDecimal `db:"pos_y"`
+}
+
 // FittingInsert is the writable payload for a fitting session. A fitting anchors
 // to a tech card (the style) and/or a specific product (the colour/SKU sample);
 // at least one of TechCardId / ProductId is set (enforced in the API layer).
@@ -70,6 +83,7 @@ type FittingInsert struct {
 	Sizes       []FittingSize    `db:"-"`
 	MediaIds    []int            `db:"-"`
 	Patterns    []FittingPattern `db:"-"`
+	Callouts    []FittingCallout `db:"-"`
 }
 
 // Fitting is a stored fitting session (fitting row + sizes + resolved media).

--- a/internal/entity/task.go
+++ b/internal/entity/task.go
@@ -75,10 +75,12 @@ type TaskInsert struct {
 	Assignee    string         `db:"assignee"`
 	Priority    TaskPriority   `db:"priority"`
 	DueDate     sql.NullTime   `db:"due_date"`
+	StartDate   sql.NullTime   `db:"start_date"` // planned start (manual); actual start is Task.StartedAt
 	TechCardId  sql.NullInt32  `db:"tech_card_id"`
 	ProductId   sql.NullInt32  `db:"product_id"`
 	OrderUuid   sql.NullString `db:"order_uuid"`
 	ArchiveId   sql.NullInt32  `db:"archive_id"`
+	FittingId   sql.NullInt32  `db:"fitting_id"`
 	Labels      []string       `db:"-"`
 	MediaIds    []int          `db:"-"`
 }
@@ -97,8 +99,11 @@ type Task struct {
 	UpdatedAt time.Time   `db:"updated_at"`
 	// ArchivedAt is the soft-archive marker: Valid = archived (hidden from the
 	// board and default list, but restorable); invalid/NULL = active.
-	ArchivedAt sql.NullTime        `db:"archived_at"`
-	Checklist  []TaskChecklistItem `db:"-"`
+	ArchivedAt sql.NullTime `db:"archived_at"`
+	// StartedAt is the actual start: server-stamped the first time the card enters
+	// in_progress, never cleared afterwards. Invalid/NULL = not started yet.
+	StartedAt sql.NullTime        `db:"started_at"`
+	Checklist []TaskChecklistItem `db:"-"`
 }
 
 // TaskChecklistItem is one row of a task's checklist — a lightweight subtask with

--- a/internal/entity/techcard.go
+++ b/internal/entity/techcard.go
@@ -123,17 +123,31 @@ func IsValidTechCardMediaKind(k TechCardMediaKind) bool {
 	return ValidTechCardMediaKinds[k]
 }
 
-// TechCardMediaItem is a writable sketch-media reference (id + kind).
+// TechCardMediaCategory is which of the two sketch lists a media item belongs to:
+// moodboard (mood / inspiration / reference) vs technical (flat sketches used in
+// construction). Stored as a string in tech_card_media.category; the item's Kind is
+// the within-list sub-classifier.
+type TechCardMediaCategory string
+
+const (
+	TechCardMediaCategoryMoodboard TechCardMediaCategory = "moodboard"
+	TechCardMediaCategoryTechnical TechCardMediaCategory = "technical"
+)
+
+// TechCardMediaItem is a writable sketch-media reference (id + category + kind).
 type TechCardMediaItem struct {
-	MediaId int               `db:"media_id"`
-	Kind    TechCardMediaKind `db:"kind"`
-	Caption sql.NullString    `db:"caption"`
+	MediaId  int                   `db:"media_id"`
+	Category TechCardMediaCategory `db:"category"`
+	Kind     TechCardMediaKind     `db:"kind"`
+	Caption  sql.NullString        `db:"caption"`
 }
 
 // TechCardMediaFull is a resolved sketch-media reference for display.
 type TechCardMediaFull struct {
-	Media MediaFull
-	Kind  TechCardMediaKind
+	Media    MediaFull
+	Category TechCardMediaCategory
+	Kind     TechCardMediaKind
+	Caption  sql.NullString
 }
 
 // TechCardCallout is a numbered detail note pointing at the technical sketch.
@@ -307,6 +321,24 @@ func (u *TechCardColorwayUsage) EffectiveTotal(bom *TechCardBomItem, orderQtyByS
 		return rt
 	}
 	return u.LineTotal(bom)
+}
+
+// UnitTotal is the usage's PER-GARMENT material cost for costing. A per-garment usage
+// (measured Consumption or countable Quantity) uses its LineTotal directly. A usage graded
+// ONLY per size has no single per-garment rate, so its per-garment figure is the whole-run
+// SizeRunTotal divided by totalOrderQty (a qty-weighted average) — this keeps per-unit and
+// per-order on ONE scale, since unit × totalOrderQty recovers the run. INVALID when neither
+// is available (e.g. per-size only with no order quantities yet).
+func (u *TechCardColorwayUsage) UnitTotal(bom *TechCardBomItem, orderQtyBySize map[int]int, totalOrderQty int) decimal.NullDecimal {
+	if lt := u.LineTotal(bom); lt.Valid {
+		return lt
+	}
+	if totalOrderQty > 0 {
+		if rt := u.SizeRunTotal(bom, orderQtyBySize); rt.Valid {
+			return decimal.NullDecimal{Decimal: rt.Decimal.Div(decimal.NewFromInt(int64(totalOrderQty))), Valid: true}
+		}
+	}
+	return decimal.NullDecimal{}
 }
 
 // applyWastage grosses a base cost up by wastage_percent when set (× (1 + pct/100)).
@@ -606,20 +638,19 @@ type TechCardPackaging struct {
 	Notes         sql.NullString      `db:"notes"`
 }
 
-// TechCardCosting holds the manually-entered cost articles (Sheet «Калькуляция», 1:1).
-// The materials rollup and total are computed on read (see dto), not stored.
+// TechCardCosting holds the manually-entered per-unit cost articles (Sheet
+// «Калькуляция», 1:1), all in a single currency. The materials line and the unit/order
+// totals are computed on read (see dto), not stored. Pricing (markup/wholesale/retail)
+// was removed — it lives on the published product.
 type TechCardCosting struct {
-	CmtCost          decimal.NullDecimal `db:"cmt_cost"`
-	HardwareCost     decimal.NullDecimal `db:"hardware_cost"`
-	PackagingCost    decimal.NullDecimal `db:"packaging_cost"`
-	LogisticsCost    decimal.NullDecimal `db:"logistics_cost"`
-	OverheadCost     decimal.NullDecimal `db:"overhead_cost"`
-	DefectPercent    decimal.NullDecimal `db:"defect_percent"`
-	MarkupMultiplier decimal.NullDecimal `db:"markup_multiplier"`
-	WholesalePrice   decimal.NullDecimal `db:"wholesale_price"`
-	RetailPrice      decimal.NullDecimal `db:"retail_price"`
-	Currency         sql.NullString      `db:"currency"`
-	Notes            sql.NullString      `db:"notes"`
+	CmtCost       decimal.NullDecimal `db:"cmt_cost"`
+	HardwareCost  decimal.NullDecimal `db:"hardware_cost"`
+	PackagingCost decimal.NullDecimal `db:"packaging_cost"`
+	LogisticsCost decimal.NullDecimal `db:"logistics_cost"`
+	OverheadCost  decimal.NullDecimal `db:"overhead_cost"`
+	DefectPercent decimal.NullDecimal `db:"defect_percent"`
+	Currency      sql.NullString      `db:"currency"`
+	Notes         sql.NullString      `db:"notes"`
 }
 
 // TechCardInsert is the writable payload for a tech card (header + child sections).

--- a/internal/store/api_updates_integration_test.go
+++ b/internal/store/api_updates_integration_test.go
@@ -1,0 +1,159 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAPIUpdatesIntegration exercises the five-feature batch (task fitting link + start
+// times, fitting callouts, tech-card media split, costing redo) against a real MySQL, to
+// catch any INSERT/SELECT column-name drift the unit tests can't. Throwaway harness.
+func TestAPIUpdatesIntegration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cfg := *testCfg
+	cfg.Automigrate = true
+	s, err := NewForTest(ctx, cfg)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Ids created below; cleaned up in reverse-dependency order so this test leaves the
+	// shared DB as it found it (else the seed media's FK refs break TestMedia's cleanup).
+	var mediaID, fid, tid, tcID int
+	defer func() {
+		if tcID != 0 {
+			_ = s.TechCards().DeleteTechCard(ctx, tcID)
+		}
+		if tid != 0 {
+			_ = s.Tasks().DeleteTask(ctx, tid)
+		}
+		if fid != 0 {
+			_ = s.Fittings().DeleteFitting(ctx, fid)
+		}
+		if mediaID != 0 {
+			_ = s.Media().DeleteMediaById(ctx, mediaID)
+		}
+	}()
+
+	// seed one media row (FK target for callouts / task media / tech-card media).
+	mediaID, err = s.Media().AddMedia(ctx, &entity.MediaItem{
+		FullSizeMediaURL: "https://x/f.jpg", FullSizeWidth: 100, FullSizeHeight: 100,
+		ThumbnailMediaURL: "https://x/t.jpg", ThumbnailWidth: 10, ThumbnailHeight: 10,
+		CompressedMediaURL: "https://x/c.jpg", CompressedWidth: 50, CompressedHeight: 50,
+	})
+	require.NoError(t, err)
+
+	nd := func(s string) decimal.NullDecimal {
+		return decimal.NullDecimal{Decimal: decimal.RequireFromString(s), Valid: true}
+	}
+
+	// ---- fitting callouts round-trip ----
+	fid, err = s.Fittings().AddFitting(ctx, &entity.FittingInsert{
+		FittingDate: time.Now().UTC(),
+		Status:      entity.FittingPlanned,
+		Verdict:     entity.FittingPending,
+		Callouts: []entity.FittingCallout{
+			{Number: 1, Note: sql.NullString{String: "shoulder tight", Valid: true},
+				MediaId: sql.NullInt32{Int32: int32(mediaID), Valid: true}, PosX: nd("0.25"), PosY: nd("0.5")},
+		},
+	})
+	require.NoError(t, err)
+	fit, err := s.Fittings().GetFittingById(ctx, fid)
+	require.NoError(t, err)
+	require.Len(t, fit.Callouts, 1)
+	require.Equal(t, "shoulder tight", fit.Callouts[0].Note.String)
+	require.Equal(t, int32(mediaID), fit.Callouts[0].MediaId.Int32)
+	require.True(t, fit.Callouts[0].PosX.Valid)
+	// update replaces callouts.
+	require.NoError(t, s.Fittings().UpdateFitting(ctx, fid, &entity.FittingInsert{
+		FittingDate: time.Now().UTC(), Status: entity.FittingDone, Verdict: entity.FittingApproved,
+		Callouts: []entity.FittingCallout{
+			{Number: 1, Note: sql.NullString{String: "a", Valid: true}},
+			{Number: 2, Note: sql.NullString{String: "b", Valid: true}},
+		},
+	}))
+	fit, err = s.Fittings().GetFittingById(ctx, fid)
+	require.NoError(t, err)
+	require.Len(t, fit.Callouts, 2)
+
+	// ---- task: fitting link + planned start + auto started_at on first in_progress ----
+	start := sql.NullTime{Time: time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC), Valid: true}
+	tid, err = s.Tasks().AddTask(ctx, &entity.Task{
+		TaskInsert: entity.TaskInsert{
+			Title:     "sew",
+			Priority:  entity.TaskPriorityUnknown,
+			StartDate: start,
+			FittingId: sql.NullInt32{Int32: int32(fid), Valid: true},
+			MediaIds:  []int{mediaID},
+		},
+		Board:  entity.TaskBoardDevelopment,
+		Status: entity.TaskStatusTodo,
+	})
+	require.NoError(t, err)
+	task, err := s.Tasks().GetTaskById(ctx, tid)
+	require.NoError(t, err)
+	require.Equal(t, int32(fid), task.FittingId.Int32)
+	require.True(t, task.StartDate.Valid)
+	require.False(t, task.StartedAt.Valid, "started_at must be NULL before in_progress")
+
+	require.NoError(t, s.Tasks().MoveTask(ctx, tid, "", entity.TaskStatusInProgress, 0))
+	task, err = s.Tasks().GetTaskById(ctx, tid)
+	require.NoError(t, err)
+	require.True(t, task.StartedAt.Valid, "started_at stamped on first in_progress")
+	firstStart := task.StartedAt.Time
+
+	// move away and back — started_at must NOT change.
+	require.NoError(t, s.Tasks().MoveTask(ctx, tid, "", entity.TaskStatusReview, 0))
+	require.NoError(t, s.Tasks().MoveTask(ctx, tid, "", entity.TaskStatusInProgress, 0))
+	task, err = s.Tasks().GetTaskById(ctx, tid)
+	require.NoError(t, err)
+	require.WithinDuration(t, firstStart, task.StartedAt.Time, time.Second, "started_at is not re-stamped")
+
+	// ---- tech card: media split (moodboard/technical) + costing without pricing columns ----
+	tcID, err = s.TechCards().AddTechCard(ctx, &entity.TechCardInsert{
+		StyleNumber:     "IT-001",
+		Name:            "Coat",
+		Stage:           entity.TechCardStageProto,
+		ApprovalState:   entity.TechCardApprovalDraft,
+		MeasurementUnit: entity.TechCardUnitMm,
+		SizeIds:         []int{4},
+		Media: []entity.TechCardMediaItem{
+			{MediaId: mediaID, Category: entity.TechCardMediaCategoryMoodboard, Kind: entity.TechCardMediaReference},
+			{MediaId: mediaID, Category: entity.TechCardMediaCategoryTechnical, Kind: entity.TechCardMediaFront},
+		},
+		SizeQuantities: []entity.TechCardSizeQuantity{{SizeId: 4, OrderQty: 100}},
+		BomItems:       []entity.TechCardBomItem{{Section: entity.BomSectionFabric, Name: "shell", UnitPrice: nd("2"), Currency: sql.NullString{String: "EUR", Valid: true}}},
+		Colorways: []entity.TechCardColorway{{Name: "Black", LabDipStatus: entity.LabDipPending, Usages: []entity.TechCardColorwayUsage{
+			{BomItemIndex: sql.NullInt32{Int32: 0, Valid: true}, Quantity: nd("3")},
+		}}},
+		Costing: &entity.TechCardCosting{CmtCost: nd("10"), Currency: sql.NullString{String: "EUR", Valid: true}},
+	})
+	require.NoError(t, err)
+	card, err := s.TechCards().GetTechCardById(ctx, tcID)
+	require.NoError(t, err)
+
+	var mood, tech int
+	for _, m := range card.Media {
+		switch m.Category {
+		case entity.TechCardMediaCategoryMoodboard:
+			mood++
+		case entity.TechCardMediaCategoryTechnical:
+			tech++
+		}
+	}
+	require.Equal(t, 1, mood, "one moodboard media")
+	require.Equal(t, 1, tech, "one technical media")
+	require.Len(t, card.ResolvedMedia, 2)
+	require.NotNil(t, card.Costing)
+	require.True(t, card.Costing.CmtCost.Valid)
+	require.Equal(t, "EUR", card.Costing.Currency.String)
+	require.Len(t, card.Colorways, 1)
+	require.Len(t, card.Colorways[0].Usages, 1)
+}

--- a/internal/store/fitting/fitting.go
+++ b/internal/store/fitting/fitting.go
@@ -50,7 +50,10 @@ func (s *Store) AddFitting(ctx context.Context, f *entity.FittingInsert) (int, e
 		if err := insertFittingMedia(ctx, rep.DB(), id, f.MediaIds); err != nil {
 			return err
 		}
-		return insertFittingPatterns(ctx, rep.DB(), id, f.Patterns)
+		if err := insertFittingPatterns(ctx, rep.DB(), id, f.Patterns); err != nil {
+			return err
+		}
+		return insertFittingCallouts(ctx, rep.DB(), id, f.Callouts)
 	})
 	if err != nil {
 		return 0, fmt.Errorf("can't add fitting: %w", err)
@@ -99,13 +102,20 @@ func (s *Store) UpdateFitting(ctx context.Context, id int, f *entity.FittingInse
 			`DELETE FROM fitting_pattern WHERE fitting_id = :id`, map[string]any{"id": id}); err != nil {
 			return fmt.Errorf("failed to clear fitting patterns: %w", err)
 		}
+		if err := storeutil.ExecNamed(ctx, rep.DB(),
+			`DELETE FROM fitting_callout WHERE fitting_id = :id`, map[string]any{"id": id}); err != nil {
+			return fmt.Errorf("failed to clear fitting callouts: %w", err)
+		}
 		if err := insertFittingSizes(ctx, rep.DB(), id, f.Sizes); err != nil {
 			return err
 		}
 		if err := insertFittingMedia(ctx, rep.DB(), id, f.MediaIds); err != nil {
 			return err
 		}
-		return insertFittingPatterns(ctx, rep.DB(), id, f.Patterns)
+		if err := insertFittingPatterns(ctx, rep.DB(), id, f.Patterns); err != nil {
+			return err
+		}
+		return insertFittingCallouts(ctx, rep.DB(), id, f.Callouts)
 	})
 	if err != nil {
 		return fmt.Errorf("can't update fitting: %w", err)
@@ -141,9 +151,14 @@ func (s *Store) GetFittingById(ctx context.Context, id int) (*entity.Fitting, er
 	if err != nil {
 		return nil, err
 	}
+	callouts, err := s.calloutsByFittingIds(ctx, []int{id})
+	if err != nil {
+		return nil, err
+	}
 	f.Sizes = sizes[id]
 	f.Media = media[id]
 	f.Patterns = patterns[id]
+	f.Callouts = callouts[id]
 	return &f, nil
 }
 
@@ -207,10 +222,15 @@ func (s *Store) ListFittings(ctx context.Context, limit, offset int, orderFactor
 	if err != nil {
 		return nil, 0, err
 	}
+	callouts, err := s.calloutsByFittingIds(ctx, ids)
+	if err != nil {
+		return nil, 0, err
+	}
 	for i := range fittings {
 		fittings[i].Sizes = sizes[fittings[i].Id]
 		fittings[i].Media = media[fittings[i].Id]
 		fittings[i].Patterns = patterns[fittings[i].Id]
+		fittings[i].Callouts = callouts[fittings[i].Id]
 	}
 	return fittings, total, nil
 }
@@ -283,6 +303,28 @@ func insertFittingPatterns(ctx context.Context, db dependency.DB, fittingID int,
 	return nil
 }
 
+func insertFittingCallouts(ctx context.Context, db dependency.DB, fittingID int, callouts []entity.FittingCallout) error {
+	if len(callouts) == 0 {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(callouts))
+	for i, c := range callouts {
+		rows = append(rows, map[string]any{
+			"fitting_id":     fittingID,
+			"callout_number": c.Number,
+			"note":           c.Note,
+			"media_id":       c.MediaId,
+			"pos_x":          c.PosX,
+			"pos_y":          c.PosY,
+			"display_order":  i,
+		})
+	}
+	if err := storeutil.BulkInsert(ctx, db, "fitting_callout", rows); err != nil {
+		return fmt.Errorf("failed to insert fitting callouts: %w", err)
+	}
+	return nil
+}
+
 func insertFittingMedia(ctx context.Context, db dependency.DB, fittingID int, mediaIDs []int) error {
 	if len(mediaIDs) == 0 {
 		return nil
@@ -333,6 +375,30 @@ type fittingMediaRow struct {
 type fittingPatternRow struct {
 	FittingID int `db:"fitting_id"`
 	entity.FittingPattern
+}
+
+type fittingCalloutRow struct {
+	FittingID int `db:"fitting_id"`
+	entity.FittingCallout
+}
+
+func (s *Store) calloutsByFittingIds(ctx context.Context, ids []int) (map[int][]entity.FittingCallout, error) {
+	if len(ids) == 0 {
+		return map[int][]entity.FittingCallout{}, nil
+	}
+	rows, err := storeutil.QueryListNamed[fittingCalloutRow](ctx, s.DB, `
+		SELECT fitting_id, callout_number, note, media_id, pos_x, pos_y
+		FROM fitting_callout
+		WHERE fitting_id IN (:ids)
+		ORDER BY fitting_id, display_order`, map[string]any{"ids": ids})
+	if err != nil {
+		return nil, fmt.Errorf("can't load fitting callouts: %w", err)
+	}
+	out := make(map[int][]entity.FittingCallout, len(ids))
+	for _, r := range rows {
+		out[r.FittingID] = append(out[r.FittingID], r.FittingCallout)
+	}
+	return out, nil
 }
 
 func (s *Store) patternsByFittingIds(ctx context.Context, ids []int) (map[int][]entity.FittingPattern, error) {

--- a/internal/store/sql/0092_api_updates_fitting_techcard.sql
+++ b/internal/store/sql/0092_api_updates_fitting_techcard.sql
@@ -1,0 +1,82 @@
+-- +migrate Up
+-- Batch of five API updates:
+--   1. task: attach a fitting (примерка) + planned/actual start times.
+--   2. fitting_callout: numbered pins on fitting photos (pin + note about the fit).
+--   3. tech_card_media: split into moodboard vs technical (category column).
+--   4. tech_card_costing: drop the pricing block (markup/wholesale/retail) — the
+--      costing sheet is now cost-only (per-unit + per-order), pricing lives on the product.
+
+-- 1) task: fitting deep link + planned start (manual) + actual start (server-stamped
+-- on the first move into in_progress). fitting_id follows the existing typed-FK
+-- deep-link pattern (ON DELETE SET NULL so deleting a fitting never blocks a card).
+ALTER TABLE task
+  ADD COLUMN fitting_id INT NULL COMMENT 'FK fitting(id); deep link to a try-on session, NULL = none',
+  ADD COLUMN start_date DATETIME NULL COMMENT 'planned start (UTC); manual, NULL = none',
+  ADD COLUMN started_at DATETIME NULL COMMENT 'actual start: stamped on first move to in_progress (UTC), NULL = not started',
+  ADD INDEX idx_task_fitting (fitting_id),
+  ADD CONSTRAINT fk_task_fitting FOREIGN KEY (fitting_id) REFERENCES fitting(id) ON DELETE SET NULL;
+
+-- 2) fitting_callout: a numbered marker pinned to a fitting photo, flagging a fit
+-- problem at a point on the image. Simpler than tech_card_callout — a pin + a note,
+-- no part/dimensions. Full-replace on fitting update; cascades on fitting delete.
+CREATE TABLE fitting_callout (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  fitting_id INT NOT NULL,
+  callout_number INT NOT NULL DEFAULT 0 COMMENT 'marker number shown on the photo',
+  note TEXT NULL COMMENT 'what is wrong with the fit here',
+  media_id INT NULL COMMENT 'FK media(id); the fitting photo this callout is pinned to (NULL = unanchored)',
+  pos_x DECIMAL(5, 4) NULL COMMENT 'normalised x (0..1) of the marker on its photo'
+    CHECK (pos_x IS NULL OR (pos_x >= 0 AND pos_x <= 1)),
+  pos_y DECIMAL(5, 4) NULL COMMENT 'normalised y (0..1) of the marker on its photo'
+    CHECK (pos_y IS NULL OR (pos_y >= 0 AND pos_y <= 1)),
+  display_order INT NOT NULL DEFAULT 0,
+  INDEX idx_fitting_callout_fitting (fitting_id),
+  FOREIGN KEY (fitting_id) REFERENCES fitting(id) ON DELETE CASCADE,
+  FOREIGN KEY (media_id) REFERENCES media(id) ON DELETE SET NULL
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT 'Callouts pinned to fitting photos';
+
+-- 3) tech_card_media: sketch media split into two lists. category says which list an
+-- item belongs to; kind stays the within-list sub-classifier. Existing rows are
+-- back-filled by kind (moodboard/reference/swatch = inspiration → moodboard; the flat
+-- sketch kinds → technical, the default). The inline CHECK here auto-names to
+-- tech_card_media_chk_1 (the only pre-existing check is the explicitly-named
+-- chk_tech_card_media_kind); the Down drops it by that name.
+ALTER TABLE tech_card_media
+  ADD COLUMN category VARCHAR(16) NOT NULL DEFAULT 'technical'
+    COMMENT 'moodboard|technical — which sketch list the item belongs to'
+    CHECK (category REGEXP '^(moodboard|technical)$');
+UPDATE tech_card_media SET category = 'moodboard'
+  WHERE kind IN ('moodboard', 'reference', 'swatch');
+
+-- 4) tech_card_costing: drop the pricing block. The costing sheet is now cost-only
+-- (materials + CMT/hardware/packaging/logistics/overhead + defect%, per unit and per
+-- order). Pricing (markup → wholesale/retail) moved to the published product.
+-- markup_multiplier/wholesale_price/retail_price were created in 0070 as the 7th/8th/9th
+-- inline CHECK columns, so MySQL auto-named their checks tech_card_costing_chk_7/_8/_9;
+-- a column referenced by a CHECK cannot be dropped, so drop those checks first (same
+-- idiom as 0073/0079).
+ALTER TABLE tech_card_costing
+  DROP CHECK tech_card_costing_chk_7,
+  DROP CHECK tech_card_costing_chk_8,
+  DROP CHECK tech_card_costing_chk_9,
+  DROP COLUMN markup_multiplier,
+  DROP COLUMN wholesale_price,
+  DROP COLUMN retail_price;
+
+-- +migrate Down
+ALTER TABLE tech_card_costing
+  ADD COLUMN markup_multiplier DECIMAL(6, 3) NULL COMMENT 'наценка (×)'
+    CHECK (markup_multiplier IS NULL OR markup_multiplier >= 0),
+  ADD COLUMN wholesale_price DECIMAL(12, 2) NULL COMMENT 'оптовая цена'
+    CHECK (wholesale_price IS NULL OR wholesale_price >= 0),
+  ADD COLUMN retail_price DECIMAL(12, 2) NULL COMMENT 'розничная цена'
+    CHECK (retail_price IS NULL OR retail_price >= 0);
+ALTER TABLE tech_card_media
+  DROP CHECK tech_card_media_chk_1,
+  DROP COLUMN category;
+DROP TABLE IF EXISTS fitting_callout;
+ALTER TABLE task
+  DROP FOREIGN KEY fk_task_fitting,
+  DROP COLUMN fitting_id,
+  DROP COLUMN start_date,
+  DROP COLUMN started_at;

--- a/internal/store/task/task.go
+++ b/internal/store/task/task.go
@@ -51,8 +51,9 @@ func (s *Store) AddTask(ctx context.Context, t *entity.Task) (int, error) {
 		params["position"] = pos
 		params["createdBy"] = t.CreatedBy
 		id, err = storeutil.ExecNamedLastId(ctx, rep.DB(), `
-			INSERT INTO task (title, description, board, status, position, assignee, priority, due_date, created_by, tech_card_id, product_id, order_uuid, archive_id)
-			VALUES (:title, :description, :board, :status, :position, :assignee, :priority, :dueDate, :createdBy, :techCardId, :productId, :orderUuid, :archiveId)`,
+			INSERT INTO task (title, description, board, status, position, assignee, priority, due_date, start_date, created_by, tech_card_id, product_id, order_uuid, archive_id, fitting_id, started_at)
+			VALUES (:title, :description, :board, :status, :position, :assignee, :priority, :dueDate, :startDate, :createdBy, :techCardId, :productId, :orderUuid, :archiveId, :fittingId,
+				CASE WHEN :status = 'in_progress' THEN UTC_TIMESTAMP() ELSE NULL END)`,
 			params)
 		if err != nil {
 			return fmt.Errorf("failed to insert task: %w", err)
@@ -90,10 +91,12 @@ func (s *Store) UpdateTask(ctx context.Context, id int, t *entity.TaskInsert) er
 				assignee = :assignee,
 				priority = :priority,
 				due_date = :dueDate,
+				start_date = :startDate,
 				tech_card_id = :techCardId,
 				product_id = :productId,
 				order_uuid = :orderUuid,
-				archive_id = :archiveId
+				archive_id = :archiveId,
+				fitting_id = :fittingId
 			WHERE id = :id`, params); err != nil {
 			return fmt.Errorf("failed to update task: %w", err)
 		}
@@ -172,6 +175,17 @@ func (s *Store) MoveTask(ctx context.Context, id int, board entity.TaskBoard, st
 			UPDATE task SET board = :board, status = :status, position = :pos WHERE id = :id`,
 			map[string]any{"board": string(board), "status": string(status), "pos": position, "id": id}); err != nil {
 			return fmt.Errorf("failed to place task: %w", err)
+		}
+
+		// 5) Stamp the actual start the FIRST time the card enters in_progress. The
+		// `started_at IS NULL` guard makes it idempotent — a later re-entry keeps the
+		// original start.
+		if status == entity.TaskStatusInProgress {
+			if err := storeutil.ExecNamed(ctx, rep.DB(), `
+				UPDATE task SET started_at = UTC_TIMESTAMP() WHERE id = :id AND started_at IS NULL`,
+				map[string]any{"id": id}); err != nil {
+				return fmt.Errorf("failed to stamp task start: %w", err)
+			}
 		}
 		return nil
 	})
@@ -485,10 +499,12 @@ func taskContentParams(t *entity.TaskInsert) map[string]any {
 		"assignee":    t.Assignee,
 		"priority":    string(t.Priority),
 		"dueDate":     t.DueDate,
+		"startDate":   t.StartDate,
 		"techCardId":  t.TechCardId,
 		"productId":   t.ProductId,
 		"orderUuid":   t.OrderUuid,
 		"archiveId":   t.ArchiveId,
+		"fittingId":   t.FittingId,
 	}
 }
 

--- a/internal/store/techcard/enrich.go
+++ b/internal/store/techcard/enrich.go
@@ -143,9 +143,10 @@ func (s *Store) productIdsByTechCardIds(ctx context.Context, ids []int) (map[int
 }
 
 type techCardMediaRow struct {
-	TechCardID int                      `db:"tech_card_id"`
-	Kind       entity.TechCardMediaKind `db:"kind"`
-	Caption    sql.NullString           `db:"caption"`
+	TechCardID int                          `db:"tech_card_id"`
+	Category   entity.TechCardMediaCategory `db:"category"`
+	Kind       entity.TechCardMediaKind     `db:"kind"`
+	Caption    sql.NullString               `db:"caption"`
 	entity.MediaFull
 }
 
@@ -156,7 +157,7 @@ func (s *Store) mediaByTechCardIds(ctx context.Context, ids []int) (map[int][]en
 		return items, full, nil
 	}
 	rows, err := storeutil.QueryListNamed[techCardMediaRow](ctx, s.DB, `
-		SELECT tcm.tech_card_id, tcm.kind, tcm.caption, m.*
+		SELECT tcm.tech_card_id, tcm.category, tcm.kind, tcm.caption, m.*
 		FROM tech_card_media tcm
 		JOIN media m ON m.id = tcm.media_id
 		WHERE tcm.tech_card_id IN (:ids)
@@ -166,8 +167,8 @@ func (s *Store) mediaByTechCardIds(ctx context.Context, ids []int) (map[int][]en
 	}
 	for i := range rows {
 		tcID := rows[i].TechCardID
-		items[tcID] = append(items[tcID], entity.TechCardMediaItem{MediaId: rows[i].Id, Kind: rows[i].Kind, Caption: rows[i].Caption})
-		full[tcID] = append(full[tcID], entity.TechCardMediaFull{Media: rows[i].MediaFull, Kind: rows[i].Kind})
+		items[tcID] = append(items[tcID], entity.TechCardMediaItem{MediaId: rows[i].Id, Category: rows[i].Category, Kind: rows[i].Kind, Caption: rows[i].Caption})
+		full[tcID] = append(full[tcID], entity.TechCardMediaFull{Media: rows[i].MediaFull, Category: rows[i].Category, Kind: rows[i].Kind, Caption: rows[i].Caption})
 	}
 	return items, full, nil
 }

--- a/internal/store/techcard/production.go
+++ b/internal/store/techcard/production.go
@@ -130,22 +130,19 @@ func insertTechCardCosting(ctx context.Context, db dependency.DB, tcID int, c *e
 	if err := storeutil.ExecNamed(ctx, db, `
 		INSERT INTO tech_card_costing
 			(tech_card_id, cmt_cost, hardware_cost, packaging_cost, logistics_cost, overhead_cost,
-			 defect_percent, markup_multiplier, wholesale_price, retail_price, currency, notes)
+			 defect_percent, currency, notes)
 		VALUES (:tech_card_id, :cmt_cost, :hardware_cost, :packaging_cost, :logistics_cost, :overhead_cost,
-			 :defect_percent, :markup_multiplier, :wholesale_price, :retail_price, :currency, :notes)`,
+			 :defect_percent, :currency, :notes)`,
 		map[string]any{
-			"tech_card_id":      tcID,
-			"cmt_cost":          c.CmtCost,
-			"hardware_cost":     c.HardwareCost,
-			"packaging_cost":    c.PackagingCost,
-			"logistics_cost":    c.LogisticsCost,
-			"overhead_cost":     c.OverheadCost,
-			"defect_percent":    c.DefectPercent,
-			"markup_multiplier": c.MarkupMultiplier,
-			"wholesale_price":   c.WholesalePrice,
-			"retail_price":      c.RetailPrice,
-			"currency":          c.Currency,
-			"notes":             c.Notes,
+			"tech_card_id":   tcID,
+			"cmt_cost":       c.CmtCost,
+			"hardware_cost":  c.HardwareCost,
+			"packaging_cost": c.PackagingCost,
+			"logistics_cost": c.LogisticsCost,
+			"overhead_cost":  c.OverheadCost,
+			"defect_percent": c.DefectPercent,
+			"currency":       c.Currency,
+			"notes":          c.Notes,
 		}); err != nil {
 		return fmt.Errorf("failed to insert tech card costing: %w", err)
 	}

--- a/internal/store/techcard/techcard.go
+++ b/internal/store/techcard/techcard.go
@@ -405,6 +405,7 @@ func insertTechCardMedia(ctx context.Context, db dependency.DB, id int, media []
 		rows = append(rows, map[string]any{
 			"tech_card_id":  id,
 			"media_id":      m.MediaId,
+			"category":      string(m.Category),
 			"kind":          string(m.Kind),
 			"caption":       m.Caption,
 			"display_order": i,

--- a/proto/common/common/fitting.proto
+++ b/proto/common/common/fitting.proto
@@ -4,6 +4,7 @@ package common;
 
 import "common/media.proto";
 import "google/protobuf/timestamp.proto";
+import "google/type/decimal.proto";
 
 option go_package = "github.com/jekabolt/grbpwr-manager/proto/gen/common;common";
 
@@ -50,6 +51,22 @@ message FittingInsert {
   // uploaded via Admin.UploadPattern; the url is stored as a snapshot (immune to later
   // tech-card edits).
   repeated FittingPattern patterns = 11;
+  // Callouts pinned onto the fitting's photos — a marker + note flagging what is
+  // wrong with the fit at a point on a specific photo (media_ids). Full-replace on
+  // update, like sizes/media/patterns.
+  repeated FittingCallout callouts = 12;
+}
+
+// FittingCallout is a numbered marker pinned to a fitting photo, noting a fit
+// problem at a point on the image ("here the shoulder is too tight"). It is the
+// fitting analogue of TechCardCallout but deliberately simpler: a pin + a note,
+// with no part/dimensions (a fitting flags posadka, not spec geometry).
+message FittingCallout {
+  int32 number = 1; // marker number shown on the photo
+  string note = 2; // what is wrong with the fit here (required)
+  int32 media_id = 3; // FK media(id); the fitting photo this callout is pinned to (0 = unanchored)
+  google.type.Decimal pos_x = 4; // normalised x (0..1) of the marker on its photo
+  google.type.Decimal pos_y = 5; // normalised y (0..1) of the marker on its photo
 }
 
 // FittingPattern is one PDF выкройка iteration tried in a fitting (snapshot of the

--- a/proto/common/common/task.proto
+++ b/proto/common/common/task.proto
@@ -73,6 +73,12 @@ message TaskInsert {
   int32 product_id = 9; // specific product / SKU / sample; GetProductByID
   string order_uuid = 10; // order needing action; GetOrderByUUID
   int32 archive_id = 11; // drop / timeline being prepared; GetArchiveByID
+  int32 fitting_id = 12; // примерка — try-on session this card is about; GetFitting
+
+  // Planned start (when work SHOULD begin), the manual counterpart of due_date.
+  // The ACTUAL start (when the card first entered IN_PROGRESS) is the
+  // server-stamped Task.started_at, not this field. Unset = no planned start.
+  google.protobuf.Timestamp start_date = 13;
 }
 
 // TaskChecklistItem is one row of a task's checklist — a lightweight subtask with
@@ -106,6 +112,10 @@ message Task {
   // Orthogonal to placement — archiving does not change board/status/position.
   google.protobuf.Timestamp archived_at = 10;
   repeated TaskChecklistItem checklist = 11; // resolved checklist items, ordered by position
+  // Actual start: server-stamped the FIRST time the card enters IN_PROGRESS
+  // (never client-supplied, never cleared on later moves). Unset = the card has
+  // not been started yet. This is distinct from the planned TaskInsert.start_date.
+  google.protobuf.Timestamp started_at = 12;
 }
 
 // TaskCommentInsert is the writable payload for a comment. author is set

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -64,6 +64,7 @@ message TechCardMediaItem {
 message TechCardMediaFull {
   MediaFull media = 1;
   TechCardMediaKind kind = 2;
+  string caption = 3; // image caption / view name
 }
 
 // TechCardCallout is a numbered detail note pointing at the technical sketch.
@@ -364,46 +365,54 @@ message TechCardCostLine {
   google.type.Decimal amount = 2;
 }
 
-// TechCardColorwayCost is the computed material cost of ONE colourway (Sheet «Калькуляция»).
-// OUTPUT-ONLY (ignored on write). Per-currency buckets; no FX conversion.
+// TechCardColorwayCost is the computed cost of ONE colourway (Sheet «Калькуляция»),
+// OUTPUT-ONLY (ignored on write). Materials come from that colourway's usages; the manual
+// articles (CMT/hardware/…) are shared across colourways, so unit_cost folds them in. All
+// figures are per GARMENT except order_cost (whole run). No FX conversion.
 message TechCardColorwayCost {
   int32 colorway_index = 1; // 0-based index into TechCardInsert.colorways
-  repeated TechCardCostLine materials_total = 2; // Σ usage cost grouped by article currency
-  google.type.Decimal materials_cost = 3; // Σ in costing.currency (and currency-less)
-  google.type.Decimal size_run_total = 4; // whole-run material spend for this colourway
-  bool has_unconverted_currencies = 5; // a usage currency ≠ costing.currency → excluded from materials_cost
+  repeated TechCardCostLine materials_total = 2; // per-unit material cost grouped by article currency
+  google.type.Decimal materials_per_unit = 6; // Σ per-garment usage cost in costing.currency (and currency-less)
+  google.type.Decimal unit_cost = 7; // (materials_per_unit + shared manual articles) × (1 + defect/100), per garment
+  int32 order_qty = 8; // Σ size_quantities.order_qty (same whole-run qty for every colourway)
+  google.type.Decimal order_cost = 9; // unit_cost × order_qty
+  bool has_unconverted_currencies = 5; // a usage currency ≠ costing.currency → excluded from materials_per_unit
+  reserved 3, 4; // was materials_cost, size_run_total (superseded by the per-unit / per-order model)
 }
 
-// TechCardCosting holds the manually-entered cost articles (Sheet «Калькуляция»).
-// The materials rollup and total are COMPUTED on read from the BOM; they are
-// output-only (ignored on write) and never converted across currencies.
+// TechCardCosting holds the manually-entered per-unit cost articles (Sheet «Калькуляция»).
+// Everything is in a SINGLE currency. The materials line and the unit/order totals are
+// COMPUTED on read (output-only, ignored on write). Model: cost is built per GARMENT, then
+// scaled to the whole order by order_qty. There is NO pricing here — markup/wholesale/retail
+// were removed; pricing lives on the published product.
 message TechCardCosting {
-  google.type.Decimal cmt_cost = 1; // пошив / работа (CMT)
-  google.type.Decimal hardware_cost = 2; // фурнитура (если вне BOM)
-  google.type.Decimal packaging_cost = 3; // упаковка и маркировка
-  google.type.Decimal logistics_cost = 4; // логистика / доставка
-  google.type.Decimal overhead_cost = 5; // накладные расходы
+  // manual per-unit cost articles (per ONE garment), all in `currency`.
+  google.type.Decimal cmt_cost = 1; // пошив / работа (CMT) за 1 изделие
+  google.type.Decimal hardware_cost = 2; // фурнитура вне BOM, за 1 изделие
+  google.type.Decimal packaging_cost = 3; // упаковка и маркировка, за 1 изделие
+  google.type.Decimal logistics_cost = 4; // логистика / доставка, за 1 изделие
+  google.type.Decimal overhead_cost = 5; // накладные расходы, за 1 изделие
   google.type.Decimal defect_percent = 6; // брак / запас (%), 0..100
-  // Pricing is single (brand policy): markup_multiplier, wholesale_price, retail_price
-  // and currency are the SAME across colourways. Per-SKU pricing, if ever needed, lives
-  // on the published product, not here.
-  google.type.Decimal markup_multiplier = 7; // наценка (×)
-  google.type.Decimal wholesale_price = 8; // оптовая цена
-  google.type.Decimal retail_price = 9; // розничная цена
-  string currency = 10; // ISO 4217 for the articles above
+  string currency = 10; // ISO 4217 — the single currency for every article and total
   string notes = 11;
 
-  // OUTPUT-ONLY computed rollup (ignored on write; no currency conversion). The root
-  // rollup is the PRIMARY colourway (colorways index 0); per-colourway figures are in
-  // colorway_costs. A usage with per-size consumption contributes its whole-run
-  // size_run_total (order-scale); a usage without contributes its per-garment line_total.
-  repeated TechCardCostLine materials_total = 12; // Σ usage cost (colourway 0) grouped by article currency
-  google.type.Decimal materials_cost = 13; // Σ usage cost (colourway 0) in `currency` (and currency-less)
-  google.type.Decimal total_cost = 14; // (materials_cost + cmt_cost + hardware + packaging + logistics + overhead) × (1 + defect/100). No labour fallback.
-  bool has_unconverted_currencies = 15; // OUTPUT-ONLY: a usage line (colourway 0) is in a currency other than `currency`, so it is excluded from total_cost
-  google.type.Decimal total_sam = 16; // OUTPUT-ONLY: Σ of operation time_norm (minutes), informative
+  // OUTPUT-ONLY computed rollup (ignored on write). Root figures are the PRIMARY colourway
+  // (colorways index 0); per-colourway figures are in colorway_costs. Materials come from the
+  // BOM via each colourway's usages, normalised to a PER-GARMENT figure (a usage graded only
+  // per size is divided by order_qty), then taken in the single `currency` — a BOM line in
+  // another currency is flagged in has_unconverted_currencies and left out of materials_per_unit
+  // (it still appears in materials_total under its own currency, never silently dropped).
+  repeated TechCardCostLine materials_total = 12; // per-unit material cost (colourway 0) grouped by article currency
+  google.type.Decimal materials_per_unit = 19; // Σ per-garment material cost (colourway 0) in `currency`
+  google.type.Decimal unit_cost = 20; // (materials_per_unit + cmt + hardware + packaging + logistics + overhead) × (1 + defect/100)
+  int32 order_qty = 21; // Σ size_quantities.order_qty (the whole production run)
+  google.type.Decimal order_cost = 22; // unit_cost × order_qty
+  bool has_unconverted_currencies = 15; // a material line (colourway 0) is in a currency other than `currency`
+  google.type.Decimal total_sam = 16; // Σ operation time_norm (minutes); informative
   repeated TechCardColorwayCost colorway_costs = 18; // OUTPUT-ONLY, per colourway
-  reserved 17; // was labour_cost (OUTPUT); labour pricing removed
+
+  reserved 7, 8, 9; // pricing removed (markup_multiplier, wholesale_price, retail_price — moved to product)
+  reserved 13, 14, 17; // was materials_cost, total_cost, labour_cost (superseded / removed)
 }
 
 // TechCardInsert is the writable payload for a tech card. Nested lists are full
@@ -469,8 +478,14 @@ message TechCardInsert {
   // children (full-replace on update)
   repeated int32 size_ids = 30; // size range / grade (FK size(id))
   repeated int32 product_ids = 31; // linked catalog products (FK product(id))
-  repeated TechCardMediaItem media = 32; // sketch / preview media
-  repeated TechCardCallout callouts = 33; // sketch callouts
+  // Sketch media split into two INDEPENDENT lists (replaces the single `media = 32`):
+  //   moodboard_media — mood / inspiration / reference / fabric-swatch photos (design intent)
+  //   technical_media — flat sketches used in construction (front / back / detail / lining / preview)
+  // Construction consumes ONLY technical_media. Each item's `kind` sub-classifies within its
+  // list. Both are full-replace on update; callouts pin onto technical_media by media_id.
+  repeated TechCardMediaItem moodboard_media = 55;
+  repeated TechCardMediaItem technical_media = 56;
+  repeated TechCardCallout callouts = 33; // sketch callouts (pin onto technical_media)
   repeated TechCardRevision revisions = 34; // revision log
 
   // materials (Phase 2): bill of materials (article catalog) and colourways (recipes).
@@ -496,8 +511,9 @@ message TechCardInsert {
   repeated TechCardDetail details = 54;
 
   // Reserved so a future field can never collide with a removed one. 17-19 targets+currency;
-  // 20-28 construction-desc strings → details[]; 42 pom_points; 39 prior.
-  reserved 17 to 28, 39, 42, 55 to 99;
+  // 20-28 construction-desc strings → details[]; 32 was the single `media` list (split into
+  // moodboard_media/technical_media); 42 pom_points; 39 prior.
+  reserved 17 to 28, 32, 39, 42, 57 to 99;
 }
 
 // TechCard is a stored tech card with resolved sketch media.
@@ -506,8 +522,11 @@ message TechCard {
   TechCardInsert tech_card = 2;
   google.protobuf.Timestamp created_at = 3;
   google.protobuf.Timestamp updated_at = 4;
-  repeated TechCardMediaFull resolved_media = 5; // sketch media with resolved MediaFull
   int32 lock_version = 6; // optimistic-lock token; echo into UpdateTechCardRequest.expected_lock_version
+  // Resolved sketch media (MediaFull), split to mirror the writable lists.
+  repeated TechCardMediaFull resolved_moodboard_media = 7;
+  repeated TechCardMediaFull resolved_technical_media = 8;
+  reserved 5; // was resolved_media (single combined list; now split)
 }
 
 // TechCardListItem is a lightweight tech-card header for list views.


### PR DESCRIPTION
Five API updates (migration 0092), contract mirrored to `grbpwr-proto` main (6f4121a).

## Changes
1. **Task ← fitting + start times** — `TaskInsert.fitting_id` (typed deep-link FK), `TaskInsert.start_date` (planned, manual), `Task.started_at` (actual — server-stamped the first time the card enters `in_progress`, idempotent on re-entry).
2. **Fitting callouts** — `FittingCallout` (numbered pin + note) on fitting photos; full-replace on update like sizes/media/patterns.
3. **Tech-card media split** — sketch media split into `moodboard_media` (inspiration/reference) and `technical_media` (flat sketches for construction), via a `category` column; resolved lists split too, caption on resolved. Construction consumes only technical.
4. **Costing redo** — per-unit + per-order in a **single currency**. Materials auto-from-BOM; a per-size-only usage is normalised to per-garment then scaled by `order_qty = Σ size_quantities`. Removed the pricing block (markup/wholesale/retail → product). `ComputeTechCardUnitCost` now reads `unit_cost`, fixing an old order-scale over-count for per-size usages.

## Migration safety
`0092` drops the auto-named CHECK constraints on the removed costing columns **before** dropping the columns (MySQL refuses to drop a column referenced by a CHECK — would otherwise halt prod boot). Full `0001→0092` **Up and Down** validated on MySQL 8, plus a store integration test covering all three store paths.

## Validation
`go build ./...`, `go vet ./...`, dto/entity/apisrv unit tests, and store integration (migration + features) all green. 3-way adversarial review run; the critical migration CHECK-drop bug was found and fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6c7sm9YtEW3EN2pkAoVJr