### PR TITLE
chore(opex): remove the superseded legacy UpsertOpexEntries API

### DIFF
--- a/internal/apisrv/admin/metrics.go
+++ b/internal/apisrv/admin/metrics.go
@@ -912,28 +912,11 @@ func (s *Server) UpsertChannelSpend(ctx context.Context, req *pb_admin.UpsertCha
 	return &pb_admin.UpsertChannelSpendResponse{}, nil
 }
 
-// UpsertOpexEntries records the fixed-cost (OPEX) journal that feeds the dashboard operating
-// result (task 22). Month/category/amount are validated and normalised in dto; upsert is on
-// (month, category).
-func (s *Server) UpsertOpexEntries(ctx context.Context, req *pb_admin.UpsertOpexEntriesRequest) (*pb_admin.UpsertOpexEntriesResponse, error) {
-	rows, err := dto.ConvertPbOpexEntriesToEntity(req.GetEntries())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	if len(rows) == 0 {
-		return &pb_admin.UpsertOpexEntriesResponse{}, nil
-	}
-	if err := s.repo.Metrics().UpsertOpexEntries(ctx, rows); err != nil {
-		slog.Default().ErrorContext(ctx, "can't upsert opex entries", slog.String("err", err.Error()))
-		return nil, status.Errorf(codes.Internal, "can't upsert opex entries")
-	}
-	return &pb_admin.UpsertOpexEntriesResponse{}, nil
-}
-
 // UpsertOpexLines writes OPEX line items (NF-08), folding each amount into base currency via the
 // costing FX before storage. OPEX figures are confidential cost data, so — like dev expenses — the
