### PR TITLE
accounting: fix utf8mb3 collation error in source_key lookup (beta hotfix)

### DIFF
--- a/internal/store/accounting/orderfacts.go
+++ b/internal/store/accounting/orderfacts.go
@@ -89,7 +89,7 @@ func (s *Store) ListUnpostedReceivedRuns(ctx context.Context, startDate time.Tim
 		SELECT r.id FROM production_run r
 		WHERE r.received_at IS NOT NULL AND r.received_at >= :start_date
 		  AND NOT EXISTS (SELECT 1 FROM acct_journal_entry e
-		                  WHERE e.source_type = 'production_receive' AND e.source_key = CAST(r.id AS CHAR) COLLATE utf8mb4_unicode_ci)
+		                  WHERE e.source_type = 'production_receive' AND e.source_key = CAST(r.id AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_unicode_ci)
 		ORDER BY r.received_at, r.id
 		LIMIT :limit`, map[string]any{"start_date": startDate.UTC(), "limit": limit})
 	if err != nil {

--- a/internal/store/accounting/periods.go
+++ b/internal/store/accounting/periods.go
@@ -104,7 +104,7 @@ func (s *Store) ClosePeriod(ctx context.Context, month time.Time, adminUsername 
 		SELECT COUNT(*) FROM production_run r
 		WHERE r.received_at >= :from AND r.received_at < :to
 		  AND NOT EXISTS (SELECT 1 FROM acct_journal_entry e
-		                  WHERE e.source_type = 'production_receive' AND e.source_key = CAST(r.id AS CHAR) COLLATE utf8mb4_unicode_ci)`,
+		                  WHERE e.source_type = 'production_receive' AND e.source_key = CAST(r.id AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_unicode_ci)`,
 		map[string]any{"from": from, "to": to})
 	if err != nil {
 		return fmt.Errorf("accounting: close period unposted runs: %w", err)

--- a/internal/store/accounting/reconcile.go
+++ b/internal/store/accounting/reconcile.go
@@ -373,7 +373,7 @@ func (s *Store) reconPending(ctx context.Context, fromStr, toStr string, fromT, 
 		SELECT r.id FROM production_run r
 		WHERE r.received_at >= :from AND r.received_at < :to
 		  AND NOT EXISTS (SELECT 1 FROM acct_journal_entry e
-		                  WHERE e.source_type = 'production_receive' AND e.source_key = CAST(r.id AS CHAR) COLLATE utf8mb4_unicode_ci)
+		                  WHERE e.source_type = 'production_receive' AND e.source_key = CAST(r.id AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_unicode_ci)
 		ORDER BY r.received_at, r.id
 		LIMIT :topN`,
 		map[string]any{"from": fromT, "to": toT, "topN": reconTopN})
@@ -391,7 +391,7 @@ func (s *Store) reconPending(ctx context.Context, fromStr, toStr string, fromT, 
 		SELECT COUNT(*) FROM production_run r
 		WHERE r.received_at >= :from AND r.received_at < :to
 		  AND NOT EXISTS (SELECT 1 FROM acct_journal_entry e
-		                  WHERE e.source_type = 'production_receive' AND e.source_key = CAST(r.id AS CHAR) COLLATE utf8mb4_unicode_ci)`,
+		                  WHERE e.source_type = 'production_receive' AND e.source_key = CAST(r.id AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_unicode_ci)`,
 		map[string]any{"from": fromT, "to": toT})
 	if err != nil {
 		return entity.AcctReconBlock{}, fmt.Errorf("accounting: recon pending run count: %w", err)


### PR DESCRIPTION
Beta smoke test surfaced Error 1253 — the acctposting worker failed every tick because `CAST(r.id AS CHAR) COLLATE utf8mb4_unicode_ci` is invalid on the prod/beta `charset=utf8` (utf8mb3) connection. Force the CAST result to utf8mb4 (`CAST(r.id AS CHAR CHARACTER SET utf8mb4)`) so the collation is valid on any connection charset. Verified against a unicode_ci column over an utf8mb3 connection; all 4 accounting integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtsdhHrFwpUgtQ5zMPYwPC