### PR TITLE
feat(production,techcard): run optimistic lock + stale filter + aux-badge purpose (mig 0120)

### DIFF
--- a/internal/apisrv/admin/productionrun.go
+++ b/internal/apisrv/admin/productionrun.go
@@ -62,9 +62,14 @@ func (s *Server) UpdateProductionRun(ctx context.Context, req *pb_admin.UpdatePr
 	if len(ins.Costs) > 0 {
 		dto.FoldProductionRunCostsToBase(ins.Costs, s.costingFx(ctx))
 	}
-	if err := s.repo.ProductionRuns().UpdateProductionRun(ctx, int(req.Id), ins); err != nil {
+	if err := s.repo.ProductionRuns().UpdateProductionRun(ctx, int(req.Id), ins, int(req.ExpectedLockVersion)); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "production run not found")
+		}
+		// A stale expected_lock_version means a concurrent edit — Aborted tells the client to reload and
+		// retry (mirrors UpdateTechCard) (#9).
+		if errors.Is(err, entity.ErrProductionRunConflict) {
+			return nil, status.Error(codes.Aborted, "production run was modified concurrently; reload and retry")
 		}
 		// A received/closed run is immutable; receive must go through ReceiveProductionRun; moving an
 		// open run to cancelled/closed while material is still issued to it would strand that stock
@@ -126,7 +131,7 @@ func (s *Server) ListProductionRuns(ctx context.Context, req *pb_admin.ListProdu
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	runs, total, err := s.repo.ProductionRuns().ListProductionRuns(ctx, int(req.Limit), int(req.Offset),
-		entity.ProductionRunListFilter{TechCardId: int(req.TechCardId), Status: st})
+		entity.ProductionRunListFilter{TechCardId: int(req.TechCardId), Status: st, StaleDays: int(req.StaleDays)})
 	if err != nil {
 		slog.Default().ErrorContext(ctx, "can't list production runs", slog.String("err", err.Error()))
 		return nil, status.Error(codes.Internal, "can't list production runs")

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -501,7 +501,7 @@ type (
 	// planned/received/defect grid, with the planned unit cost snapshotted at plan time.
 	ProductionRuns interface {
 		CreateProductionRun(ctx context.Context, r *entity.ProductionRunInsert) (int, error)
-		UpdateProductionRun(ctx context.Context, id int, r *entity.ProductionRunInsert) error
+		UpdateProductionRun(ctx context.Context, id int, r *entity.ProductionRunInsert, expectedLockVersion int) error
 		DeleteProductionRun(ctx context.Context, id int) error
 		GetProductionRun(ctx context.Context, id int) (*entity.ProductionRun, error)
 		ListProductionRuns(ctx context.Context, limit, offset int, filter entity.ProductionRunListFilter) ([]entity.ProductionRun, int, error)

--- a/internal/dto/productionrun.go
+++ b/internal/dto/productionrun.go
@@ -345,6 +345,7 @@ func ConvertEntityProductionRunToPb(r *entity.ProductionRun) *pb_common.Producti
 		CreatedAt:       timestamppb.New(r.CreatedAt),
 		UpdatedAt:       timestamppb.New(r.UpdatedAt),
 		Actuals:         computeProductionRunActuals(r),
+		LockVersion:     int32(r.LockVersion),
 	}
 }
 

--- a/internal/dto/techcard.go
+++ b/internal/dto/techcard.go
@@ -749,6 +749,7 @@ func ConvertEntityTechCardToListItemPb(tc *entity.TechCard) *pb_common.TechCardL
 		UpdatedAt:     timestamppb.New(tc.UpdatedAt),
 		LockVersion:   int32(tc.LockVersion),
 		PreviewUrl:    tc.PreviewURL,
+		Purpose:       string(tc.Purpose),
 	}
 }
 

--- a/internal/dto/techcard_test.go
+++ b/internal/dto/techcard_test.go
@@ -674,13 +674,17 @@ func TestConvertTechCardZeroTimestampsAreNull(t *testing.T) {
 func TestConvertEntityTechCardToListItemPb(t *testing.T) {
 	tc := &entity.TechCard{
 		Id:             5,
-		TechCardInsert: entity.TechCardInsert{StyleNumber: sql.NullString{String: "ST-003", Valid: true}, Name: "Pants", Stage: entity.TechCardStagePP},
+		TechCardInsert: entity.TechCardInsert{StyleNumber: sql.NullString{String: "ST-003", Valid: true}, Name: "Pants", Stage: entity.TechCardStagePP, Purpose: entity.TechCardPurposeAuxiliary},
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
 	}
 	li := ConvertEntityTechCardToListItemPb(tc)
 	if li.Id != 5 || li.StyleNumber != "ST-003" || li.Stage != pb_common.TechCardStage_TECH_CARD_STAGE_PP {
 		t.Errorf("list item mismatch: %+v", li)
+	}
+	// #8: purpose is surfaced on the light card so a board can badge auxiliary cards without an N+1 GetTechCard.
+	if li.Purpose != "auxiliary" {
+		t.Errorf("list item purpose = %q, want auxiliary", li.Purpose)
 	}
 }
 

--- a/internal/entity/productionrun.go
+++ b/internal/entity/productionrun.go
@@ -61,6 +61,11 @@ var ErrProductionRunConcurrentModification = errors.New("production run changed 
 // movement journal keeps the old one (g25-13). Create a new run for the other style instead.
 var ErrProductionRunCardChange = errors.New("a production run cannot move to another tech card; create a new run")
 
+// ErrProductionRunConflict is returned by UpdateProductionRun when the caller passed a positive
+// expected_lock_version that no longer matches the stored one — the run was edited concurrently
+// between the read and the save. The caller should reload and retry (mirrors ErrTechCardConflict).
+var ErrProductionRunConflict = errors.New("production run was modified concurrently; reload and retry")
+
 // ProductionRunStatus is the lifecycle state of a production run (партия). It mirrors the
 // common.ProductionRunStatus proto enum and is stored as its lowercase string in the DB.
 type ProductionRunStatus string
@@ -220,12 +225,16 @@ type ProductionRun struct {
 	MaterialMovements []MaterialMovement `db:"-"`
 	CreatedAt         time.Time          `db:"created_at"`
 	UpdatedAt         time.Time          `db:"updated_at"`
+	LockVersion       int                `db:"lock_version"` // optimistic-lock token, bumped on every update (#9)
 }
 
 // ProductionRunListFilter narrows ListProductionRuns. Zero-value fields mean "no filter".
 type ProductionRunListFilter struct {
 	TechCardId int                 // only runs of this tech card
 	Status     ProductionRunStatus // only runs in this status
+	// StaleDays > 0 restricts the result to "stale" runs — still open (planned/in_progress) and
+	// created more than StaleDays days ago, matching the stale_open_production_run dashboard alert (#10).
+	StaleDays int
 }
 
 // NetReceivedQty sums received quantities across all lines.

--- a/internal/store/economics_wave3_integration_test.go
+++ b/internal/store/economics_wave3_integration_test.go
@@ -176,7 +176,7 @@ func TestProductionRun(t *testing.T) {
 		Costs: []entity.ProductionRunCost{
 			{Kind: entity.ProductionRunCostCMT, Amount: decimal.RequireFromString("400"), Currency: "EUR", AmountBase: nd("400")},
 		},
-	}))
+	}, 0))
 	got, err = P.GetProductionRun(ctx, runID)
 	require.NoError(t, err)
 	require.Equal(t, entity.ProductionRunInProgress, got.Status)
