### PR TITLE
Merge beta into master: Stripe settlement detail in admin + customer order (migration 0122)

### DIFF
--- a/internal/apisrv/admin/fulfillment.go
+++ b/internal/apisrv/admin/fulfillment.go
@@ -59,8 +59,9 @@ func (s *Server) GetFulfillmentCard(ctx context.Context, req *pb_admin.GetFulfil
 		return nil, status.Errorf(codes.Internal, "can't get fulfillment card")
 	}
 	return &pb_admin.GetFulfillmentCardResponse{
-		Order:      pbOrder,
-		Annotation: dto.ConvertEntityOrderFulfillmentToPb(req.OrderUuid, ann),
+		Order:         pbOrder,
+		Annotation:    dto.ConvertEntityOrderFulfillmentToPb(req.OrderUuid, ann),
+		StripeDetails: dto.ConvertToOrderStripeDetails(orderFull),
 	}, nil
 }
 

--- a/internal/apisrv/admin/order.go
+++ b/internal/apisrv/admin/order.go
@@ -96,7 +96,8 @@ func (s *Server) GetOrderByUUID(ctx context.Context, req *pb_admin.GetOrderByUUI
 	}
 
 	return &pb_admin.GetOrderByUUIDResponse{
-		Order: oPb,
+		Order:         oPb,
+		StripeDetails: dto.ConvertToOrderStripeDetails(o),
 	}, nil
 }
 

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -138,6 +138,7 @@ type (
 		AssociatePaymentIntentWithOrder(ctx context.Context, orderUUID string, paymentIntentId string) error
 		UpdateTotalPaymentCurrency(ctx context.Context, orderUUID string, tapc decimal.Decimal) error
 		UpdateSettledBaseAndFee(ctx context.Context, orderUUID string, settledBase, paymentFee decimal.Decimal) error
+		UpdatePaymentStripeDetails(ctx context.Context, orderUUID string, d entity.StripePaymentDetails) error
 		SetTrackingNumber(ctx context.Context, orderUUID string, trackingCode string) (*entity.OrderBuyerShipment, error)
 		SetShipmentActualCost(ctx context.Context, orderUUID string, actualCost, returnShippingCost decimal.NullDecimal) error
 		GetOrderById(ctx context.Context, orderID int) (*entity.OrderFull, error)

--- a/internal/dto/payment.go
+++ b/internal/dto/payment.go
@@ -73,22 +73,75 @@ func ConvertEntityToPbPaymentInsert(p *entity.PaymentInsert) (*pb_common.Payment
 		ClientSecret:                     p.ClientSecret.String,
 		IsTransactionDone:                p.IsTransactionDone,
 		ExpiredAt:                        timestamppb.New(p.ExpiredAt.Time),
+		PaymentMethodType:                p.PaymentMethodType.String,
+		ReceiptUrl:                       p.ReceiptURL.String,
 	}, nil
+}
+
+// stripeDashboardBase is the Stripe dashboard payment path; the "/test" segment is inserted
+// for test-mode payments so the deep link opens the right account view.
+const (
+	stripeDashboardLive = "https://dashboard.stripe.com/payments/"
+	stripeDashboardTest = "https://dashboard.stripe.com/test/payments/"
+)
+
+// ConvertToOrderStripeDetails builds the admin-only settlement/Stripe view of an order from
+// the captured payment facts. It is attached to admin responses only (never to the shared
+// customer-facing order), so EUR revenue and the Stripe fee stay out of the storefront.
+// Returns nil when the order carries no Stripe settlement/detail at all (non-Stripe or
+// pre-feature), so the admin UI can simply hide the block.
+func ConvertToOrderStripeDetails(o *entity.OrderFull) *pb_common.OrderStripeDetails {
+	if o == nil {
+		return nil
+	}
+	p := o.Payment.PaymentInsert
+	hasSettled := o.Order.TotalSettledBase.Valid
+	hasDetail := p.TransactionID.Valid || p.CardBrand.Valid || p.ReceiptURL.Valid ||
+		p.PaymentMethodType.Valid || p.StripeRiskLevel.Valid
+	if !hasSettled && !hasDetail {
+		return nil
+	}
+
+	d := &pb_common.OrderStripeDetails{
+		CardBrand: p.CardBrand.String,
+		CardLast4: p.CardLast4.String,
+		RiskLevel: p.StripeRiskLevel.String,
+	}
+	if o.Order.TotalSettledBase.Valid {
+		settled := o.Order.TotalSettledBase.Decimal
+		d.TotalSettledBase = &pb_decimal.Decimal{Value: settled.String()}
+		if o.Order.PaymentFee.Valid {
+			fee := o.Order.PaymentFee.Decimal
+			d.PaymentFee = &pb_decimal.Decimal{Value: fee.String()}
+			d.NetSettledBase = &pb_decimal.Decimal{Value: settled.Sub(fee).String()}
+		}
+	}
+	if p.StripeExchangeRate.Valid {
+		d.StripeExchangeRate = &pb_decimal.Decimal{Value: p.StripeExchangeRate.Decimal.String()}
+	}
+	if p.TransactionID.Valid && p.TransactionID.String != "" {
+		base := stripeDashboardLive
+		if pm, ok := cache.GetPaymentMethodById(p.PaymentMethodID); ok && pm.Method.Name == entity.CARD_TEST {
+			base = stripeDashboardTest
+		}
+		d.StripeDashboardUrl = base + p.TransactionID.String
+	}
+	return d
 }
 
 // TODO:
 var paymentMethodToCurrency = map[pb_common.PaymentMethodNameEnum]string{
 	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_CARD:         "EUR",
 	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_CARD_TEST:    "EUR",
-	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_BANK_INVOICE:  "EUR",
-	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_CASH:          "EUR",
+	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_BANK_INVOICE: "EUR",
+	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_CASH:         "EUR",
 }
 
 var pbPaymentMethodToEntity = map[pb_common.PaymentMethodNameEnum]entity.PaymentMethodName{
 	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_CARD:         entity.CARD,
 	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_CARD_TEST:    entity.CARD_TEST,
-	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_BANK_INVOICE:  entity.BANK_INVOICE,
-	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_CASH:          entity.CASH,
+	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_BANK_INVOICE: entity.BANK_INVOICE,
+	pb_common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_CASH:         entity.CASH,
 }
 
 func ConvertPaymentMethodToCurrency(pbPaymentMethod pb_common.PaymentMethodNameEnum) string {

--- a/internal/dto/payment_stripe_details_test.go
+++ b/internal/dto/payment_stripe_details_test.go
@@ -1,0 +1,102 @@
+package dto
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+)
+
+// nd (decimal.NullDecimal from string) is shared with style_economics_test.go.
+
+func ns(s string) sql.NullString {
+	return sql.NullString{String: s, Valid: s != ""}
+}
+
+func TestConvertToOrderStripeDetails_NilWhenEmpty(t *testing.T) {
+	// No settled amount and no captured payment detail -> nothing to show.
+	of := &entity.OrderFull{}
+	if got := ConvertToOrderStripeDetails(of); got != nil {
+		t.Fatalf("expected nil for an order with no Stripe data, got %+v", got)
+	}
+	if got := ConvertToOrderStripeDetails(nil); got != nil {
+		t.Fatalf("expected nil for a nil order, got %+v", got)
+	}
+}
+
+func TestConvertToOrderStripeDetails_FullCapture(t *testing.T) {
+	of := &entity.OrderFull{}
+	of.Order.TotalSettledBase = nd("91.30")
+	of.Order.PaymentFee = nd("3.20")
+	of.Payment.PaymentInsert.TransactionID = ns("pi_test123")
+	of.Payment.PaymentInsert.CardBrand = ns("visa")
+	of.Payment.PaymentInsert.CardLast4 = ns("4242")
+	of.Payment.PaymentInsert.StripeRiskLevel = ns("normal")
+	of.Payment.PaymentInsert.StripeExchangeRate = nd("0.9130")
+
+	got := ConvertToOrderStripeDetails(of)
+	if got == nil {
+		t.Fatal("expected non-nil details")
+	}
+	if got.GetTotalSettledBase().GetValue() != "91.3" {
+		t.Errorf("settled base = %q, want 91.3", got.GetTotalSettledBase().GetValue())
+	}
+	if got.GetPaymentFee().GetValue() != "3.2" {
+		t.Errorf("fee = %q, want 3.2", got.GetPaymentFee().GetValue())
+	}
+	if got.GetNetSettledBase().GetValue() != "88.1" { // 91.30 - 3.20
+		t.Errorf("net = %q, want 88.1", got.GetNetSettledBase().GetValue())
+	}
+	if got.GetStripeExchangeRate().GetValue() != "0.913" {
+		t.Errorf("fx = %q, want 0.913", got.GetStripeExchangeRate().GetValue())
+	}
+	if got.GetCardBrand() != "visa" || got.GetCardLast4() != "4242" {
+		t.Errorf("card = %s %s, want visa 4242", got.GetCardBrand(), got.GetCardLast4())
+	}
+	if got.GetRiskLevel() != "normal" {
+		t.Errorf("risk = %q, want normal", got.GetRiskLevel())
+	}
+	// URL is built from the PaymentIntent id; live vs test prefix depends on the payment
+	// method (cache), but the id and Stripe host are always present.
+	url := got.GetStripeDashboardUrl()
+	if !strings.Contains(url, "dashboard.stripe.com") || !strings.HasSuffix(url, "pi_test123") {
+		t.Errorf("dashboard url = %q, want a stripe dashboard link ending in the PI id", url)
+	}
+}
+
+func TestConvertToOrderStripeDetails_SettledWithoutFee_NoNet(t *testing.T) {
+	// Settled captured but the fee was not: net is undefined, not zero.
+	of := &entity.OrderFull{}
+	of.Order.TotalSettledBase = nd("50.00")
+
+	got := ConvertToOrderStripeDetails(of)
+	if got == nil {
+		t.Fatal("expected non-nil details")
+	}
+	if got.GetPaymentFee() != nil {
+		t.Errorf("expected nil fee, got %v", got.GetPaymentFee())
+	}
+	if got.GetNetSettledBase() != nil {
+		t.Errorf("expected nil net when fee is absent, got %v", got.GetNetSettledBase())
+	}
+}
+
+func TestConvertToOrderStripeDetails_DetailWithoutSettled(t *testing.T) {
+	// A charge captured (card/receipt) but the balance transaction not yet settled:
+	// still surface the detail block, just without the EUR figures.
+	of := &entity.OrderFull{}
+	of.Payment.PaymentInsert.CardBrand = ns("mastercard")
+	of.Payment.PaymentInsert.ReceiptURL = ns("https://pay.stripe.com/receipts/x")
+
+	got := ConvertToOrderStripeDetails(of)
+	if got == nil {
+		t.Fatal("expected non-nil details when only charge detail is present")
+	}
+	if got.GetTotalSettledBase() != nil {
+		t.Errorf("expected nil settled base, got %v", got.GetTotalSettledBase())
+	}
+	if got.GetCardBrand() != "mastercard" {
+		t.Errorf("card brand = %q, want mastercard", got.GetCardBrand())
+	}
+}

