### PR TITLE
betaseed: cover all 5 VAT regimes + verify worker/return coverage

### DIFF
--- a/internal/betaseed/accounting.go
+++ b/internal/betaseed/accounting.go
@@ -3,6 +3,7 @@ package betaseed
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -94,6 +95,11 @@ func (s *Seeder) SeedAccounting(ctx context.Context) (*AccountingResult, error) 
 	if err := s.proveAccounting(ctx, r); err != nil {
 		return r, err
 	}
+
+	// Best-effort read-back of the WORKER's operational postings + the VAT returns (never fails the
+	// phase — those entries lag a full seed on the ~1m ticker).
+	s.logf("=== SeedAccounting: operational coverage ===")
+	s.verifyOperationalCoverage(ctx, r)
 	return r, nil
 }
 
@@ -302,4 +308,93 @@ func (s *Seeder) proveAccounting(ctx context.Context, r *AccountingResult) error
 	}
 	s.logf("  ACCEPTANCE PASSED: balanced ledger, %d non-zero accounts, %d journal entries in range", nonZero, entries)
 	return nil
+}
+
+// ---------------------------------------------------------------- 6. operational coverage (worker)
+
+// verifyOperationalCoverage is a best-effort read-back of the accounting WORKER's output. The
+// acctposting worker posts order_sale / order_refund / opex_month / material_* / production_receive
+// entries from the operational facts the other phases seed, on its ~1m ticker — so they lag a full
+// seed rather than appearing synchronously with it. This step polls the ledger for a bounded window
+// for the worker's (non-manual) entries, buckets them by source_type, then reads the JPK_VAT + OSS
+// returns and logs per-regime coverage so a full seed leaves a visibly complete accounting picture.
+//
+// It NEVER fails the phase: on a standalone --only=accounting run (no orders) or a still-warming worker
+// it simply logs what is (not yet) covered, with guidance to re-check shortly. The real gate stays the
+// balanced-ledger acceptance above.
+func (s *Seeder) verifyOperationalCoverage(ctx context.Context, r *AccountingResult) {
+	now := time.Now().UTC()
+	from := now.AddDate(0, 0, -60).Format("2006-01-02")
+	to := now.AddDate(0, 0, 1).Format("2006-01-02")
+
+	// Poll up to ~90s (worker interval ~1m) for the worker's first order_sale to land.
+	bySource := map[string]int{}
+	const attempts = 6
+	for a := 0; a < attempts; a++ {
+		lj, err := s.C.ListJournalEntries(ctx, &admin.ListJournalEntriesRequest{From: from, To: to, Limit: 1000})
+		if err != nil {
+			r.warn(s, "coverage: ListJournalEntries: %v", err)
+			return
+		}
+		bySource = map[string]int{}
+		for _, e := range lj.GetEntries() {
+			st := e.GetSourceType()
+			if st == "" {
+				st = "(none)"
+			}
+			bySource[st]++
+		}
+		if bySource["order_sale"] > 0 {
+			break
+		}
+		if a < attempts-1 {
+			s.logf("  coverage: no order_sale posted yet (worker ~1m) — waiting… [%d/%d]", a+1, attempts)
+			time.Sleep(15 * time.Second)
+		}
+	}
+	s.logf("  ledger entries by source_type: %s", fmtCounts(bySource))
+	operational := 0
+	for st, n := range bySource {
+		if st != "manual" && st != "(none)" {
+			operational += n
+		}
+	}
+	if operational == 0 {
+		r.warn(s, "coverage: no worker (operational) entries yet — order_sale/opex/material postings lag the seed (~1m); re-run `--only=accounting` shortly to confirm")
+	}
+
+	// JPK_VAT (this month): output VAT by regime (pl_domestic / uk_stock) + the wdt / export net bases —
+	// non-zero values here prove the worker posted order_sale across the regimes the orders exercise.
+	month := now.Format("2006-01-02")
+	if v, err := s.C.GetVatReturnPL(ctx, &admin.GetVatReturnPLRequest{Month: month}); err != nil {
+		r.warn(s, "coverage: GetVatReturnPL(%s): %v", month, err)
+	} else {
+		s.logf("  JPK_VAT[%s]: output_domestic=%.2f output_uk_stock=%.2f oss_info=%.2f net_wdt=%.2f net_export=%.2f net_payable=%.2f",
+			month, decFloat(v.GetOutputDomestic()), decFloat(v.GetOutputUkStockDomestic()), decFloat(v.GetOssInfoTotal()),
+			decFloat(v.GetNetWdt()), decFloat(v.GetNetExport()), decFloat(v.GetNetPayable()))
+	}
+	// OSS (this quarter): EU B2C destination VAT breakdown (vat_regime=oss).
+	if o, err := s.C.GetOssReturn(ctx, &admin.GetOssReturnRequest{Quarter: month}); err != nil {
+		r.warn(s, "coverage: GetOssReturn(%s): %v", month, err)
+	} else {
+		s.logf("  OSS[quarter of %s]: rows=%d total_net=%.2f total_vat=%.2f",
+			month, len(o.GetRows()), decFloat(o.GetTotalNet()), decFloat(o.GetTotalVat()))
+	}
+}
+
+// fmtCounts renders a source_type -> count map as a stable "k=v" list (sorted by key).
+func fmtCounts(m map[string]int) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", k, m[k]))
+	}
+	if len(parts) == 0 {
+		return "(none)"
+	}
+	return strings.Join(parts, " ")
 }

--- a/internal/betaseed/analytics.go
+++ b/internal/betaseed/analytics.go
@@ -40,6 +40,8 @@ type AnalyticsResult struct {
 	OrdersCancelled         int
 	OrdersTotal             int
 	OrdersOnCostPriced      int            // subset placed on the PLM cost-priced style (MARGIN/COGS)
+	OrdersWdt               int            // B2B EU≠PL orders with a buyer VAT id (wdt / reverse charge)
+	OrdersUkStock           int            // CASH orders (uk_stock_domestic regime)
 	CountriesUsed           map[string]int // shipping country -> net-revenue order count (GEOGRAPHY)
 
 	// Part 3 — fulfillment board.
@@ -483,17 +485,88 @@ func (s *Seeder) seedOrderVolume(ctx context.Context, pool []analyticsProduct, p
 	}
 	s.logf("  cancelled (storefront): %d/%d created", cxMade, cancelledN)
 
-	r.OrdersTotal = r.OrdersDelivered + r.OrdersShipped + r.OrdersConfirmed +
-		r.OrdersPartiallyRefunded + r.OrdersAwaitingPayment + r.OrdersCancelled
-	s.logf("  VOLUME TOTAL: %d orders (delivered=%d shipped=%d confirmed=%d partial_refund=%d awaiting=%d cancelled=%d; cost-priced=%d)",
-		r.OrdersTotal, r.OrdersDelivered, r.OrdersShipped, r.OrdersConfirmed,
-		r.OrdersPartiallyRefunded, r.OrdersAwaitingPayment, r.OrdersCancelled, r.OrdersOnCostPriced)
+	// --- VAT-regime coverage: wdt (B2B EU≠PL, buyer VAT id) + uk_stock_domestic (CASH) ---
+	// The country spread above already exercises oss (B2C EU≠PL), pl_domestic (PL) and export
+	// (US/JP/GB). These two extra buckets close the remaining regimes so the accounting worker posts
+	// order_sale across all five vat_regime values — and so the wdt/reverse-charge invoice path (buyer
+	// VAT id → 4310 wholesale revenue, 0% reverse charge) has real data. Delivered so they settle.
+	wdtN := s.scaleN(1, 2, 4)
+	wdtMade := 0
+	for i := 0; i < wdtN; i++ {
+		p := pickProduct(seq)
+		v := p.variants[seq%len(p.variants)]
+		price := s.orderPrice(p, seq)
+		dest := []string{"DE", "FR"}[seq%2] // EU, ≠PL → wdt when a matching-country VAT id is present
+		seq++
+		uuid, used, err := s.anCreateOrderOpt(ctx, []*common.CustomOrderItemInsert{
+			{Quantity: 1, VariantId: int64(v.VariantID), CustomPrice: price},
+		}, dest, custEmail(), anCreateOrderOpts{buyerVatID: fmt.Sprintf("%s%09d", dest, 100000000+seq)})
+		if err != nil {
+			r.warn(s, "wdt order %d (%s): %v", i, p.label, err)
+			continue
+		}
+		if _, err := s.C.SetTrackingNumber(ctx, &admin.SetTrackingNumberRequest{OrderUuid: uuid, TrackingCode: fmt.Sprintf("AN-%s-wdt-%03d", s.Run, i)}); err != nil {
+			r.warn(s, "wdt SetTrackingNumber(%s): %v", uuid, err)
+		}
+		if _, err := s.C.DeliveredOrder(ctx, &admin.DeliveredOrderRequest{OrderUuid: uuid}); err != nil {
+			r.warn(s, "wdt DeliveredOrder(%s): %v", uuid, err)
+		}
+		r.OrdersWdt++
+		r.CountriesUsed[used]++
+		if p.costPriced {
+			r.OrdersOnCostPriced++
+		}
+		wdtMade++
+	}
+	s.logf("  wdt (B2B reverse-charge): %d/%d created", wdtMade, wdtN)
 
-	netRevenueOrders := r.OrdersDelivered + r.OrdersShipped + r.OrdersConfirmed + r.OrdersPartiallyRefunded
+	ukN := s.scaleN(1, 2, 3)
+	ukMade := 0
+	for i := 0; i < ukN; i++ {
+		p := pickProduct(seq)
+		v := p.variants[seq%len(p.variants)]
+		price := s.orderPrice(p, seq)
+		seq++
+		// CASH → uk_stock_domestic regardless of destination; keep DE for a served region.
+		_, used, err := s.anCreateOrderOpt(ctx, []*common.CustomOrderItemInsert{
+			{Quantity: 1, VariantId: int64(v.VariantID), CustomPrice: price},
+		}, "DE", custEmail(), anCreateOrderOpts{cash: true})
+		if err != nil {
+			r.warn(s, "uk_stock (cash) order %d (%s): %v", i, p.label, err)
+			continue
+		}
+		r.OrdersUkStock++
+		r.CountriesUsed[used]++
+		if p.costPriced {
+			r.OrdersOnCostPriced++
+		}
+		ukMade++
+	}
+	s.logf("  uk_stock_domestic (cash): %d/%d created", ukMade, ukN)
+
+	r.OrdersTotal = r.OrdersDelivered + r.OrdersShipped + r.OrdersConfirmed +
+		r.OrdersPartiallyRefunded + r.OrdersAwaitingPayment + r.OrdersCancelled +
+		r.OrdersWdt + r.OrdersUkStock
+	s.logf("  VOLUME TOTAL: %d orders (delivered=%d shipped=%d confirmed=%d partial_refund=%d awaiting=%d cancelled=%d wdt=%d uk_stock=%d; cost-priced=%d)",
+		r.OrdersTotal, r.OrdersDelivered, r.OrdersShipped, r.OrdersConfirmed,
+		r.OrdersPartiallyRefunded, r.OrdersAwaitingPayment, r.OrdersCancelled,
+		r.OrdersWdt, r.OrdersUkStock, r.OrdersOnCostPriced)
+
+	netRevenueOrders := r.OrdersDelivered + r.OrdersShipped + r.OrdersConfirmed +
+		r.OrdersPartiallyRefunded + r.OrdersWdt + r.OrdersUkStock
 	if netRevenueOrders == 0 {
 		return fmt.Errorf("no net-revenue orders created (delivered/shipped/confirmed/partial-refund all 0)")
 	}
 	return nil
+}
+
+// anCreateOrderOpts carries optional VAT-regime overrides for a seeded custom order. Zero value =
+// the default B2C bank_invoice order. buyerVatID (non-empty) makes the order B2B — for an EU≠PL
+// destination the resolver classifies it wdt (intra-community reverse charge). cash switches the
+// payment method to CASH, which the resolver classifies uk_stock_domestic regardless of destination.
+type anCreateOrderOpts struct {
+	buyerVatID string
+	cash       bool
 }
 
 // anCreateOrder places one admin custom order (bank_invoice -> born Confirmed). It
@@ -501,15 +574,27 @@ func (s *Seeder) seedOrderVolume(ctx context.Context, pool []analyticsProduct, p
 // region, falls back to DE so the order (and its revenue) still lands. Returns the
 // order uuid and the country actually used.
 func (s *Seeder) anCreateOrder(ctx context.Context, items []*common.CustomOrderItemInsert, country, email string) (uuid, used string, err error) {
+	return s.anCreateOrderOpt(ctx, items, country, email, anCreateOrderOpts{})
+}
+
+// anCreateOrderOpt is anCreateOrder with VAT-regime overrides (buyer_vat_id / cash payment). A cash
+// order keeps its requested country (uk_stock_domestic ignores destination); a bank_invoice order
+// still falls back to DE if the carrier does not serve the region, so the order always lands.
+func (s *Seeder) anCreateOrderOpt(ctx context.Context, items []*common.CustomOrderItemInsert, country, email string, o anCreateOrderOpts) (uuid, used string, err error) {
+	pm := common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_BANK_INVOICE
+	if o.cash {
+		pm = common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_CASH
+	}
 	mk := func(cc string) (string, error) {
 		resp, e := s.C.CreateCustomOrder(ctx, &admin.CreateCustomOrderRequest{
 			Items:             items,
 			ShippingAddress:   seedAddrIn(cc),
 			BillingAddress:    seedAddrIn(cc),
 			Buyer:             &common.BuyerInsert{FirstName: "Ana", LastName: "Lytics", Email: email, Phone: "+49301230000"},
-			PaymentMethod:     common.PaymentMethodNameEnum_PAYMENT_METHOD_NAME_ENUM_BANK_INVOICE,
+			PaymentMethod:     pm,
 			ShipmentCarrierId: s.carrierID(),
 			Currency:          "eur",
+			BuyerVatId:        o.buyerVatID,
 		})
 		if e != nil {
 			return "", e

--- a/internal/betaseed/rpc_gen.go
+++ b/internal/betaseed/rpc_gen.go
@@ -11,7 +11,7 @@ import (
 
 var _ = context.Background
 
-// ---- admin (237 rpc) ----
+// ---- admin (242 rpc) ----
 
 func (c *Client) AddArchive(ctx context.Context, in *admin.AddArchiveRequest) (*admin.AddArchiveResponse, error) {
 	out := new(admin.AddArchiveResponse)
@@ -773,6 +773,14 @@ func (c *Client) GetOrderReviewsPaged(ctx context.Context, in *admin.GetOrderRev
 	return out, nil
 }
 
+func (c *Client) GetOssReturn(ctx context.Context, in *admin.GetOssReturnRequest) (*admin.GetOssReturnResponse, error) {
+	out := new(admin.GetOssReturnResponse)
+	if err := c.call(ctx, "GET", "/api/admin/accounting/reports/oss-return", in, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *Client) GetProductReviewsPaged(ctx context.Context, in *admin.GetProductReviewsPagedRequest) (*admin.GetProductReviewsPagedResponse, error) {
 	out := new(admin.GetProductReviewsPagedResponse)
 	if err := c.call(ctx, "GET", "/api/admin/product/{product_id}/reviews", in, out); err != nil {
@@ -949,6 +957,14 @@ func (c *Client) GetVatRates(ctx context.Context, in *admin.GetVatRatesRequest) 
 	return out, nil
 }
 
+func (c *Client) GetVatReturnPL(ctx context.Context, in *admin.GetVatReturnPLRequest) (*admin.GetVatReturnPLResponse, error) {
+	out := new(admin.GetVatReturnPLResponse)
+	if err := c.call(ctx, "GET", "/api/admin/accounting/reports/vat-return", in, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *Client) HardEraseMember(ctx context.Context, in *admin.HardEraseMemberRequest) (*admin.HardEraseMemberResponse, error) {
 	out := new(admin.HardEraseMemberResponse)
 	if err := c.call(ctx, "POST", "/api/admin/members/{user_id}/erase", in, out); err != nil {
@@ -984,6 +1000,14 @@ func (c *Client) ListAccounts(ctx context.Context, in *admin.ListAccountsRequest
 func (c *Client) ListAcctAccounts(ctx context.Context, in *admin.ListAcctAccountsRequest) (*admin.ListAcctAccountsResponse, error) {
 	out := new(admin.ListAcctAccountsResponse)
 	if err := c.call(ctx, "GET", "/api/admin/accounting/accounts", in, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) ListAcctEventsNeedingReview(ctx context.Context, in *admin.ListAcctEventsNeedingReviewRequest) (*admin.ListAcctEventsNeedingReviewResponse, error) {
+	out := new(admin.ListAcctEventsNeedingReviewResponse)
+	if err := c.call(ctx, "GET", "/api/admin/accounting/events/needs-review", in, out); err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -1381,9 +1405,25 @@ func (c *Client) ReopenAcctPeriod(ctx context.Context, in *admin.ReopenAcctPerio
 	return out, nil
 }
 
+func (c *Client) ReprocessAcctEvent(ctx context.Context, in *admin.ReprocessAcctEventRequest) (*admin.ReprocessAcctEventResponse, error) {
+	out := new(admin.ReprocessAcctEventResponse)
+	if err := c.call(ctx, "POST", "/api/admin/accounting/events/reprocess", in, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *Client) ResetAccountPassword(ctx context.Context, in *admin.ResetAccountPasswordRequest) (*admin.ResetAccountPasswordResponse, error) {
 	out := new(admin.ResetAccountPasswordResponse)
 	if err := c.call(ctx, "PUT", "/api/admin/accounts/{username}/password", in, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *Client) ResolveAcctEvent(ctx context.Context, in *admin.ResolveAcctEventRequest) (*admin.ResolveAcctEventResponse, error) {
+	out := new(admin.ResolveAcctEventResponse)
+	if err := c.call(ctx, "POST", "/api/admin/accounting/events/resolve", in, out); err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -2184,4 +2224,3 @@ func (c *Client) SFVerifyAccountMagicLink(ctx context.Context, in *frontend.Veri
 	}
 	return out, nil
 }
-


### PR DESCRIPTION
Closes the accounting-coverage gap in the beta seeder: orders were all B2C bank_invoice, so only **oss / pl_domestic / export** regimes occurred. **wdt** (B2B intra-community reverse charge) and **uk_stock_domestic** (cash) never happened — so the worker never posted their order_sale, and the JPK_VAT/OSS returns + the reverse-charge invoice path had no data.

- `anCreateOrderOpt`: optional `buyer_vat_id` (B2B → wdt for EU≠PL dest) + cash payment (→ uk_stock_domestic).
- analytics orders: **wdt** bucket (B2B, buyer VAT id, DE/FR, delivered) + **cash** bucket (uk_stock_domestic), volume-scaled, folded into totals.
- accounting: `verifyOperationalCoverage` — best-effort read-back that polls (~90s, worker ~1m) for the worker's order_sale/opex/material postings, buckets the ledger by source_type, and logs JPK_VAT (per-regime output VAT + wdt/export net) + OSS. Never fails the phase; balanced-ledger gate unchanged.
- `rpc_gen.go` regenerated: adds GetVatReturnPL / GetOssReturn / ListAcctEventsNeedingReview / ReprocessAcctEvent / ResolveAcctEvent to the seeder client.

Prep for the beta DB flush + full reseed. `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)