@@ -189,7 +189,7 @@ func TestProductionRun(t *testing.T) {
 	require.Equal(t, entity.ProductionRunCostCMT, got.Costs[0].Kind)
 
 	// update of a missing run → ErrNoRows
-	err = P.UpdateProductionRun(ctx, 0, &entity.ProductionRunInsert{TechCardId: tcID, Status: entity.ProductionRunPlanned})
+	err = P.UpdateProductionRun(ctx, 0, &entity.ProductionRunInsert{TechCardId: tcID, Status: entity.ProductionRunPlanned}, 0)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 
 	// delete: run gone, grid cascades

--- a/internal/store/new_flow_marker_integration_test.go
+++ b/internal/store/new_flow_marker_integration_test.go
@@ -97,7 +97,7 @@ func TestProductionRunMarkers(t *testing.T) {
 		TechCardId: tcID, Status: entity.ProductionRunInProgress,
 		Lines:   []entity.ProductionRunLine{{SizeId: 1, PlannedQty: 20}},
 		Markers: []entity.ProductionRunMarker{{Source: entity.ProductionMarkerSourceOptitex, MarkerName: ns("M-C")}},
-	})
+	}, 0)
 	require.NoError(t, err)
 	run, err = PR.GetProductionRun(ctx, runID)
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestProductionRunMarkers(t *testing.T) {
 	err = PR.UpdateProductionRun(ctx, runID, &entity.ProductionRunInsert{
 		TechCardId: tcID, Status: entity.ProductionRunInProgress,
 		Lines: []entity.ProductionRunLine{{SizeId: 1, PlannedQty: 20}},
-	})
+	}, 0)
 	require.NoError(t, err)
 	var markerCount int
 	require.NoError(t, testDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM production_run_marker WHERE run_id = ?", runID).Scan(&markerCount))
@@ -125,7 +125,7 @@ func TestProductionRunMarkers(t *testing.T) {
 	err = PR.UpdateProductionRun(ctx, runID, &entity.ProductionRunInsert{
 		TechCardId: tc2, Status: entity.ProductionRunInProgress,
 		Lines: []entity.ProductionRunLine{{SizeId: 1, PlannedQty: 20}},
-	})
+	}, 0)
 	require.ErrorIs(t, err, entity.ErrProductionRunCardChange, "re-pointing a run to another style is refused")
 
 	// --- markers cascade-delete with the run ---