-// detailed line API is gated by costing:write on top of the analytics section (the legacy aggregate
-// UpsertOpexEntries stays analytics-only for backward compatibility).
+// detailed line API is gated by costing:write on top of the analytics section. It supersedes the
+// removed legacy aggregate UpsertOpexEntries (one lump sum per month/category); the '(aggregate)'
+// rows that API wrote survive in opex_line and are still summed, with the double-count guard intact.
 func (s *Server) UpsertOpexLines(ctx context.Context, req *pb_admin.UpsertOpexLinesRequest) (*pb_admin.UpsertOpexLinesResponse, error) {
 	if _, write := s.costingAccess(ctx); !write {
 		return nil, status.Error(codes.PermissionDenied, "costing:write is required to edit OPEX lines")

--- a/internal/betaseed/rpc_gen.go
+++ b/internal/betaseed/rpc_gen.go
@@ -11,7 +11,7 @@ import (
 
 var _ = context.Background
 
-// ---- admin (222 rpc) ----
+// ---- admin (221 rpc) ----
 
 func (c *Client) AddArchive(ctx context.Context, in *admin.AddArchiveRequest) (*admin.AddArchiveResponse, error) {
 	out := new(admin.AddArchiveResponse)
@@ -1712,14 +1712,6 @@ func (c *Client) UpsertEmployee(ctx context.Context, in *admin.UpsertEmployeeReq
 func (c *Client) UpsertInventoryTargets(ctx context.Context, in *admin.UpsertInventoryTargetsRequest) (*admin.UpsertInventoryTargetsResponse, error) {
 	out := new(admin.UpsertInventoryTargetsResponse)
 	if err := c.call(ctx, "POST", "/api/admin/metrics/inventory/targets/upsert", in, out); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *Client) UpsertOpexEntries(ctx context.Context, in *admin.UpsertOpexEntriesRequest) (*admin.UpsertOpexEntriesResponse, error) {
-	out := new(admin.UpsertOpexEntriesResponse)
-	if err := c.call(ctx, "POST", "/api/admin/metrics/opex/upsert", in, out); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -385,10 +385,6 @@ type (
 		// thresholds behind the dashboard alerts (alert_setting table).
 		GetAlertThresholds(ctx context.Context) (entity.AlertThresholds, error)
 		UpsertAlertThresholds(ctx context.Context, t entity.AlertThresholds) error
-		// UpsertOpexEntries writes the fixed-cost (OPEX) journal used by the dashboard
-		// operating result (opex_entry table), upserting on (month, category). NF-08: it also
-		// mirrors each aggregate into opex_line as an '(aggregate)' base-currency line.
-		UpsertOpexEntries(ctx context.Context, rows []entity.OpexEntry) error
 		// UpsertOpexLines writes OPEX line items (opex_line, NF-08), upserting on
 		// (month, category, label). AmountBase is folded to base currency by the caller.
 		UpsertOpexLines(ctx context.Context, rows []entity.OpexLineInsert) error

--- a/internal/dto/metrics.go
+++ b/internal/dto/metrics.go
@@ -1840,48 +1840,6 @@ func ConvertPbChannelSpendToEntity(list []*pb_admin.ChannelSpendInsert) ([]entit
 	return out, nil
 }
 
-// ConvertPbOpexEntriesToEntity validates and normalises OPEX journal lines (task 22): the month
-// is snapped to the first of its month, the category is checked against the closed set, and the
-// amount must be a non-negative base-currency figure.
-func ConvertPbOpexEntriesToEntity(list []*pb_admin.OpexEntryInsert) ([]entity.OpexEntry, error) {
-	out := make([]entity.OpexEntry, 0, len(list))
-	for _, e := range list {
-		if e == nil {
-			continue
-		}
-		m, err := time.Parse("2006-01-02", e.Month)
-		if err != nil {
-			return nil, fmt.Errorf("invalid opex month %q: %w", e.Month, err)
-		}
-		m = time.Date(m.Year(), m.Month(), 1, 0, 0, 0, 0, time.UTC) // first of the month
-		category := strings.TrimSpace(e.Category)
-		if _, ok := entity.ValidOpexCategories[category]; !ok {
-			return nil, fmt.Errorf("invalid opex category %q", category)
-		}
-		amount := shopspring.Zero
-		if e.Amount != nil && e.Amount.Value != "" {
-			amount, err = shopspring.NewFromString(e.Amount.Value)
-			if err != nil {
-				return nil, fmt.Errorf("invalid opex amount %q: %w", e.Amount.Value, err)
-			}
-		}
-		if amount.IsNegative() {
-			return nil, fmt.Errorf("opex amount must be >= 0")
-		}
-		note := sql.NullString{}
-		if s := strings.TrimSpace(e.Note); s != "" {
-			note = sql.NullString{String: s, Valid: true}
-		}
-		out = append(out, entity.OpexEntry{
-			Month:    m,
-			Category: category,
-			Amount:   amount.Round(2),
-			Note:     note,
-		})
-	}
-	return out, nil
-}
-
 // ConvertCustomerSegmentationToPb converts AOV customer segments to protobuf.
 func ConvertCustomerSegmentationToPb(rows []entity.CustomerSegmentRow) []*pb_admin.CustomerSegmentRow {
 	result := make([]*pb_admin.CustomerSegmentRow, len(rows))

--- a/internal/entity/metrics.go
+++ b/internal/entity/metrics.go
@@ -1306,15 +1306,6 @@ type ChannelSettledRow struct {
 	NewCustomers   int64           `db:"new_customers"`
 }
 
-// OpexEntry is one fixed-cost (OPEX) line: an amount for a category in a given month, base
-// currency (task 22). Feeds the dashboard operating result (contribution − OPEX − marketing).
-type OpexEntry struct {
-	Month    time.Time       `db:"month"` // first day of the month
-	Category string          `db:"category"`
-	Amount   decimal.Decimal `db:"amount"`
-	Note     sql.NullString  `db:"note"`
-}
-
 // ValidOpexCategories is the closed set of OPEX categories (validated in dto rather than a DB
 // CHECK, so the set can evolve without a migration). marketing spend is deliberately NOT here —
 // it lives in channel_spend and is subtracted separately, so ROAS and the operating result

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -204,7 +204,6 @@ var methodRequirements = map[string]Requirement{
 	"GetChannelRoasSettled":  rd(SectionAnalytics),
 	"UpsertInventoryTargets": wr(SectionAnalytics),
 	"UpsertChannelSpend":     wr(SectionAnalytics),
-	"UpsertOpexEntries":      wr(SectionAnalytics),
 	// OPEX v2 detailed line/recurring APIs (NF-08). Classified under analytics like the legacy
 	// aggregate; the handlers additionally gate on costing:* (writes → PermissionDenied, reads →
 	// empty) because the figures are confidential cost data. SectionCosting itself is field-shaping

--- a/internal/store/economics_wave5_integration_test.go
+++ b/internal/store/economics_wave5_integration_test.go
@@ -213,22 +213,28 @@ func TestOpexOperatingResult(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, cache.InitConsts(ctx, di, hf))
 
-	// April 2027: a distinctive, order-free window. Clean the opex rows we own, then upsert.
+	// April 2027: a distinctive, order-free window. Clean the opex_line rows we own, then upsert via
+	// UpsertOpexLines (the legacy aggregate UpsertOpexEntries API was removed; the dashboard sums
+	// opex_line by amount_base regardless of label).
 	aprStart := time.Date(2027, 4, 1, 0, 0, 0, 0, time.UTC)
 	mayStart := time.Date(2027, 5, 1, 0, 0, 0, 0, time.UTC)
-	_, _ = testDB.ExecContext(ctx, "DELETE FROM opex_entry WHERE month = ?", aprStart.Format("2006-01-02"))
+	_, _ = testDB.ExecContext(ctx, "DELETE FROM opex_line WHERE month = ?", aprStart.Format("2006-01-02"))
 	defer func() {
-		_, _ = testDB.ExecContext(ctx, "DELETE FROM opex_entry WHERE month = ?", aprStart.Format("2006-01-02"))
+		_, _ = testDB.ExecContext(ctx, "DELETE FROM opex_line WHERE month = ?", aprStart.Format("2006-01-02"))
 	}()
 
-	require.NoError(t, s.Metrics().UpsertOpexEntries(ctx, []entity.OpexEntry{
-		{Month: aprStart, Category: "salaries", Amount: decimal.RequireFromString("1000.00")},
-		{Month: aprStart, Category: "rent", Amount: decimal.RequireFromString("500.00")},
+	opexLine := func(cat, amt string) entity.OpexLineInsert {
+		a := decimal.RequireFromString(amt)
+		return entity.OpexLineInsert{
+			Month: aprStart, Category: cat, Label: "test", Amount: a,
+			Currency: cache.GetBaseCurrency(), AmountBase: decimal.NullDecimal{Decimal: a, Valid: true},
+		}
+	}
+	require.NoError(t, s.Metrics().UpsertOpexLines(ctx, []entity.OpexLineInsert{
+		opexLine("salaries", "1000.00"), opexLine("rent", "500.00"),
 	}))
-	// Upsert on (month, category): re-writing salaries changes the amount, not the row count.
-	require.NoError(t, s.Metrics().UpsertOpexEntries(ctx, []entity.OpexEntry{
-		{Month: aprStart, Category: "salaries", Amount: decimal.RequireFromString("1200.00")},
-	}))
+	// Upsert on (month, category, label): re-writing salaries changes the amount, not the row count.
+	require.NoError(t, s.Metrics().UpsertOpexLines(ctx, []entity.OpexLineInsert{opexLine("salaries", "1200.00")}))
 	// April total = 1200 + 500 = 1700.
 
 	// Full April → OPEX fully attributed; no orders → contribution 0; operating result = −1700 − marketing.
@@ -251,7 +257,7 @@ func TestOpexOperatingResult(t *testing.T) {
 	// A month with no OPEX recorded → caveat set, zero OPEX.
 	julStart := time.Date(2027, 7, 1, 0, 0, 0, 0, time.UTC)
 	augStart := time.Date(2027, 8, 1, 0, 0, 0, 0, time.UTC)
-	_, _ = testDB.ExecContext(ctx, "DELETE FROM opex_entry WHERE month = ?", julStart.Format("2006-01-02"))
+	_, _ = testDB.ExecContext(ctx, "DELETE FROM opex_line WHERE month = ?", julStart.Format("2006-01-02"))
 	none, err := s.Metrics().GetDashboard(ctx, julStart, augStart, 10)
 	require.NoError(t, err)
 	require.True(t, none.OpexTotal.IsZero(), "no OPEX rows → zero total")

--- a/internal/store/metrics/opex.go
+++ b/internal/store/metrics/opex.go
@@ -6,53 +6,16 @@ import (
 	"time"
 
 	"github.com/jekabolt/grbpwr-manager/internal/cache"
-	"github.com/jekabolt/grbpwr-manager/internal/entity"
 	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
 	"github.com/shopspring/decimal"
 	"strings"
 )
 
-// UpsertOpexEntries writes fixed-cost (OPEX) journal lines, one amount per (month, category),
-// upserting on the UNIQUE (month, category) key (task 22). Callers pass base-currency amounts;
-// category validity is enforced in dto before this point.
-//
-// NF-08: the dashboard now reads opex_line, so each aggregate is mirrored there as a base-currency
-// line labelled '(aggregate)' (the same label migration 0112 backfilled). opex_entry is kept in sync
-// for rollback safety. The '(aggregate)' label keeps this old lump API disjoint from per-item lines
-// entered via UpsertOpexLines — the two never collide on the (month, category, label) key.
-func (s *Store) UpsertOpexEntries(ctx context.Context, rows []entity.OpexEntry) error {
-	lines := make([]entity.OpexLineInsert, 0, len(rows))
-	for _, r := range rows {
-		if err := storeutil.ExecNamed(ctx, s.DB, `
-			INSERT INTO opex_entry (month, category, amount, note)
-			VALUES (:month, :category, :amount, :note)
-			ON DUPLICATE KEY UPDATE amount = VALUES(amount), note = VALUES(note)`,
-			map[string]any{
-				"month":    r.Month.Format("2006-01-02"),
-				"category": r.Category,
-				"amount":   r.Amount,
-				"note":     r.Note,
-			}); err != nil {
-			return fmt.Errorf("upsert opex %s/%s: %w", r.Month.Format("2006-01"), r.Category, err)
-		}
-		lines = append(lines, entity.OpexLineInsert{
-			Month:      r.Month,
-			Category:   r.Category,
-			Label:      opexAggregateLabel,
-			Amount:     r.Amount,
-			Currency:   strings.ToUpper(cache.GetBaseCurrency()),
-			AmountBase: decimal.NullDecimal{Decimal: r.Amount, Valid: true},
-			Note:       r.Note,
-		})
-	}
-	if err := s.UpsertOpexLines(ctx, lines); err != nil {
-		return fmt.Errorf("mirror opex aggregate to opex_line: %w", err)
-	}
-	return nil
-}
-
-// opexAggregateLabel is the reserved label for base-currency aggregates written by the legacy
-// UpsertOpexEntries API (and backfilled from opex_entry by migration 0112).
+// opexAggregateLabel is the reserved label for base-currency aggregates that the (now removed) legacy
+// UpsertOpexEntries API wrote into opex_line, and that migration 0112 backfilled from opex_entry. The
+// write path is gone, but existing '(aggregate)' rows are still read/summed by getOpexForPeriod, and
+// the double-count guard below still flags any (month, category) that carries both an aggregate and
+// itemised NF-08 lines.
 const opexAggregateLabel = "(aggregate)"
 
 // opexPeriod is the OPEX read for a dashboard period: the pro-rated total plus two independent

--- a/internal/store/new_flow_opex_integration_test.go
+++ b/internal/store/new_flow_opex_integration_test.go
@@ -92,19 +92,6 @@ func TestOpexV2(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, lines, 1)
 
-	// --- legacy aggregate mirrors into opex_line as '(aggregate)' ---
-	require.NoError(t, mtr.UpsertOpexEntries(ctx, []entity.OpexEntry{{
-		Month: opexMonth(2029, time.July), Category: "rent", Amount: decimal.RequireFromString("1200"),
-	}}))
-	agg, err := mtr.ListOpexLines(ctx, entity.OpexLineFilter{
-		MonthFrom: opexMonth(2029, time.July), MonthTo: opexMonth(2029, time.July), Category: "rent",
-	})
-	require.NoError(t, err)
-	require.Len(t, agg, 1)
-	require.Equal(t, "(aggregate)", agg[0].Label)
-	require.True(t, agg[0].AmountBase.Valid)
-	require.Equal(t, "1200", agg[0].AmountBase.Decimal.String())
-
 	// --- recurring template materialisation ---
 	// Materialisation now folds each month at the FX rate effective THAT month, read from
 	// costing_fx_rate (no rates param). Seed test-only currencies so we don't perturb real rates

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -528,15 +528,6 @@ service AdminService {
     };
   }
 
-  // UpsertOpexEntries records the fixed-cost (OPEX) journal — one amount per month per category,
-  // base currency — feeding the dashboard operating result (task 22). Upserts on (month, category).
-  rpc UpsertOpexEntries(UpsertOpexEntriesRequest) returns (UpsertOpexEntriesResponse) {
-    option (google.api.http) = {
-      post: "/api/admin/metrics/opex/upsert"
-      body: "*"
-    };
-  }
-
   // UpsertOpexLines writes OPEX line items (NF-08) — each with its own currency (folded to base) and
   // a label — upserting on (month, category, label). Requires costing:write.
   rpc UpsertOpexLines(UpsertOpexLinesRequest) returns (UpsertOpexLinesResponse) {
@@ -4607,20 +4598,6 @@ message UpsertChannelSpendRequest {
 }
 
 message UpsertChannelSpendResponse {}
-
-// OpexEntryInsert is one fixed-cost line: an amount for a category in a month, base currency (task 22).
-message OpexEntryInsert {
-  string month = 1; // any date in the target month, YYYY-MM-DD; normalised to the first of the month server-side
-  string category = 2; // salaries | rent | software | marketing_other | production_content | other
-  google.type.Decimal amount = 3; // base currency (EUR), >= 0
-  string note = 4;
-}
-
-message UpsertOpexEntriesRequest {
-  repeated OpexEntryInsert entries = 1;
-}
-
-message UpsertOpexEntriesResponse {}
 
 // OpexLineInsert is one operating-expense line item (NF-08). Amount is in `currency`; it is folded
 // to the base currency server-side via the manual costing FX rates (left uncosted, and excluded


### PR DESCRIPTION
`UpsertOpexEntries` (task 22 — one lump amount per month/category) is fully superseded by the itemised `UpsertOpexLines` (NF-08).

## Why it's safe to remove
A repo grep of **admin-client `master`** (the deployed prod admin) shows **zero non-generated** references to `UpsertOpexEntries` / `opex/upsert` — only the dead generated client stub. No live screen calls it. (The `PackagingBomTab` screen, by contrast, DOES use the packaging-bom shims, so those are **kept** — this PR touches OPEX only.)

## What's removed
RPC + request/response messages + `OpexEntryInsert` (proto), the handler, the dto converter, `entity.OpexEntry`, the store mirror method, the `dependency.Metrics` method, the RBAC entry, and the betaseed wrapper (regenerated).

This also removes the **double-count source**: the legacy method mirrored each aggregate into `opex_line` as an `'(aggregate)'` row, which double-counted when the same (month, category) also had itemised lines.

## Deliberately KEPT (no historical-data rewrite)
`opexAggregateLabel` + the double-count guard in `getOpexForPeriod`: existing `'(aggregate)'` rows (backfilled by migration 0112) are **still summed** into the dashboard, and the guard still flags any month carrying both an aggregate and itemised lines. The `opex_entry` table stays (its drop is a separate later migration).

## Tests
`economics_wave5` `TestOpexOperatingResult` now writes OPEX via `UpsertOpexLines` (the dashboard sums `opex_line` by `amount_base` regardless of label); `new_flow_opex` drops the legacy-aggregate-mirror assertions. `go build ./...` + `go vet` clean (store tests compile-checked, run in CI).

## ⚠️ Breaking
`POST /api/admin/metrics/opex/upsert` now 404s. No known external caller; the replacement is `POST /api/admin/metrics/opex/lines/upsert`. The admin frontend's generated client should be regenerated to drop the dead stub (cosmetic — nothing calls it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)