--- a/internal/entity/order.go
+++ b/internal/entity/order.go
@@ -80,6 +80,10 @@ type Order struct {
 	// snapshot, not a settlement). NULL when not captured (pre-feature, non-Stripe,
 	// or unpaid), in which case metrics fall back to the product_price reconstruction.
 	TotalSettledBase decimal.NullDecimal `db:"total_settled_base"`
+	// PaymentFee is the Stripe processing fee for this order in the base currency (EUR),
+	// taken from the same charge balance transaction as TotalSettledBase. A real
+	// contribution-margin cost; NULL when not captured (pre-feature / non-Stripe / unpaid).
+	PaymentFee decimal.NullDecimal `db:"payment_fee"`
 	// VatRatePct is the destination-country VAT rate (percent) resolved from the
 	// shipping country and snapshotted at order time, so historical net revenue is
 	// reproducible if a rate later changes. NULL for pre-feature orders (metrics treat

--- a/internal/entity/payment.go
+++ b/internal/entity/payment.go
@@ -29,8 +29,40 @@ type PaymentInsert struct {
 	ClientSecret                     sql.NullString  `db:"client_secret"`
 	IsTransactionDone                bool            `db:"is_transaction_done"`
 	ExpiredAt                        sql.NullTime    `db:"expired_at"`
-	// PaymentMethodType is the provider's sub-method used (card, apple_pay, klarna, etc.)
+	// PaymentMethodType is the provider's sub-method used. It carries the most specific
+	// label we can derive from the Stripe charge: the card wallet (apple_pay, google_pay,
+	// link) when the card was tokenised through a wallet, otherwise the payment-method type
+	// (card, klarna, sepa_debit, ...). NULL for pre-feature / non-Stripe / uncaptured.
 	PaymentMethodType sql.NullString `db:"payment_method_type"`
+	// CardBrand / CardLast4 identify the funding card on the Stripe charge (visa, 4242).
+	// Admin-only detail for support and dispute lookups; empty for non-card methods.
+	CardBrand sql.NullString `db:"card_brand"`
+	CardLast4 sql.NullString `db:"card_last4"`
+	// ReceiptURL is Stripe's hosted receipt for the charge. Customer-facing (surfaced on the
+	// storefront order too), NULL when the charge produced no receipt (non-Stripe methods).
+	ReceiptURL sql.NullString `db:"receipt_url"`
+	// StripeExchangeRate is the presentment->settlement FX rate Stripe applied at the sale
+	// (from the charge's balance transaction). Pairs with customer_order.total_settled_base to
+	// explain a non-base-currency sale. NULL for base-currency or uncaptured payments.
+	StripeExchangeRate decimal.NullDecimal `db:"stripe_exchange_rate"`
+	// StripeRiskLevel is Stripe Radar's outcome for the charge (normal/elevated/highest),
+	// captured for manual fraud review. NULL for non-Stripe / uncaptured payments.
+	StripeRiskLevel sql.NullString `db:"stripe_risk_level"`
+}
+
+// StripePaymentDetails carries the payment-row facts captured from a succeeded Stripe charge
+// (and its balance transaction) at confirmation time. It is written best-effort after the
+// order is marked paid; see Processor.capturePaymentDetails.
+type StripePaymentDetails struct {
+	// TransactionID is the Stripe PaymentIntent id (pi_...), stored in payment.transaction_id
+	// and combined with the payment method to build the dashboard deep link.
+	TransactionID      string
+	PaymentMethodType  string
+	CardBrand          string
+	CardLast4          string
+	ReceiptURL         string
+	StripeExchangeRate decimal.NullDecimal
+	StripeRiskLevel    string
 }
 
 type PaymentMethodName string

--- a/internal/payment/stripe/payment.go
+++ b/internal/payment/stripe/payment.go
@@ -172,14 +172,8 @@ func (p *Processor) expireOrderPayment(ctx context.Context, orderUUID string) er
 
 	switch pi.Status {
 	case stripe.PaymentIntentStatusSucceeded:
-		// Fetch PaymentIntent with expanded payment_method to get sub-type (apple_pay, klarna, etc.)
-		piExpanded, expandErr := p.getPaymentIntentWithExpand(payment.ClientSecret.String, []string{"payment_method"})
-		if expandErr == nil && piExpanded.PaymentMethod != nil {
-			payment.PaymentInsert.PaymentMethodType = sql.NullString{
-				String: string(piExpanded.PaymentMethod.Type),
-				Valid:  true,
-			}
-		}
+		// The payment method type, card, receipt and settled amount are all captured from the
+		// charge in capturePaymentDetails (via updateOrderAsPaid), so no separate expand here.
 		received := AmountFromSmallestUnit(pi.AmountReceived, string(pi.Currency))
 		err = p.updateOrderAsPaid(ctx, p.rep, orderUUID, *payment, received)
 		if err != nil {
@@ -269,9 +263,10 @@ func (p *Processor) updateOrderAsPaid(ctx context.Context, rep dependency.Reposi
 
 	slog.Default().InfoContext(ctx, "Order marked as paid", slog.String("orderUUID", orderUUID))
 
-	// Capture the actual amount Stripe settled, in base currency, for accurate
-	// revenue analytics. Best effort — never blocks fulfillment.
-	p.captureSettledBase(ctx, rep, orderUUID, payment)
+	// Capture the Stripe payment detail (settled EUR + fee, PaymentIntent id, method
+	// type, card, receipt, FX rate, risk) for accurate revenue analytics and admin
+	// visibility. Best effort — never blocks fulfillment.
+	p.capturePaymentDetails(ctx, rep, orderUUID, payment)
 
 	// RELEASE RESERVATION: Free stock when payment is completed
 	if p.reservationMgr != nil {
@@ -308,53 +303,108 @@ func (p *Processor) updateOrderAsPaid(ctx context.Context, rep dependency.Reposi
 
 }
 
-// captureSettledBase records the actual amount Stripe settled for the order,
-// converted to the base currency, taken from the charge's balance transaction. The
-// Stripe account settles in the base currency (EUR), so BalanceTransaction.Amount is
-// already in base. Best effort: it never blocks fulfillment — when total_settled_base
-// stays NULL (no charge yet, or a non-base settlement), revenue metrics fall back to
-// the product_price reconstruction.
-func (p *Processor) captureSettledBase(ctx context.Context, rep dependency.Repository, orderUUID string, payment entity.Payment) {
+// capturePaymentDetails records, best-effort, the facts of a succeeded Stripe charge:
+//   - the actual amount Stripe settled in the base currency + the processing fee, from the
+//     charge's balance transaction (may lag for async methods; guarded);
+//   - the PaymentIntent id, payment method / wallet, card brand+last4, hosted receipt URL,
+//     FX rate and Radar risk level, all read from the charge (present as soon as the PI
+//     succeeds), so the admin can see and deep-link the payment without re-hitting Stripe.
+//
+// It never blocks fulfilment: when total_settled_base stays NULL (no balance transaction yet,
+// or a non-base settlement), revenue metrics fall back to the product_price reconstruction.
+// This is the single capture point for every confirmation path (webhook, expiry monitor, lazy
+// CheckForTransactions), so the payment method type is populated on all of them.
+func (p *Processor) capturePaymentDetails(ctx context.Context, rep dependency.Repository, orderUUID string, payment entity.Payment) {
 	if !payment.ClientSecret.Valid || payment.ClientSecret.String == "" {
 		return
 	}
 	pi, err := p.getPaymentIntentWithExpand(payment.ClientSecret.String, []string{"latest_charge.balance_transaction"})
 	if err != nil {
-		slog.Default().ErrorContext(ctx, "settled-base: can't fetch payment intent",
+		slog.Default().ErrorContext(ctx, "capture-payment: can't fetch payment intent",
 			slog.String("orderUUID", orderUUID), slog.String("err", err.Error()))
 		return
 	}
-	if pi.LatestCharge == nil || pi.LatestCharge.BalanceTransaction == nil {
-		slog.Default().WarnContext(ctx, "settled-base: no balance transaction on charge yet",
+	ch := pi.LatestCharge
+	if ch == nil {
+		slog.Default().WarnContext(ctx, "capture-payment: no charge on succeeded payment intent yet",
 			slog.String("orderUUID", orderUUID))
 		return
 	}
-	bt := pi.LatestCharge.BalanceTransaction
+
+	// Charge-level detail (available as soon as the PI succeeds). Persisted to the payment row.
+	details := entity.StripePaymentDetails{
+		TransactionID:     pi.ID,
+		PaymentMethodType: paymentMethodLabel(ch),
+		ReceiptURL:        ch.ReceiptURL,
+	}
+	if pmd := ch.PaymentMethodDetails; pmd != nil && pmd.Card != nil {
+		details.CardBrand = string(pmd.Card.Brand)
+		details.CardLast4 = pmd.Card.Last4
+	}
+	if ch.Outcome != nil {
+		details.StripeRiskLevel = ch.Outcome.RiskLevel
+	}
+
+	// Settlement figures (base currency) from the balance transaction. It may not exist yet
+	// for async settlement — capture the charge detail regardless and only write settled/fee
+	// (and the FX rate) when the balance transaction is present and settles in the base ccy.
 	baseCurrency := cache.GetBaseCurrency()
-	// The balance transaction settles in the Stripe account's payout currency, which
-	// we require to equal the base currency. If Stripe ever settles in another
-	// currency, skip rather than store a non-base amount as if it were base.
-	if !strings.EqualFold(string(bt.Currency), baseCurrency) {
-		slog.Default().ErrorContext(ctx, "settled-base: Stripe settlement currency != base currency; skipping capture",
-			slog.String("orderUUID", orderUUID),
-			slog.String("settlement_currency", string(bt.Currency)),
-			slog.String("base_currency", baseCurrency))
-		return
+	var settledCaptured bool
+	var settledBase, paymentFee decimal.Decimal
+	if bt := ch.BalanceTransaction; bt != nil {
+		if strings.EqualFold(string(bt.Currency), baseCurrency) {
+			settledBase = AmountFromSmallestUnit(bt.Amount, baseCurrency)
+			// Stripe keeps the fee even on refunds, so this is the full fee actually paid.
+			paymentFee = AmountFromSmallestUnit(bt.Fee, baseCurrency)
+			settledCaptured = true
+			if bt.ExchangeRate != 0 {
+				details.StripeExchangeRate = decimal.NullDecimal{
+					Decimal: decimal.NewFromFloat(bt.ExchangeRate),
+					Valid:   true,
+				}
+			}
+		} else {
+			slog.Default().ErrorContext(ctx, "capture-payment: Stripe settlement currency != base currency; skipping settled capture",
+				slog.String("orderUUID", orderUUID),
+				slog.String("settlement_currency", string(bt.Currency)),
+				slog.String("base_currency", baseCurrency))
+		}
+	} else {
+		slog.Default().WarnContext(ctx, "capture-payment: no balance transaction on charge yet; settled base left NULL",
+			slog.String("orderUUID", orderUUID))
 	}
-	settledBase := AmountFromSmallestUnit(bt.Amount, baseCurrency)
-	// The processing fee rides on the same balance transaction (same base currency, already
-	// expanded above), so capture it here for free. Stripe keeps the fee even on refunds, so
-	// it is the full fee actually paid — a real contribution-margin cost.
-	paymentFee := AmountFromSmallestUnit(bt.Fee, baseCurrency)
-	if err := rep.Order().UpdateSettledBaseAndFee(ctx, orderUUID, settledBase, paymentFee); err != nil {
-		slog.Default().ErrorContext(ctx, "settled-base: can't persist",
+
+	if err := rep.Order().UpdatePaymentStripeDetails(ctx, orderUUID, details); err != nil {
+		slog.Default().ErrorContext(ctx, "capture-payment: can't persist payment detail",
 			slog.String("orderUUID", orderUUID), slog.String("err", err.Error()))
-		return
 	}
-	slog.Default().InfoContext(ctx, "settled-base captured",
+	if settledCaptured {
+		if err := rep.Order().UpdateSettledBaseAndFee(ctx, orderUUID, settledBase, paymentFee); err != nil {
+			slog.Default().ErrorContext(ctx, "capture-payment: can't persist settled base and fee",
+				slog.String("orderUUID", orderUUID), slog.String("err", err.Error()))
+		}
+	}
+	slog.Default().InfoContext(ctx, "payment detail captured",
 		slog.String("orderUUID", orderUUID),
+		slog.String("payment_intent_id", pi.ID),
+		slog.String("method_type", details.PaymentMethodType),
+		slog.Bool("settled_captured", settledCaptured),
 		slog.String("amount_base", settledBase.String()),
 		slog.String("payment_fee_base", paymentFee.String()))
+}
+
+// paymentMethodLabel returns the most specific label for how a charge was paid: the card
+// wallet (apple_pay, google_pay, link, ...) when the card was tokenised through a wallet,
+// otherwise the payment-method type on the charge (card, klarna, sepa_debit, ...).
+func paymentMethodLabel(ch *stripe.Charge) string {
+	pmd := ch.PaymentMethodDetails
+	if pmd == nil {
+		return ""
+	}
+	if pmd.Card != nil && pmd.Card.Wallet != nil && pmd.Card.Wallet.Type != "" {
+		return string(pmd.Card.Wallet.Type)
+	}
+	return string(pmd.Type)
 }
 
 // flagUnderpaidForReview records a persistent, admin-visible marker on the order

--- a/internal/payment/stripe/webhook.go
+++ b/internal/payment/stripe/webhook.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -128,11 +127,8 @@ func (p *Processor) confirmPaymentFromWebhook(ctx context.Context, pi *stripe.Pa
 		return fmt.Errorf("can't get payment for order %s: %w", orderUUID, err)
 	}
 
-	// Capture the payment method sub-type (apple_pay, klarna, ...) when available.
-	if piExpanded, expErr := p.getPaymentIntentWithExpand(payment.ClientSecret.String, []string{"payment_method"}); expErr == nil && piExpanded.PaymentMethod != nil {
-		payment.PaymentInsert.PaymentMethodType = sql.NullString{String: string(piExpanded.PaymentMethod.Type), Valid: true}
-	}
-
+	// The payment method type, card, receipt and settled amount are captured from the charge
+	// in capturePaymentDetails (via updateOrderAsPaid), shared by every confirmation path.
 	received := AmountFromSmallestUnit(pi.AmountReceived, string(pi.Currency))
 	if err := p.updateOrderAsPaid(ctx, p.rep, orderUUID, *payment, received); err != nil {
 		// Underpaid: order stays AwaitingPayment (flagged for review). Acknowledge

--- a/internal/store/order/fetch.go
+++ b/internal/store/order/fetch.go
@@ -315,7 +315,13 @@ func paymentsByOrderIds(ctx context.Context, db dependency.DB, orderIds []int) (
 		payment.is_transaction_done,
 		payment.created_at,
 		payment.modified_at,
-		payment.expired_at
+		payment.expired_at,
+		payment.payment_method_type,
+		payment.card_brand,
+		payment.card_last4,
+		payment.receipt_url,
+		payment.stripe_exchange_rate,
+		payment.stripe_risk_level
 	FROM payment
 	JOIN customer_order ON payment.order_id = customer_order.id
 	WHERE customer_order.id IN (:orderIds)`

--- a/internal/store/order/payment.go
+++ b/internal/store/order/payment.go
@@ -239,6 +239,45 @@ func (s *Store) UpdateSettledBaseAndFee(ctx context.Context, orderUUID string, s
 	return nil
 }
 
+// nullStr maps an empty string to a NULL column value so uncaptured Stripe fields stay NULL
+// rather than being written as empty strings.
+func nullStr(s string) sql.NullString {
+	return sql.NullString{String: s, Valid: s != ""}
+}
+
+// UpdatePaymentStripeDetails records the payment-row facts captured from a succeeded Stripe
+// charge (PaymentIntent id, method type, card, receipt, FX rate, risk). Written best-effort
+// after the order is confirmed; see Processor.capturePaymentDetails. Only overwrites a field
+// when a value was captured, so a later partial re-capture never blanks an earlier one.
+func (s *Store) UpdatePaymentStripeDetails(ctx context.Context, orderUUID string, d entity.StripePaymentDetails) error {
+	query := `
+	UPDATE payment p
+	JOIN customer_order co ON p.order_id = co.id
+	SET p.transaction_id        = COALESCE(:transactionId, p.transaction_id),
+	    p.payment_method_type    = COALESCE(:paymentMethodType, p.payment_method_type),
+	    p.card_brand             = COALESCE(:cardBrand, p.card_brand),
+	    p.card_last4             = COALESCE(:cardLast4, p.card_last4),
+	    p.receipt_url            = COALESCE(:receiptUrl, p.receipt_url),
+	    p.stripe_exchange_rate   = COALESCE(:exchangeRate, p.stripe_exchange_rate),
+	    p.stripe_risk_level      = COALESCE(:riskLevel, p.stripe_risk_level)
+	WHERE co.uuid = :orderUUID`
+
+	err := storeutil.ExecNamed(ctx, s.DB, query, map[string]any{
+		"transactionId":     nullStr(d.TransactionID),
+		"paymentMethodType": nullStr(d.PaymentMethodType),
+		"cardBrand":         nullStr(d.CardBrand),
+		"cardLast4":         nullStr(d.CardLast4),
+		"receiptUrl":        nullStr(d.ReceiptURL),
+		"exchangeRate":      d.StripeExchangeRate,
+		"riskLevel":         nullStr(d.StripeRiskLevel),
+		"orderUUID":         orderUUID,
+	})
+	if err != nil {
+		return fmt.Errorf("can't update payment stripe details: %w", err)
+	}
+	return nil
+}
+
 // shouldReconcileLoyaltyEUR reports whether the order's loyalty snapshot (total_price_eur)
 // should be collapsed onto the settled base at capture. It returns true only when a snapshot
 // exists and sits within settledEURReconcileTolerance of settledBase. A missing snapshot, a

--- a/internal/store/sql/0122_payment_stripe_details.sql
+++ b/internal/store/sql/0122_payment_stripe_details.sql
@@ -1,0 +1,75 @@
+-- +migrate Up
+
+-- Enrich the payment row with the Stripe payment detail captured from the charge and its
+-- balance transaction at confirmation time, so the admin panel can show what was actually
+-- paid without re-hitting the Stripe API on every order view:
+--   * card_brand / card_last4      — the funding card (support, dispute lookup)
+--   * receipt_url                  — Stripe-hosted receipt (also surfaced to the customer)
+--   * stripe_exchange_rate         — presentment->settlement FX Stripe applied at the sale;
+--                                    pairs with customer_order.total_settled_base to explain a
+--                                    non-EUR sale ("$100 -> EUR 91.30 @ 0.9130")
+--   * stripe_risk_level            — Stripe Radar outcome (normal/elevated/highest) for review
+-- The Stripe PaymentIntent id itself is stored in the existing payment.transaction_id column
+-- (previously only populated for manual/custom orders); combined with the payment method it
+-- yields the dashboard deep link. All nullable and best-effort: NULL for pre-feature orders,
+-- non-Stripe methods, or when the balance transaction was not yet available at capture.
+--
+-- Idempotent: each ADD COLUMN is guarded via information_schema so a mid-file failure (DDL
+-- auto-commits, no gorp_migrations row) re-runs cleanly. Multi-line PREPARE/EXECUTE/DEALLOCATE
+-- (a single-line form returns 1064 on the managed DSN).
+
+SET @need := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'payment' AND COLUMN_NAME = 'card_brand');
+SET @sql := IF(@need,
+    'ALTER TABLE payment ADD COLUMN card_brand VARCHAR(20) NULL COMMENT ''Funding card brand (visa, mastercard, amex...) from the Stripe charge''',
+    'SELECT 1');
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
+
+SET @need := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'payment' AND COLUMN_NAME = 'card_last4');
+SET @sql := IF(@need,
+    'ALTER TABLE payment ADD COLUMN card_last4 VARCHAR(4) NULL COMMENT ''Last 4 digits of the funding card''',
+    'SELECT 1');
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
+
+SET @need := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'payment' AND COLUMN_NAME = 'receipt_url');
+SET @sql := IF(@need,
+    'ALTER TABLE payment ADD COLUMN receipt_url VARCHAR(512) NULL COMMENT ''Stripe-hosted receipt URL for the charge''',
+    'SELECT 1');
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
+
+SET @need := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'payment' AND COLUMN_NAME = 'stripe_exchange_rate');
+SET @sql := IF(@need,
+    'ALTER TABLE payment ADD COLUMN stripe_exchange_rate DECIMAL(18, 8) NULL COMMENT ''Presentment->settlement FX rate Stripe applied at the sale''',
+    'SELECT 1');
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
+
+SET @need := (SELECT COUNT(*) = 0 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'payment' AND COLUMN_NAME = 'stripe_risk_level');
+SET @sql := IF(@need,
+    'ALTER TABLE payment ADD COLUMN stripe_risk_level VARCHAR(20) NULL COMMENT ''Stripe Radar risk level (normal/elevated/highest)''',
+    'SELECT 1');
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;
+
+-- +migrate Down
+
+SET @has := (SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'payment' AND COLUMN_NAME = 'card_brand');
+SET @sql := IF(@has,
+    'ALTER TABLE payment DROP COLUMN card_brand, DROP COLUMN card_last4, DROP COLUMN receipt_url, DROP COLUMN stripe_exchange_rate, DROP COLUMN stripe_risk_level',
+    'SELECT 1');
+PREPARE s FROM @sql;
+EXECUTE s;
+DEALLOCATE PREPARE s;

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -1410,6 +1410,9 @@ message GetOrderByUUIDRequest {
 
 message GetOrderByUUIDResponse {
   common.OrderFull order = 1;
+  // stripe_details holds admin-only settlement/Stripe metadata (EUR received, fee,
+  // FX rate, card, dashboard link) not present on the customer-facing order.
+  common.OrderStripeDetails stripe_details = 2;
 }
 
 message SetTrackingNumberRequest {
@@ -2304,6 +2307,9 @@ message GetFulfillmentCardRequest {
 message GetFulfillmentCardResponse {
   common.OrderFull order = 1; // full order detail
   common.FulfillmentAnnotation annotation = 2; // assignee / notes / checklist
+  // stripe_details holds admin-only settlement/Stripe metadata (EUR received, fee,
+  // FX rate, card, dashboard link) not present on the customer-facing order.
+  common.OrderStripeDetails stripe_details = 3;
 }
 
 message SetFulfillmentAssigneeRequest {

--- a/proto/common/common/payment.proto
+++ b/proto/common/common/payment.proto
@@ -22,6 +22,35 @@ message PaymentInsert {
   string client_secret = 5;
   bool is_transaction_done = 6;
   google.protobuf.Timestamp expired_at = 7;
+  // payment_method_type is the most specific label for how the customer paid:
+  // the card wallet (apple_pay, google_pay, link) when tokenised through a wallet,
+  // otherwise the payment-method type (card, klarna, ...). Empty when uncaptured.
+  string payment_method_type = 8;
+  // receipt_url is Stripe's hosted receipt for the charge (customer-facing). Empty
+  // for non-Stripe methods or when no receipt was produced.
+  string receipt_url = 9;
+}
+
+// OrderStripeDetails carries admin-only financial and Stripe metadata for an order.
+// It is NOT part of the customer-facing order (kept off common.Order/common.Payment,
+// which the storefront shares) and is attached only to admin responses. All amounts
+// are in the base currency (EUR); fields are empty when not captured.
+message OrderStripeDetails {
+  // total_settled_base is the actual amount Stripe settled in the base currency (EUR)
+  // at Stripe's FX rate — the authoritative "how much we received" figure.
+  google.type.Decimal total_settled_base = 1;
+  // payment_fee is the Stripe processing fee (EUR) from the same balance transaction.
+  google.type.Decimal payment_fee = 2;
+  // net_settled_base = total_settled_base - payment_fee (EUR), what actually reached us.
+  google.type.Decimal net_settled_base = 3;
+  // stripe_exchange_rate is the presentment->settlement FX rate Stripe applied at the sale.
+  google.type.Decimal stripe_exchange_rate = 4;
+  string card_brand = 5; // visa, mastercard, amex, ...
+  string card_last4 = 6;
+  string risk_level = 7; // Stripe Radar outcome: normal / elevated / highest
+  // stripe_dashboard_url deep-links to the payment in the Stripe dashboard (test vs live
+  // resolved from the order's payment method). Empty when the PaymentIntent id is unknown.
+  string stripe_dashboard_url = 8;
 }
 
 enum PaymentMethodNameEnum {


### PR DESCRIPTION
Promotes the Stripe settlement-detail feature to prod. Verified on beta (deploy ACTIVE, /readyz 200 — migration 0122 applied cleanly on boot).

Surfaces the already-captured multi-currency EUR settlement plus the rest of the Stripe payment facts:
- **Admin** (`OrderStripeDetails`, admin-only): EUR received (`total_settled_base`), Stripe fee, net, FX rate, card brand+last4, Radar risk level, Stripe dashboard deep link (test/live from the payment method).
- **Customer order** (shared `PaymentInsert`): payment method type (Apple Pay / Google Pay / card / klarna …, now distinguishing wallets) + Stripe receipt URL.

Capture consolidated into `capturePaymentDetails` (one charge fetch, runs on every confirmation path). Migration **0122** adds `payment.card_brand/card_last4/receipt_url/stripe_exchange_rate/stripe_risk_level` (idempotent, information_schema-guarded); PaymentIntent id reuses `payment.transaction_id`. EUR revenue/fee kept off `common.Order`/`Payment` so they never reach the storefront.

Proto mirrored in grbpwr-proto#1. See PR #45 for the full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6c7sm9YtEW3EN2pkAoVJr