@@ -134,7 +134,7 @@ func TestProductionRunMarkers(t *testing.T) {
 		TechCardId: tcID, Status: entity.ProductionRunInProgress,
 		Lines:   []entity.ProductionRunLine{{SizeId: 1, PlannedQty: 20}},
 		Markers: []entity.ProductionRunMarker{{Source: entity.ProductionMarkerSourceManual, MarkerName: ns("M-D")}},
-	}))
+	}, 0))
 	require.NoError(t, PR.DeleteProductionRun(ctx, runID))
 	require.NoError(t, testDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM production_run_marker WHERE run_id = ?", runID).Scan(&markerCount))
 	require.Equal(t, 0, markerCount, "markers cascade-deleted with the run")

--- a/internal/store/production_run_lock_stale_integration_test.go
+++ b/internal/store/production_run_lock_stale_integration_test.go
@@ -1,0 +1,156 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/jekabolt/grbpwr-manager/internal/cache"
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProductionRunOptimisticLock covers #9: lock_version is 0 on a fresh run, bumps on every
+// UpdateProductionRun, a positive-but-stale expected_lock_version is refused with
+// ErrProductionRunConflict, the matching version succeeds, and expected=0 keeps the legacy
+// last-write-wins behaviour regardless of the stored version.
+func TestProductionRunOptimisticLock(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	cfg := *testCfg
+	cfg.Automigrate = true
+	s, err := NewForTest(ctx, cfg)
+	require.NoError(t, err)
+	defer s.Close()
+
+	di, err := s.Cache().GetDictionaryInfo(ctx)
+	require.NoError(t, err)
+	hf, err := s.Hero().GetHero(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cache.InitConsts(ctx, di, hf))
+
+	ns := func(v string) sql.NullString { return sql.NullString{String: v, Valid: true} }
+	PR := s.ProductionRuns()
+
+	tcID, err := s.TechCards().AddTechCard(ctx, &entity.TechCardInsert{
+		Name: "NF Lock Style", Stage: entity.TechCardStageProto,
+		StyleNumber: ns("NF-LOCK-1"), MeasurementUnit: entity.TechCardUnitMm, ApprovalState: entity.TechCardApprovalDraft,
+	})
+	require.NoError(t, err)
+	runID, err := PR.CreateProductionRun(ctx, &entity.ProductionRunInsert{
+		TechCardId: tcID, Status: entity.ProductionRunInProgress,
+		Lines: []entity.ProductionRunLine{{SizeId: 1, PlannedQty: 20}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cctx := context.Background()
+		_, _ = testDB.ExecContext(cctx, "DELETE FROM production_run WHERE id = ?", runID)
+		_, _ = testDB.ExecContext(cctx, "DELETE FROM tech_card WHERE id = ?", tcID)
+	})
+
+	upd := func(expected int) error {
+		return PR.UpdateProductionRun(ctx, runID, &entity.ProductionRunInsert{
+			TechCardId: tcID, Status: entity.ProductionRunInProgress,
+			Lines: []entity.ProductionRunLine{{SizeId: 1, PlannedQty: 20}},
+		}, expected)
+	}
+
+	// fresh run starts at lock_version 0.
+	run, err := PR.GetProductionRun(ctx, runID)
+	require.NoError(t, err)
+	require.Equal(t, 0, run.LockVersion, "fresh run lock_version is 0")
+
+	// expected=0 opts out of the lock and always applies; it still bumps the version.
+	require.NoError(t, upd(0))
+	run, err = PR.GetProductionRun(ctx, runID)
+	require.NoError(t, err)
+	require.Equal(t, 1, run.LockVersion, "update bumps lock_version even when opted out")
+
+	// a stale positive expected version is refused.
+	require.ErrorIs(t, upd(0+99), entity.ErrProductionRunConflict, "stale expected_lock_version is refused")
+	run, err = PR.GetProductionRun(ctx, runID)
+	require.NoError(t, err)
+	require.Equal(t, 1, run.LockVersion, "a refused update does not bump the version")
+
+	// the matching version succeeds and bumps again.
+	require.NoError(t, upd(1))
+	run, err = PR.GetProductionRun(ctx, runID)
+	require.NoError(t, err)
+	require.Equal(t, 2, run.LockVersion)
+
+	// re-using the now-stale version 1 is refused.
+	require.ErrorIs(t, upd(1), entity.ErrProductionRunConflict)
+}
+
+// TestProductionRunStaleFilter covers #10: ListProductionRuns with StaleDays>0 returns only runs
+// still open (planned/in_progress) whose created_at is older than the cutoff — the same rule as the
+// stale_open_production_run dashboard alert. A fresh open run and an old but closed run are excluded.
+func TestProductionRunStaleFilter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	cfg := *testCfg
+	cfg.Automigrate = true
+	s, err := NewForTest(ctx, cfg)
+	require.NoError(t, err)
+	defer s.Close()
+
+	di, err := s.Cache().GetDictionaryInfo(ctx)
+	require.NoError(t, err)
+	hf, err := s.Hero().GetHero(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cache.InitConsts(ctx, di, hf))
+
+	ns := func(v string) sql.NullString { return sql.NullString{String: v, Valid: true} }
+	PR := s.ProductionRuns()
+
+	tcID, err := s.TechCards().AddTechCard(ctx, &entity.TechCardInsert{
+		Name: "NF Stale Style", Stage: entity.TechCardStageProto,
+		StyleNumber: ns("NF-STALE-1"), MeasurementUnit: entity.TechCardUnitMm, ApprovalState: entity.TechCardApprovalDraft,
+	})
+	require.NoError(t, err)
+
+	mkRun := func(status entity.ProductionRunStatus) int {
+		id, err := PR.CreateProductionRun(ctx, &entity.ProductionRunInsert{
+			TechCardId: tcID, Status: status,
+			Lines: []entity.ProductionRunLine{{SizeId: 1, PlannedQty: 20}},
+		})
+		require.NoError(t, err)
+		return id
+	}
+	oldOpen := mkRun(entity.ProductionRunInProgress)  // old + open  -> stale
+	freshOpen := mkRun(entity.ProductionRunPlanned)   // new + open  -> not stale
+	oldClosed := mkRun(entity.ProductionRunInProgress) // old but will be closed -> not stale
+
+	// backdate the two "old" runs 30 days; close one of them.
+	old := time.Now().UTC().AddDate(0, 0, -30)
+	for _, id := range []int{oldOpen, oldClosed} {
+		_, err = testDB.ExecContext(ctx, "UPDATE production_run SET created_at = ? WHERE id = ?", old, id)
+		require.NoError(t, err)
+	}
+	_, err = testDB.ExecContext(ctx, "UPDATE production_run SET status = ? WHERE id = ?", string(entity.ProductionRunClosed), oldClosed)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cctx := context.Background()
+		for _, id := range []int{oldOpen, freshOpen, oldClosed} {
+			_, _ = testDB.ExecContext(cctx, "DELETE FROM production_run WHERE id = ?", id)
+		}
+		_, _ = testDB.ExecContext(cctx, "DELETE FROM tech_card WHERE id = ?", tcID)
+	})
+
+	// stale_days=7: only the old, still-open run qualifies.
+	runs, total, err := PR.ListProductionRuns(ctx, 50, 0, entity.ProductionRunListFilter{TechCardId: tcID, StaleDays: 7})
+	require.NoError(t, err)
+	require.Equal(t, 1, total, "only one stale run")
+	require.Len(t, runs, 1)
+	require.Equal(t, oldOpen, runs[0].Id)
+
+	// no stale filter: all three runs of this card are returned.
+	all, totalAll, err := PR.ListProductionRuns(ctx, 50, 0, entity.ProductionRunListFilter{TechCardId: tcID})
+	require.NoError(t, err)
+	require.Equal(t, 3, totalAll)
+	require.Len(t, all, 3)
+}

