### PR TITLE
fix(migrations): split PREPARE one-liners — repair beta deploy (0106 boot failure)

### DIFF
--- a/internal/store/sql/0106_new_flow_material_catalog_v2.sql
+++ b/internal/store/sql/0106_new_flow_material_catalog_v2.sql
@@ -21,7 +21,9 @@ SET @sql := IF(@need_cols,
         ADD COLUMN min_stock DECIMAL(12,3) NULL,
         ADD COLUMN notes TEXT NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- --- material.section: drop the auto-named CHECK, add the named, widened one ---
 SET @cname := (
@@ -35,13 +37,17 @@ SET @cname := (
         AND tc.CONSTRAINT_NAME <> 'chk_material_section'
     LIMIT 1);
 SET @sql := IF(@cname IS NULL, 'SELECT 1', CONCAT('ALTER TABLE material DROP CHECK ', @cname));
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @have := (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'material' AND CONSTRAINT_NAME = 'chk_material_section');
 SET @sql := IF(@have > 0, 'SELECT 1',
     'ALTER TABLE material ADD CONSTRAINT chk_material_section CHECK (section REGEXP ''^(fabric|lining|interlining|insulation|hardware|thread|label|packaging|trim|decoration|other)$'')');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- --- tech_card_bom_item.section: same realignment ---
 SET @cname := (
@@ -55,19 +61,25 @@ SET @cname := (
         AND tc.CONSTRAINT_NAME <> 'chk_bom_item_section'
     LIMIT 1);
 SET @sql := IF(@cname IS NULL, 'SELECT 1', CONCAT('ALTER TABLE tech_card_bom_item DROP CHECK ', @cname));
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @have := (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tech_card_bom_item' AND CONSTRAINT_NAME = 'chk_bom_item_section');
 SET @sql := IF(@have > 0, 'SELECT 1',
     'ALTER TABLE tech_card_bom_item ADD CONSTRAINT chk_bom_item_section CHECK (section REGEXP ''^(fabric|lining|interlining|insulation|hardware|thread|label|packaging|trim|decoration|other)$'')');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- index for the internal article lookup
 SET @have_idx := (SELECT COUNT(*) FROM information_schema.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'material' AND INDEX_NAME = 'idx_material_code');
 SET @sql := IF(@have_idx > 0, 'SELECT 1', 'CREATE INDEX idx_material_code ON material (code)');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 

--- a/internal/store/sql/0107_new_flow_style_idea_stage.sql
+++ b/internal/store/sql/0107_new_flow_style_idea_stage.sql
@@ -23,13 +23,17 @@ SET @cname := (
         AND tc.CONSTRAINT_NAME <> 'chk_tech_card_stage'
     LIMIT 1);
 SET @sql := IF(@cname IS NULL, 'SELECT 1', CONCAT('ALTER TABLE tech_card DROP CHECK ', @cname));
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @have := (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tech_card' AND CONSTRAINT_NAME = 'chk_tech_card_stage');
 SET @sql := IF(@have > 0, 'SELECT 1',
     'ALTER TABLE tech_card ADD CONSTRAINT chk_tech_card_stage CHECK (stage REGEXP ''^(idea|proto|fit|sms|pp|prod)$'')');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 

--- a/internal/store/sql/0108_new_flow_samples.sql
+++ b/internal/store/sql/0108_new_flow_samples.sql
@@ -34,31 +34,45 @@ CREATE TABLE IF NOT EXISTS sample (
 -- fitting.sample_id
 SET @need := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fitting' AND COLUMN_NAME = 'sample_id');
 SET @sql := IF(@need, 'ALTER TABLE fitting ADD COLUMN sample_id INT NULL', 'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 SET @need := (SELECT COUNT(*) = 0 FROM information_schema.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fitting' AND CONSTRAINT_NAME = 'fk_fitting_sample');
 SET @sql := IF(@need, 'ALTER TABLE fitting ADD CONSTRAINT fk_fitting_sample FOREIGN KEY (sample_id) REFERENCES sample(id) ON DELETE SET NULL', 'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- tech_card_dev_expense.sample_id
 SET @need := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tech_card_dev_expense' AND COLUMN_NAME = 'sample_id');
 SET @sql := IF(@need, 'ALTER TABLE tech_card_dev_expense ADD COLUMN sample_id INT NULL', 'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 SET @need := (SELECT COUNT(*) = 0 FROM information_schema.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tech_card_dev_expense' AND CONSTRAINT_NAME = 'fk_dev_expense_sample');
 SET @sql := IF(@need, 'ALTER TABLE tech_card_dev_expense ADD CONSTRAINT fk_dev_expense_sample FOREIGN KEY (sample_id) REFERENCES sample(id) ON DELETE SET NULL', 'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- task.sample_id (deep-link, continuing the tech_card/product/order/archive/fitting/production_run row)
 SET @need := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task' AND COLUMN_NAME = 'sample_id');
 SET @sql := IF(@need, 'ALTER TABLE task ADD COLUMN sample_id INT NULL', 'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 SET @need := (SELECT COUNT(*) = 0 FROM information_schema.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task' AND CONSTRAINT_NAME = 'fk_task_sample');
 SET @sql := IF(@need, 'ALTER TABLE task ADD CONSTRAINT fk_task_sample FOREIGN KEY (sample_id) REFERENCES sample(id) ON DELETE SET NULL', 'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- material_stock_movement.sample_id FK (the column was created in 0105 without an FK; sample exists now)
 SET @need := (SELECT COUNT(*) = 0 FROM information_schema.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'material_stock_movement' AND CONSTRAINT_NAME = 'fk_msm_sample');
 SET @sql := IF(@need, 'ALTER TABLE material_stock_movement ADD CONSTRAINT fk_msm_sample FOREIGN KEY (sample_id) REFERENCES sample(id) ON DELETE SET NULL', 'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 

--- a/internal/store/sql/0109_new_flow_pattern_pieces.sql
+++ b/internal/store/sql/0109_new_flow_pattern_pieces.sql
@@ -53,7 +53,9 @@ SET @need_col := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
 SET @sql := IF(@need_col,
     'ALTER TABLE tech_card_colorway_usage ADD COLUMN piece_index INT NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 

--- a/internal/store/sql/0110_new_flow_production_run_lines.sql
+++ b/internal/store/sql/0110_new_flow_production_run_lines.sql
@@ -49,7 +49,9 @@ SET @sql := IF(@need_cols,
         ADD COLUMN marker_efficiency_pct DECIMAL(5,2) NULL,
         ADD COLUMN marker_notes TEXT NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 

--- a/internal/store/sql/0111_new_flow_auxiliary_tech_card.sql
+++ b/internal/store/sql/0111_new_flow_auxiliary_tech_card.sql
@@ -20,21 +20,27 @@ SET @sql := IF(@need_cols,
         ADD COLUMN purpose VARCHAR(16) NOT NULL DEFAULT ''sellable'',
         ADD COLUMN output_material_id INT NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @need_fk := (SELECT COUNT(*) = 0 FROM information_schema.TABLE_CONSTRAINTS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tech_card' AND CONSTRAINT_NAME = 'fk_tech_card_output_material');
 SET @sql := IF(@need_fk,
     'ALTER TABLE tech_card ADD CONSTRAINT fk_tech_card_output_material FOREIGN KEY (output_material_id) REFERENCES material(id) ON DELETE SET NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @need_chk := (SELECT COUNT(*) = 0 FROM information_schema.TABLE_CONSTRAINTS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tech_card' AND CONSTRAINT_NAME = 'chk_tech_card_purpose');
 SET @sql := IF(@need_chk,
     'ALTER TABLE tech_card ADD CONSTRAINT chk_tech_card_purpose CHECK (purpose REGEXP ''^(sellable|auxiliary)$'')',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 

--- a/internal/store/sql/0113_new_flow_opex_dedup_key.sql
+++ b/internal/store/sql/0113_new_flow_opex_dedup_key.sql
@@ -25,13 +25,17 @@ SET @need_col := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
 SET @sql := IF(@need_col,
     'ALTER TABLE opex_line ADD COLUMN manual_key TINYINT AS (IF(recurring_id IS NULL, 1, NULL)) VIRTUAL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- 2) drop the label-based unique key (superseded by the two below).
 SET @has_old := (SELECT COUNT(*) FROM information_schema.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'opex_line' AND INDEX_NAME = 'uniq_opex_line');
 SET @sql := IF(@has_old > 0, 'ALTER TABLE opex_line DROP INDEX uniq_opex_line', 'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- 3) manual/aggregate dedup: (month, category, label) among manual rows only (manual_key = 1).
 SET @has_manual := (SELECT COUNT(*) FROM information_schema.STATISTICS
@@ -39,7 +43,9 @@ SET @has_manual := (SELECT COUNT(*) FROM information_schema.STATISTICS
 SET @sql := IF(@has_manual = 0,
     'ALTER TABLE opex_line ADD UNIQUE KEY uniq_opex_manual (month, category, label, manual_key)',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- 4) materialised dedup: one line per template per month, independent of label.
 SET @has_rec := (SELECT COUNT(*) FROM information_schema.STATISTICS
@@ -47,7 +53,9 @@ SET @has_rec := (SELECT COUNT(*) FROM information_schema.STATISTICS
 SET @sql := IF(@has_rec = 0,
     'ALTER TABLE opex_line ADD UNIQUE KEY uniq_opex_recurring_month (recurring_id, month)',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 
@@ -55,11 +63,15 @@ PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
 SET @has_manual := (SELECT COUNT(*) FROM information_schema.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'opex_line' AND INDEX_NAME = 'uniq_opex_manual');
 SET @sql := IF(@has_manual > 0, 'ALTER TABLE opex_line DROP INDEX uniq_opex_manual', 'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @has_rec := (SELECT COUNT(*) FROM information_schema.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'opex_line' AND INDEX_NAME = 'uniq_opex_recurring_month');
 SET @sql := IF(@has_rec > 0, 'ALTER TABLE opex_line DROP INDEX uniq_opex_recurring_month', 'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SELECT 1;

--- a/internal/store/sql/0114_new_flow_sample_media_pattern.sql
+++ b/internal/store/sql/0114_new_flow_sample_media_pattern.sql
@@ -25,7 +25,9 @@ SET @sql := IF(@need_cols,
         ADD COLUMN pattern_url VARCHAR(512) NULL,
         ADD COLUMN pattern_note VARCHAR(255) NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 

--- a/internal/store/sql/0115_new_flow_employee_registry.sql
+++ b/internal/store/sql/0115_new_flow_employee_registry.sql
@@ -31,7 +31,9 @@ SET @need_col := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
 SET @sql := IF(@need_col,
     'ALTER TABLE opex_recurring ADD COLUMN employee_id INT NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @need_fk := (SELECT COUNT(*) = 0 FROM information_schema.TABLE_CONSTRAINTS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'opex_recurring'
@@ -40,7 +42,9 @@ SET @sql := IF(@need_fk,
     'ALTER TABLE opex_recurring
         ADD CONSTRAINT fk_opex_rec_employee FOREIGN KEY (employee_id) REFERENCES employee(id) ON DELETE SET NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 
@@ -51,7 +55,9 @@ SET @has_fk := (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
 SET @sql := IF(@has_fk,
     'ALTER TABLE opex_recurring DROP FOREIGN KEY fk_opex_rec_employee',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 DROP TABLE IF EXISTS employee;
 SELECT 1;

--- a/internal/store/sql/0117_new_flow_movement_product_id.sql
+++ b/internal/store/sql/0117_new_flow_movement_product_id.sql
@@ -14,7 +14,9 @@ SET @need_col := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
 SET @sql := IF(@need_col,
     'ALTER TABLE material_stock_movement ADD COLUMN product_id INT NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @need_fk := (SELECT COUNT(*) = 0 FROM information_schema.TABLE_CONSTRAINTS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'material_stock_movement'
@@ -23,14 +25,18 @@ SET @sql := IF(@need_fk,
     'ALTER TABLE material_stock_movement
         ADD CONSTRAINT fk_msm_product FOREIGN KEY (product_id) REFERENCES product(id) ON DELETE SET NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @need_idx := (SELECT COUNT(*) = 0 FROM information_schema.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'material_stock_movement' AND INDEX_NAME = 'idx_msm_product');
 SET @sql := IF(@need_idx,
     'ALTER TABLE material_stock_movement ADD INDEX idx_msm_product (product_id)',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 
@@ -40,6 +46,8 @@ SET @has_fk := (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
 SET @sql := IF(@has_fk,
     'ALTER TABLE material_stock_movement DROP FOREIGN KEY fk_msm_product',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 -- (leaves the product_id column + index; Down is not exercised in prod automigrate)
 SELECT 1;

--- a/internal/store/sql/0118_new_flow_material_lot.sql
+++ b/internal/store/sql/0118_new_flow_material_lot.sql
@@ -37,7 +37,9 @@ SET @need_col := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
 SET @sql := IF(@need_col,
     'ALTER TABLE material_stock_movement ADD COLUMN lot_id INT NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @need_fk := (SELECT COUNT(*) = 0 FROM information_schema.TABLE_CONSTRAINTS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'material_stock_movement'
@@ -46,14 +48,18 @@ SET @sql := IF(@need_fk,
     'ALTER TABLE material_stock_movement
         ADD CONSTRAINT fk_msm_lot FOREIGN KEY (lot_id) REFERENCES material_lot(id) ON DELETE SET NULL',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 SET @need_idx := (SELECT COUNT(*) = 0 FROM information_schema.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'material_stock_movement' AND INDEX_NAME = 'idx_msm_lot');
 SET @sql := IF(@need_idx,
     'ALTER TABLE material_stock_movement ADD INDEX idx_msm_lot (lot_id)',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 -- +migrate Down
 
@@ -63,7 +69,9 @@ SET @has_fk := (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
 SET @sql := IF(@has_fk,
     'ALTER TABLE material_stock_movement DROP FOREIGN KEY fk_msm_lot',
     'SELECT 1');
-PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
 
 DROP TABLE IF EXISTS material_lot;
 -- (leaves the lot_id column; Down is not exercised in prod automigrate)


### PR DESCRIPTION
Beta deployment 1367d622 died on boot: migration 0106 hit a 1064 syntax error because sql-migrate sent the one-line `PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;` as a single multi-statement (beta DSN has no multiStatements; local test DSN does, which is why CI was green). Split all 38 occurrences across 0106-0118 into the three-line form already proven in prod (0062/0063/0066). Nothing after 0105 was applied on beta — 0106 re-runs cleanly from the top (only SETs preceded the failing line). Re-verified with a from-scratch automigrate + integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6c7sm9YtEW3EN2pkAoVJr