--- a/internal/store/productionrun/productionrun.go
+++ b/internal/store/productionrun/productionrun.go
@@ -96,12 +96,13 @@ func (s *Store) CreateProductionRun(ctx context.Context, r *entity.ProductionRun
 // Existence is established by the FOR UPDATE read (not by rows-affected, which is 0 for a no-op
 // header edit and would spuriously read as NotFound — the receive-v2 flow only touches line rows).
 // Returns sql.ErrNoRows when no run exists.
-func (s *Store) UpdateProductionRun(ctx context.Context, id int, r *entity.ProductionRunInsert) error {
+func (s *Store) UpdateProductionRun(ctx context.Context, id int, r *entity.ProductionRunInsert, expectedLockVersion int) error {
 	err := s.txFunc(ctx, func(ctx context.Context, rep dependency.Repository) error {
 		cur, err := storeutil.QueryNamedOne[struct {
-			Status     string `db:"status"`
-			TechCardId int    `db:"tech_card_id"`
-		}](ctx, rep.DB(), `SELECT status, tech_card_id FROM production_run WHERE id = :id FOR UPDATE`, map[string]any{"id": id})
+			Status      string `db:"status"`
+			TechCardId  int    `db:"tech_card_id"`
+			LockVersion int    `db:"lock_version"`
+		}](ctx, rep.DB(), `SELECT status, tech_card_id, lock_version FROM production_run WHERE id = :id FOR UPDATE`, map[string]any{"id": id})
 		if err != nil {
 			if err == sql.ErrNoRows {
 				return sql.ErrNoRows
@@ -113,6 +114,14 @@ func (s *Store) UpdateProductionRun(ctx context.Context, id int, r *entity.Produ
 		}
 		if r.Status == entity.ProductionRunReceived {
 			return entity.ErrProductionRunReceiveViaUpdate
+		}
+		// Optimistic lock (#9): a positive expected version that no longer matches means the run was
+		// edited concurrently — reject rather than clobber the other writer's full-replace. 0 opts out
+		// (legacy last-write-wins), so pre-existing clients are unaffected. The FOR UPDATE read above
+		// serialises this against a concurrent update, so the in-Go check is authoritative; the WHERE
+		// guard on the UPDATE is belt-and-suspenders (mirrors UpdateTechCard).
+		if expectedLockVersion > 0 && cur.LockVersion != expectedLockVersion {
+			return entity.ErrProductionRunConflict
 		}
 		// The run's style is fixed at creation: the planned-cost snapshot, the movements' denormalised
 		// tech_card_id and the style roll-ups are all anchored to it (g25-13).
@@ -130,13 +139,25 @@ func (s *Store) UpdateProductionRun(ctx context.Context, id int, r *entity.Produ
 		}
 		params := runParams(r)
 		params["id"] = id
-		if err := storeutil.ExecNamed(ctx, rep.DB(), `
+		params["expected_lock_version"] = expectedLockVersion
+		lockGuard := ""
+		if expectedLockVersion > 0 {
+			lockGuard = " AND lock_version = :expected_lock_version"
+		}
+		rows, err := storeutil.ExecNamedRows(ctx, rep.DB(), `
 			UPDATE production_run SET
+				lock_version = lock_version + 1,
 				tech_card_id = :tech_card_id, release_id = :release_id, status = :status,
 				started_at = :started_at, received_at = :received_at,
 				marker_efficiency_pct = :marker_efficiency_pct, marker_notes = :marker_notes, notes = :notes
-			WHERE id = :id`, params); err != nil {
+			WHERE id = :id`+lockGuard, params)
+		if err != nil {
 			return fmt.Errorf("failed to update production run: %w", err)
+		}
+		// The row provably exists (loaded above). With the lock guard present, 0 rows means the version
+		// moved under us — make the WHERE guard load-bearing, not just the in-Go check.
+		if expectedLockVersion > 0 && rows == 0 {
+			return entity.ErrProductionRunConflict
 		}
 		for _, tbl := range []string{"production_run_line", "production_run_cost", "production_run_marker"} {
 			if err := storeutil.ExecNamed(ctx, rep.DB(),
@@ -156,7 +177,7 @@ func (s *Store) UpdateProductionRun(ctx context.Context, id int, r *entity.Produ
 		switch err {
 		case sql.ErrNoRows, entity.ErrProductionRunReceivedImmutable,
 			entity.ErrProductionRunReceiveViaUpdate, entity.ErrProductionRunHasOpenIssues,
-			entity.ErrProductionRunCardChange:
+			entity.ErrProductionRunCardChange, entity.ErrProductionRunConflict:
 			return err
 		}
 		return fmt.Errorf("can't update production run: %w", err)
@@ -495,6 +516,15 @@ func (s *Store) ListProductionRuns(ctx context.Context, limit, offset int, filte
 	if filter.Status != "" {
 		where += " AND status = :status"
 		params["status"] = string(filter.Status)
+	}
+	// Stale attention filter (#10): still-open runs older than N days — the same rule as the
+	// stale_open_production_run dashboard alert (GetStaleOpenRunCount). Combined with an explicit
+	// status filter it just intersects (e.g. status=received + stale_days>0 yields nothing).
+	if filter.StaleDays > 0 {
+		where += " AND status IN (:staleOpenPlanned, :staleOpenInProgress) AND created_at < :staleCutoff"
+		params["staleOpenPlanned"] = string(entity.ProductionRunPlanned)
+		params["staleOpenInProgress"] = string(entity.ProductionRunInProgress)
+		params["staleCutoff"] = s.Now().AddDate(0, 0, -filter.StaleDays)
 	}
 
 	total, err := storeutil.QueryCountNamed(ctx, s.DB,

--- a/internal/store/sql/0120_production_run_lock_version.sql
+++ b/internal/store/sql/0120_production_run_lock_version.sql
@@ -1,0 +1,35 @@
+-- +migrate Up
+
+-- #9: optimistic-lock token on production_run. UpdateProductionRun is a full-replace of the run's
+-- lines/costs/markers; without a version token a list→edit→save races a concurrent edit and the last
+-- writer silently wins. lock_version is bumped on every UpdateProductionRun; a client that echoes the
+-- value it read back as UpdateProductionRunRequest.expected_lock_version gets a concurrent edit
+-- rejected (Aborted) instead of clobbered. Mirrors tech_card.lock_version.
+--
+-- DEFAULT 0 so existing rows and legacy clients (expected_lock_version = 0) keep the old
+-- last-write-wins behaviour — the guard is opt-in, so this is backward-compatible.
+--
+-- Idempotent: guarded ADD COLUMN via information_schema (a mid-file re-run must not error on the
+-- already-added column). The one-statement-per-line PREPARE/EXECUTE/DEALLOCATE form is required —
+-- managed MySQL rejects them joined on one line without multiStatements.
+
+SET @need_col := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'production_run' AND COLUMN_NAME = 'lock_version');
+SET @sql := IF(@need_col,
+    'ALTER TABLE production_run ADD COLUMN lock_version INT NOT NULL DEFAULT 0',
+    'SELECT 1');
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
+
+-- +migrate Down
+
+SET @has_col := (SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'production_run' AND COLUMN_NAME = 'lock_version');
+SET @sql := IF(@has_col,
+    'ALTER TABLE production_run DROP COLUMN lock_version',
+    'SELECT 1');
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
+SELECT 1;

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -3882,6 +3882,10 @@ message CreateProductionRunResponse {
 message UpdateProductionRunRequest {
   int32 id = 1;
   common.ProductionRunInsert run = 2;
+  // Optimistic-lock guard from GetProductionRun/list. >0 enforces the lock: a mismatch means the run
+  // changed under the editor -> Aborted (reload and retry). 0 keeps the legacy last-write-wins
+  // behaviour, so pre-existing clients are unaffected (#9).
+  int32 expected_lock_version = 3;
 }
 
 message UpdateProductionRunResponse {}
@@ -3905,6 +3909,10 @@ message ListProductionRunsRequest {
   string status = 2; // empty = all statuses
   int32 limit = 3;
   int32 offset = 4;
+  // >0: return only "stale" runs — still open (planned/in_progress) and created more than N days ago
+  // (the same rule as the stale_open_production_run dashboard alert). Server-side so the attention
+  // filter/strip does not client-scan the two status pages (#10). 0 = no staleness filter.
+  int32 stale_days = 5;
 }
 
 message ListProductionRunsResponse {

--- a/proto/common/common/production.proto
+++ b/proto/common/common/production.proto
@@ -157,4 +157,8 @@ message ProductionRun {
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp updated_at = 6;
   ProductionRunActuals actuals = 7; // computed-on-read plan/fact summary
+  // Optimistic-lock token, bumped on every UpdateProductionRun. Echo into
+  // UpdateProductionRunRequest.expected_lock_version so a list→edit needs no extra GET (mirrors
+  // TechCard.lock_version).
+  int32 lock_version = 8;
 }

--- a/proto/common/common/techcard.proto
+++ b/proto/common/common/techcard.proto
@@ -711,4 +711,7 @@ message TechCardListItem {
   // moodboard image; otherwise the PREVIEW-kind sketch (falling back to the first technical, then any
   // media). Empty when the card has no media. Resolved server-side to avoid an N+1 GetTechCard.
   string preview_url = 13;
+  // Card purpose: "sellable" (default) or "auxiliary" (NF-07). Lets a board/list badge auxiliary
+  // cards (dust bags, shoppers…) without an N+1 GetTechCard, mirroring TechCard.purpose.
+  string purpose = 14;
 }


### PR DESCRIPTION
Frontend nice-to-haves **#8/#9/#10** — the only backend code left from the forwarded list (everything urgent/blocking was already implemented and deployed in 6132857).

## #8 — `TechCardListItem.purpose`
Surface `sellable`/`auxiliary` on the light card so a board can badge aux cards (dust bags, shoppers) without an N+1 `GetTechCard`. Mirrors `TechCard.purpose`.

## #9 — ProductionRun optimistic lock
- `production_run.lock_version` (**migration 0120**, `DEFAULT 0`), bumped on every `UpdateProductionRun`.
- `UpdateProductionRunRequest.expected_lock_version` opts in: `>0` rejects a concurrent edit with **Aborted** (mirrors `UpdateTechCard`); `0` keeps the legacy last-write-wins behaviour → **pre-existing clients unaffected**.
- Emitted on `GetProductionRun`/list so a list→edit needs no extra GET.

## #10 — `ListProductionRunsRequest.stale_days`
Server-side stale attention filter: `>0` returns only runs still open (planned/in_progress) created more than N days ago — the same rule as the `stale_open_production_run` dashboard alert. Client stops scanning two status pages.

## Notes
- Migration 0120 is a guarded idempotent `ADD COLUMN` (three-line PREPARE/EXECUTE/DEALLOCATE — managed MySQL rejects the one-line form).
- `proto/gen`, mocks, swagger regenerate at build. Proto mirrored to grbpwr-proto main (`4016a8a`).
- Tests: optimistic-lock + stale-filter integration tests, purpose-emission dto test; full store/apisrv/rbac suites green (only the pre-existing `MarkSendDead` fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6c7sm9YtEW3EN2pkAoVJr