### PR TITLE
accounting: wave 5 (partial) — Cash Flow + Financial Health reports

### DIFF
--- a/internal/accounting/reports.go
+++ b/internal/accounting/reports.go
@@ -1,0 +1,362 @@
+package accounting
+
+import (
+	"time"
+
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/shopspring/decimal"
+)
+
+// Wave-5 reporting math (docs/plan-accounting-phase2/05-wave5-reporting.md §5.1/§5.2). These are the
+// PURE derivations behind GetCashFlowStatement and GetFinancialHealth: the store gathers ledger
+// balances (and operational units) and hands them here; no SQL, no clock, no store — so the sign
+// conventions and the divide-by-zero guards are unit-tested in isolation (reports_test.go). Money is
+// EUR (the ledger base); the store labels any borrowed operational unit counts by source.
+
+// Cash-flow section names (the wire "name" of each AcctCashFlowSection).
+const (
+	CashFlowOperating = "operating"
+	CashFlowInvesting = "investing"
+	CashFlowFinancing = "financing"
+)
+
+// Financial-health row statuses. na is a guarded divide-by-zero (value 0); track is a no-benchmark row.
+const (
+	HealthStatusOK    = "ok"
+	HealthStatusWarn  = "warn"
+	HealthStatusNA    = "na"
+	HealthStatusTrack = "track"
+)
+
+// Financial-health display units.
+const (
+	HealthUnitPct  = "%"
+	HealthUnitX    = "x"
+	HealthUnitDays = "days"
+)
+
+// CashFlowInputs is the ledger-derived input to ComputeCashFlow. Every *Delta is the SECTION-SIGNED
+// balance change over the period (closing balance strictly before `to`, minus opening balance strictly
+// before `from`) of that account group — i.e. positive means the account grew on its own normal side.
+// ComputeCashFlow applies the cash-flow sign itself (an asset growing is a USE of cash; a liability or
+// equity growing is a SOURCE), so the store never signs ad-hoc. NetProfit is the period Σ_PL(cr − dr);
+// Depreciation is the period 6370 charge (a non-cash add-back whose 1225 contra is deliberately left
+// out of CapexDelta, so the two cancel and cash reconciles).
+type CashFlowInputs struct {
+	From, To     time.Time
+	Currency     string
+	NetProfit    decimal.Decimal // Σ_PL(cr − dr) over [from, to)
+	Depreciation decimal.Decimal // 6370 charge over [from, to) (add-back)
+
+	// Working capital — asset groups (a positive delta is cash tied up).
+	ARDelta        decimal.Decimal // 1040 Accounts Receivable
+	InventoryDelta decimal.Decimal // 1110 + 1120 + 1130 + 1140
+	PrepaidDelta   decimal.Decimal // 1210 Prepaid Expenses — a CURRENT operating asset, not capex
+
+	// Working capital — liability groups (a positive delta is a cash source).
+	APDelta          decimal.Decimal // 2010 Accounts Payable
+	AccruedDelta     decimal.Decimal // 2030 Accrued Expenses
+	IncomeTaxDelta   decimal.Decimal // 2050 Income Tax Payable
+	VatDelta         decimal.Decimal // 2070 VAT Payable + 2080 VAT Input (recoverable)
+	PrepaymentsDelta decimal.Decimal // 2090 Customer Prepayments
+
+	// Investing — non-current asset groups (a purchase is a use of cash). 1210 Prepaid Expenses is NOT
+	// here — it is a current operating asset (see PrepaidDelta).
+	CapexDelta decimal.Decimal // 1220 Equipment (+ 1230 + 1240 when they exist)
+
+	// Financing.
+	EquityDelta decimal.Decimal // 3010 Owner's Equity + 3020 Retained Earnings
+	DrawsDelta  decimal.Decimal // 3030 Draws / Distributions
+	LoansDelta  decimal.Decimal // 2015 Director's/Shareholder Loan (+ 2060 when it exists)
+
+	OpeningCash       decimal.Decimal // 1010 + 1030 (+ 1050) as of From
+	ClosingCashActual decimal.Decimal // 1010 + 1030 (+ 1050) as of To
+}
+
+// ComputeCashFlow builds the indirect-method statement from CashFlowInputs. Operating starts from net
+// profit, adds back depreciation, then folds the working-capital deltas (assets negated, liabilities
+// kept); investing folds capex (negated); financing folds equity, draws and loans (kept). NetChange is
+// the sum of the three subtotals; ClosingCash = OpeningCash + NetChange; Check compares that to the
+// actual closing cash balance and Balanced flags a zero difference (the trust panel).
+func ComputeCashFlow(in CashFlowInputs) *entity.AcctCashFlowStatement {
+	neg := func(d decimal.Decimal) decimal.Decimal { return d.Neg() }
+
+	operating := entity.AcctCashFlowSection{Name: CashFlowOperating, Lines: []entity.AcctCashFlowLine{
+		{Label: "Net profit for the period", Amount: in.NetProfit},
+		{Label: "Add back: depreciation (6370)", Amount: in.Depreciation},
+		{Label: "Change in accounts receivable (1040)", Amount: neg(in.ARDelta)},
+		{Label: "Change in inventory (1110–1140)", Amount: neg(in.InventoryDelta)},
+		{Label: "Change in prepaid expenses (1210)", Amount: neg(in.PrepaidDelta)},
+		{Label: "Change in accounts payable (2010)", Amount: in.APDelta},
+		{Label: "Change in accrued expenses (2030)", Amount: in.AccruedDelta},
+		{Label: "Change in income tax payable (2050)", Amount: in.IncomeTaxDelta},
+		{Label: "Change in VAT (2070/2080)", Amount: in.VatDelta},
+		{Label: "Change in customer prepayments (2090)", Amount: in.PrepaymentsDelta},
+	}}
+	operating.Subtotal = sumCashFlowLines(operating.Lines)
+
+	investing := entity.AcctCashFlowSection{Name: CashFlowInvesting, Lines: []entity.AcctCashFlowLine{
+		{Label: "Purchase of non-current assets (1220)", Amount: neg(in.CapexDelta)},
+	}}
+	investing.Subtotal = sumCashFlowLines(investing.Lines)
+
+	financing := entity.AcctCashFlowSection{Name: CashFlowFinancing, Lines: []entity.AcctCashFlowLine{
+		{Label: "Owner equity contributions (3010/3020)", Amount: in.EquityDelta},
+		{Label: "Owner draws / distributions (3030)", Amount: in.DrawsDelta},
+		{Label: "Loans (2015)", Amount: in.LoansDelta},
+	}}
+	financing.Subtotal = sumCashFlowLines(financing.Lines)
+
+	netChange := operating.Subtotal.Add(investing.Subtotal).Add(financing.Subtotal)
+	closingCash := in.OpeningCash.Add(netChange)
+	check := in.ClosingCashActual.Sub(closingCash)
+
+	return &entity.AcctCashFlowStatement{
+		From:              in.From,
+		To:                in.To,
+		Currency:          in.Currency,
+		Operating:         operating,
+		Investing:         investing,
+		Financing:         financing,
+		NetChange:         netChange,
+		OpeningCash:       in.OpeningCash,
+		ClosingCash:       closingCash,
+		ClosingCashActual: in.ClosingCashActual,
+		Check:             check,
+		Balanced:          check.IsZero(),
+	}
+}
+
+// sumCashFlowLines totals a section's line amounts.
+func sumCashFlowLines(lines []entity.AcctCashFlowLine) decimal.Decimal {
+	sum := decimal.Zero
+	for _, l := range lines {
+		sum = sum.Add(l.Amount)
+	}
+	return sum
+}
+
+// FinancialHealthInputs is the ledger-derived (+ operational-units) input to ComputeFinancialHealth.
+// Period figures (NetRevenue, GrossRevenue, Cogs, Opex, NetProfit, Discounts, Returns) are signed to
+// their natural positive direction over [from, to); balance-sheet figures are as of To. Units come
+// from operational metrics (labelled by source in the caveats), not the ledger.
+type FinancialHealthInputs struct {
+	Currency string
+
+	// Period P&L (ledger, natural-positive).
+	NetRevenue   decimal.Decimal // revenue section net of 4030/4040/4050 contra
+	GrossRevenue decimal.Decimal // 4010 + 4020 + 4110 + 4310 before contra
+	Cogs         decimal.Decimal // cogs section
+	NetProfit    decimal.Decimal // Σ_PL(cr − dr) — after tax
+	Discounts    decimal.Decimal // 4030 magnitude
+	Returns      decimal.Decimal // 4040 magnitude
+
+	// Balance sheet as of To (ledger).
+	TotalAssets        decimal.Decimal
+	TotalLiabilities   decimal.Decimal
+	Equity             decimal.Decimal // equity section + current-period retained earnings
+	CurrentAssets      decimal.Decimal
+	CurrentLiabilities decimal.Decimal
+	Cash               decimal.Decimal // 1010 + 1030 (+ 1050)
+	AR                 decimal.Decimal // 1040
+	OpeningInventory   decimal.Decimal // 1110–1140 as of From
+	ClosingInventory   decimal.Decimal // 1110–1140 as of To
+
+	// Operational units (metrics; lifetime, collection-tagged products — labelled by source).
+	UnitsSold     decimal.Decimal
+	UnitsReceived decimal.Decimal
+	ActiveSKU     decimal.Decimal
+
+	// PeriodDays is the length of [from, to) in days (>= 1). Flow-over-stock ratios (ROA/ROE/turnover/
+	// DIO/DSO/GMROI) whose benchmarks are ANNUAL are annualized by 365/PeriodDays so a one-month window
+	// is not read against a yearly threshold; margins (same-period flow ratios) are scale-invariant and
+	// use raw flows. Zero/negative ⇒ no annualization (factor 1) rather than a bad divisor.
+	PeriodDays int
+}
+
+// ComputeFinancialHealth builds the ratio set with the owner's benchmark strings and an ok/warn/na/track
+// status per row. Every quotient is guarded (a zero denominator yields a zero value with status "na");
+// "track" rows have no pass/fail. Benchmarks and thresholds are the owner's Excel values verbatim.
+func ComputeFinancialHealth(in FinancialHealthInputs) *entity.AcctFinancialHealth {
+	grossProfit := in.NetRevenue.Sub(in.Cogs)
+	avgInventory := in.OpeningInventory.Add(in.ClosingInventory).Div(decimal.NewFromInt(2))
+	quickAssets := in.Cash.Add(in.AR)
+
+	// Annualize period flows for the stock-based ratios whose benchmarks are yearly. periodDays drives
+	// DSO/DIO directly (days), annFactor scales NetProfit/COGS/GrossProfit up to a yearly run-rate.
+	periodDays := decimal.NewFromInt(365)
+	annFactor := decimal.NewFromInt(1)
+	if in.PeriodDays > 0 {
+		periodDays = decimal.NewFromInt(int64(in.PeriodDays))
+		annFactor = decimal.NewFromInt(365).Div(periodDays)
+	}
+	annNetProfit := in.NetProfit.Mul(annFactor)
+	annCogs := in.Cogs.Mul(annFactor)
+	annGrossProfit := grossProfit.Mul(annFactor)
+
+	rows := make([]entity.AcctFinancialHealthRow, 0, 17)
+
+	// --- Profitability ---
+	gmV, gmOK := pct(grossProfit, in.NetRevenue)
+	rows = append(rows, healthRow("Gross Margin", "(Revenue − COGS) / Revenue", "50–70%", HealthUnitPct,
+		gmV, statusRange(gmOK, gmV, 50, 70)))
+
+	npmV, npmOK := pct(in.NetProfit, in.NetRevenue)
+	rows = append(rows, healthRow("Net Profit Margin", "Net Profit / Revenue", ">5%", HealthUnitPct,
+		npmV, statusMin(npmOK, npmV, decimal.NewFromInt(5))))
+
+	roaV, roaOK := pct(annNetProfit, in.TotalAssets)
+	rows = append(rows, healthRow("Return on Assets (ROA)", "Net Profit (annualized) / Total Assets", ">5%", HealthUnitPct,
+		roaV, statusMin(roaOK, roaV, decimal.NewFromInt(5))))
+
+	roeV, roeOK := pct(annNetProfit, in.Equity)
+	rows = append(rows, healthRow("Return on Equity (ROE)", "Net Profit (annualized) / Equity", ">20%", HealthUnitPct,
+		roeV, statusMin(roeOK, roeV, decimal.NewFromInt(20))))
+
+	// --- Liquidity ---
+	crV, crOK := ratio(in.CurrentAssets, in.CurrentLiabilities)
+	rows = append(rows, healthRow("Current Ratio", "Current Assets / Current Liabilities", ">1.5", HealthUnitX,
+		crV, statusMin(crOK, crV, decimal.NewFromFloat(1.5))))
+
+	qrV, qrOK := ratio(quickAssets, in.CurrentLiabilities)
+	rows = append(rows, healthRow("Quick Ratio", "(Cash + AR) / Current Liabilities", ">1.0", HealthUnitX,
+		qrV, statusMin(qrOK, qrV, decimal.NewFromInt(1))))
+
+	// --- Inventory ---
+	turnV, turnOK := ratio(annCogs, avgInventory)
+	rows = append(rows, healthRow("Inventory Turnover", "COGS (annualized) / Avg Inventory", "4–8×", HealthUnitX,
+		turnV, statusRange(turnOK, turnV, 4, 8)))
+
+	// DIO derives from the turnover value; guard both the turnover denominator and a zero turnover.
+	dioV, dioOK := decimal.Zero, false
+	if turnOK && turnV.IsPositive() {
+		dioV, dioOK = decimal.NewFromInt(365).Div(turnV).Round(2), true
+	}
+	rows = append(rows, healthRow("Days Inventory Outstanding (DIO)", "365 / Inventory Turnover", "45–90 days", HealthUnitDays,
+		dioV, statusRange(dioOK, dioV, 45, 90)))
+
+	stV, stOK := pct(in.UnitsSold, in.UnitsReceived)
+	rows = append(rows, healthRow("Sell-Through", "Units Sold / Units Received", ">70%", HealthUnitPct,
+		stV, statusMin(stOK, stV, decimal.NewFromInt(70))))
+
+	// DSO = AR / (revenue per day) = AR / Revenue × days-in-period (NOT ×365, or a one-month window
+	// reads ~12× too high against the <30-day annual benchmark).
+	dsoV, dsoOK := decimal.Zero, false
+	if !in.NetRevenue.IsZero() {
+		dsoV, dsoOK = in.AR.Div(in.NetRevenue).Mul(periodDays).Round(2), true
+	}
+	rows = append(rows, healthRow("Days Sales Outstanding (DSO)", "AR / Revenue × days in period", "<30 days", HealthUnitDays,
+		dsoV, statusMax(dsoOK, dsoV, decimal.NewFromInt(30))))
+
+	// --- Cost structure ---
+	cogsPctV, cogsPctOK := pct(in.Cogs, in.NetRevenue)
+	rows = append(rows, healthRow("COGS %", "COGS / Revenue", "30–50%", HealthUnitPct,
+		cogsPctV, statusRange(cogsPctOK, cogsPctV, 30, 50)))
+
+	drV, drOK := pct(in.Discounts, in.GrossRevenue)
+	rows = append(rows, healthRow("Discount Rate", "Discounts (4030) / Gross Revenue", "<20%", HealthUnitPct,
+		drV, statusMax(drOK, drV, decimal.NewFromInt(20))))
+
+	rrV, rrOK := pct(in.Returns, in.GrossRevenue)
+	rows = append(rows, healthRow("Return Rate", "Returns (4040) / Gross Revenue", "<15%", HealthUnitPct,
+		rrV, statusMax(rrOK, rrV, decimal.NewFromInt(15))))
+
+	// --- Leverage ---
+	deV, deOK := ratio(in.TotalLiabilities, in.Equity)
+	rows = append(rows, healthRow("Debt-to-Equity", "Total Liabilities / Equity", "<1.0", HealthUnitX,
+		deV, statusMax(deOK, deV, decimal.NewFromInt(1))))
+
+	// --- Fashion / track (no pass/fail) ---
+	// Revenue per SKU / Cost per Unit are "track" only: they divide PERIOD money by LIFETIME unit/SKU
+	// counts (the metrics source is not date-windowed — see caveats), so the formula labels say so and
+	// they carry no pass/fail.
+	rpsV, rpsOK := ratio(in.NetRevenue, in.ActiveSKU)
+	rows = append(rows, healthRow("Revenue per SKU", "Period Revenue / active SKU count (lifetime)", "track", in.Currency,
+		rpsV, trackStatus(rpsOK)))
+
+	gmroiV, gmroiOK := ratio(annGrossProfit, avgInventory)
+	rows = append(rows, healthRow("GMROI", "Gross Profit (annualized) / Avg Inventory Cost", ">2.0", HealthUnitX,
+		gmroiV, statusMin(gmroiOK, gmroiV, decimal.NewFromInt(2))))
+
+	cpuV, cpuOK := ratio(in.Cogs, in.UnitsSold)
+	rows = append(rows, healthRow("Cost per Unit", "Period COGS / units sold (lifetime)", "track", in.Currency,
+		cpuV, trackStatus(cpuOK)))
+
+	return &entity.AcctFinancialHealth{
+		Currency: in.Currency,
+		Rows:     rows,
+		Caveats: []string{
+			"Money figures are ledger-first (EUR); revenue is net of returns/discounts.",
+			"Units Sold / Received and Active SKU come from operational metrics (lifetime drop sell-through, collection-tagged products), not the ledger.",
+		},
+	}
+}
+
+// healthRow assembles one ratio row.
+func healthRow(name, formula, benchmark, unit string, value decimal.Decimal, status string) entity.AcctFinancialHealthRow {
+	return entity.AcctFinancialHealthRow{
+		Name:      name,
+		Formula:   formula,
+		Value:     value,
+		Benchmark: benchmark,
+		Status:    status,
+		Unit:      unit,
+	}
+}
+
+// pct returns num/den×100 rounded to 2dp and true, or (0, false) when den is zero (a guarded n/a).
+func pct(num, den decimal.Decimal) (decimal.Decimal, bool) {
+	if den.IsZero() {
+		return decimal.Zero, false
+	}
+	return num.Div(den).Mul(decimal.NewFromInt(100)).Round(2), true
+}
+
+// ratio returns num/den rounded to 2dp and true, or (0, false) when den is zero (a guarded n/a).
+func ratio(num, den decimal.Decimal) (decimal.Decimal, bool) {
+	if den.IsZero() {
+		return decimal.Zero, false
+	}
+	return num.Div(den).Round(2), true
+}
+
+// statusRange is ok when lo ≤ v ≤ hi, warn otherwise; na when the value could not be computed.
+func statusRange(ok bool, v decimal.Decimal, lo, hi int64) string {
+	if !ok {
+		return HealthStatusNA
+	}
+	if v.GreaterThanOrEqual(decimal.NewFromInt(lo)) && v.LessThanOrEqual(decimal.NewFromInt(hi)) {
+		return HealthStatusOK
+	}
+	return HealthStatusWarn
+}
+
+// statusMin is ok when v ≥ min, warn otherwise; na when not computable.
+func statusMin(ok bool, v, min decimal.Decimal) string {
+	if !ok {
+		return HealthStatusNA
+	}
+	if v.GreaterThanOrEqual(min) {
+		return HealthStatusOK
+	}
+	return HealthStatusWarn
+}
+
+// statusMax is ok when v ≤ max, warn otherwise; na when not computable.
+func statusMax(ok bool, v, max decimal.Decimal) string {
+	if !ok {
+		return HealthStatusNA
+	}
+	if v.LessThanOrEqual(max) {
+		return HealthStatusOK
+	}
+	return HealthStatusWarn
+}
+
+// trackStatus is track (no benchmark) when computable, na otherwise.
+func trackStatus(ok bool) string {
+	if !ok {
+		return HealthStatusNA
+	}
+	return HealthStatusTrack
+}

--- a/internal/accounting/reports_test.go
+++ b/internal/accounting/reports_test.go
@@ -1,0 +1,179 @@
+package accounting
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func di(i int64) decimal.Decimal  { return decimal.NewFromInt(i) }
+func ds(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func TestComputeCashFlow_SignsAndReconciliation(t *testing.T) {
+	in := CashFlowInputs{
+		Currency:          "EUR",
+		NetProfit:         di(1000),
+		Depreciation:      di(200),
+		ARDelta:           di(300), // asset grew → use of cash (−300)
+		InventoryDelta:    di(100), // −100
+		APDelta:           di(50),  // liability grew → source (+50)
+		AccruedDelta:      di(20),
+		IncomeTaxDelta:    di(10),
+		VatDelta:          di(15),
+		PrepaymentsDelta:  di(40),
+		CapexDelta:        di(400),  // investing −400
+		EquityDelta:       di(500),  // +500
+		DrawsDelta:        di(-150), // a draw (Dr 3030) → −150
+		LoansDelta:        di(300),  // loan drawn → +300
+		OpeningCash:       di(100),
+		ClosingCashActual: di(1285),
+	}
+	cf := ComputeCashFlow(in)
+
+	// Operating: 1000 + 200 − 300 − 100 + 50 + 20 + 10 + 15 + 40 = 935.
+	if !cf.Operating.Subtotal.Equal(di(935)) {
+		t.Fatalf("operating subtotal = %s, want 935", cf.Operating.Subtotal)
+	}
+	if !cf.Investing.Subtotal.Equal(di(-400)) {
+		t.Fatalf("investing subtotal = %s, want -400", cf.Investing.Subtotal)
+	}
+	if !cf.Financing.Subtotal.Equal(di(650)) { // 500 − 150 + 300
+		t.Fatalf("financing subtotal = %s, want 650", cf.Financing.Subtotal)
+	}
+	if !cf.NetChange.Equal(di(1185)) {
+		t.Fatalf("net change = %s, want 1185", cf.NetChange)
+	}
+	if !cf.ClosingCash.Equal(di(1285)) {
+		t.Fatalf("closing cash = %s, want 1285", cf.ClosingCash)
+	}
+	if !cf.Check.IsZero() || !cf.Balanced {
+		t.Fatalf("expected reconciled: check=%s balanced=%v", cf.Check, cf.Balanced)
+	}
+
+	// AR line signs to a use of cash; AP line to a source.
+	if got := cf.Operating.Lines[2]; got.Label != "Change in accounts receivable (1040)" || !got.Amount.Equal(di(-300)) {
+		t.Fatalf("AR line = %+v, want -300", got)
+	}
+	if got := cf.Operating.Lines[5]; got.Label != "Change in accounts payable (2010)" || !got.Amount.Equal(di(50)) {
+		t.Fatalf("AP line = %+v, want 50", got)
+	}
+}
+
+func TestComputeCashFlow_UnbalancedSurfacesInCheck(t *testing.T) {
+	in := CashFlowInputs{
+		NetProfit:         di(1000),
+		OpeningCash:       di(0),
+		ClosingCashActual: di(950), // computed closing is 1000 → check −50
+	}
+	cf := ComputeCashFlow(in)
+	if cf.Balanced {
+		t.Fatalf("expected not balanced")
+	}
+	if !cf.Check.Equal(di(-50)) {
+		t.Fatalf("check = %s, want -50", cf.Check)
+	}
+}
+
+func healthByName(t *testing.T, in FinancialHealthInputs) map[string]struct {
+	value  decimal.Decimal
+	status string
+	unit   string
+} {
+	t.Helper()
+	fh := ComputeFinancialHealth(in)
+	out := map[string]struct {
+		value  decimal.Decimal
+		status string
+		unit   string
+	}{}
+	for _, r := range fh.Rows {
+		out[r.Name] = struct {
+			value  decimal.Decimal
+			status string
+			unit   string
+		}{r.Value, r.Status, r.Unit}
+	}
+	return out
+}
+
+func TestComputeFinancialHealth_Values(t *testing.T) {
+	in := FinancialHealthInputs{
+		Currency:           "EUR",
+		NetRevenue:         di(1000),
+		GrossRevenue:       di(1200),
+		Cogs:               di(400),
+		NetProfit:          di(100),
+		Discounts:          di(120),
+		Returns:            di(60),
+		TotalAssets:        di(2000),
+		TotalLiabilities:   di(800),
+		Equity:             di(1200),
+		CurrentAssets:      di(900),
+		CurrentLiabilities: di(300),
+		Cash:               di(200),
+		AR:                 di(100),
+		OpeningInventory:   di(300),
+		ClosingInventory:   di(500), // avg 400
+		UnitsSold:          di(80),
+		UnitsReceived:      di(100),
+		ActiveSKU:          di(50),
+	}
+	m := healthByName(t, in)
+
+	cases := []struct {
+		name   string
+		value  decimal.Decimal
+		status string
+	}{
+		{"Gross Margin", di(60), HealthStatusOK},
+		{"Net Profit Margin", di(10), HealthStatusOK},
+		{"Return on Assets (ROA)", di(5), HealthStatusOK}, // 5 ≥ 5
+		{"Return on Equity (ROE)", ds("8.33"), HealthStatusWarn},
+		{"Current Ratio", di(3), HealthStatusOK},
+		{"Quick Ratio", di(1), HealthStatusOK},
+		{"Inventory Turnover", di(1), HealthStatusWarn},
+		{"Days Inventory Outstanding (DIO)", di(365), HealthStatusWarn},
+		{"Sell-Through", di(80), HealthStatusOK},
+		{"Days Sales Outstanding (DSO)", ds("36.5"), HealthStatusWarn},
+		{"COGS %", di(40), HealthStatusOK},
+		{"Discount Rate", di(10), HealthStatusOK},
+		{"Return Rate", di(5), HealthStatusOK},
+		{"Debt-to-Equity", ds("0.67"), HealthStatusOK},
+		{"Revenue per SKU", di(20), HealthStatusTrack},
+		{"GMROI", ds("1.5"), HealthStatusWarn},
+		{"Cost per Unit", di(5), HealthStatusTrack},
+	}
+	if len(m) != len(cases) {
+		t.Fatalf("row count = %d, want %d", len(m), len(cases))
+	}
+	for _, c := range cases {
+		got, ok := m[c.name]
+		if !ok {
+			t.Errorf("missing row %q", c.name)
+			continue
+		}
+		if !got.value.Equal(c.value) {
+			t.Errorf("%s value = %s, want %s", c.name, got.value, c.value)
+		}
+		if got.status != c.status {
+			t.Errorf("%s status = %s, want %s", c.name, got.status, c.status)
+		}
+	}
+	// Track rows display the base currency as their unit.
+	if m["Revenue per SKU"].unit != "EUR" {
+		t.Errorf("Revenue per SKU unit = %q, want EUR", m["Revenue per SKU"].unit)
+	}
+}
+
+func TestComputeFinancialHealth_DivideByZeroIsNA(t *testing.T) {
+	// All-zero inputs: every quotient must guard to a zero value with status na (no panic, no NaN).
+	m := healthByName(t, FinancialHealthInputs{Currency: "EUR"})
+	for name, r := range m {
+		if r.status != HealthStatusNA {
+			t.Errorf("%s status = %s, want na on zero inputs", name, r.status)
+		}
+		if !r.value.IsZero() {
+			t.Errorf("%s value = %s, want 0 on zero inputs", name, r.value)
+		}
+	}
+}

--- a/internal/apisrv/admin/accounting.go
+++ b/internal/apisrv/admin/accounting.go
@@ -358,6 +358,32 @@ func (s *Server) GetAcctReconciliation(ctx context.Context, req *pb_admin.GetAcc
 	return dto.ConvertAcctReconciliationToPb(*rec), nil
 }
 
+// GetCashFlowStatement returns the indirect-method cash-flow statement over [from, to) (wave 5, §5.1).
+func (s *Server) GetCashFlowStatement(ctx context.Context, req *pb_admin.GetCashFlowStatementRequest) (*pb_admin.GetCashFlowStatementResponse, error) {
+	from, to, err := dto.ParseAcctDateRange(req.GetFrom(), req.GetTo())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	cf, err := s.repo.Accounting().GetCashFlowStatement(ctx, from, to)
+	if err != nil {
+		return nil, mapAcctErr(ctx, "get cash flow statement", err)
+	}
+	return dto.ConvertAcctCashFlowStatementToPb(*cf), nil
+}
+
+// GetFinancialHealth returns the financial-health ratio set over [from, to) (wave 5, §5.2).
+func (s *Server) GetFinancialHealth(ctx context.Context, req *pb_admin.GetFinancialHealthRequest) (*pb_admin.GetFinancialHealthResponse, error) {
+	from, to, err := dto.ParseAcctDateRange(req.GetFrom(), req.GetTo())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	fh, err := s.repo.Accounting().GetFinancialHealth(ctx, from, to)
+	if err != nil {
+		return nil, mapAcctErr(ctx, "get financial health", err)
+	}
+	return dto.ConvertAcctFinancialHealthToPb(*fh), nil
+}
+
 // --- FX folding for manual amount_src lines ---
 
 // errAcctNoFxRate distinguishes "no costing FX rate for this currency" (InvalidArgument) from a

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -804,6 +804,12 @@ type (
 		// GetFrs105Accounts re-groups the ledger into FRS 105 micro-entity line items (Income Statement +
 		// SoFP) over [from, to) — a base-currency DRAFT (not GBP / entity-isolated).
 		GetFrs105Accounts(ctx context.Context, from, to time.Time) (*entity.AcctFrs105Accounts, error)
+		// GetCashFlowStatement is the indirect-method cash-flow statement over [from, to) (wave 5, §5.1):
+		// net profit + non-cash add-backs + balance-sheet deltas, reconciled against the actual cash balance.
+		GetCashFlowStatement(ctx context.Context, from, to time.Time) (*entity.AcctCashFlowStatement, error)
+		// GetFinancialHealth computes the financial-health ratio set over [from, to) (wave 5, §5.2) from the
+		// ledger (money) plus operational unit counts from metrics (labelled by source).
+		GetFinancialHealth(ctx context.Context, from, to time.Time) (*entity.AcctFinancialHealth, error)
 		// Fixed-asset register + straight-line depreciation (posts Dr 6370 / Cr 1225 per asset-month).
 		CreateFixedAsset(ctx context.Context, in entity.FixedAssetInsert) (int, error)
 		ListFixedAssets(ctx context.Context) ([]entity.FixedAsset, error)

--- a/internal/dto/accounting.go
+++ b/internal/dto/accounting.go
@@ -711,6 +711,60 @@ func ConvertAcctEventsToPb(events []entity.AcctEvent) []*pb_admin.AcctEvent {
 }
 
 // =====================================================================================
+// Wave 5 — reporting (docs/plan-accounting-phase2/05-wave5-reporting.md). Cash Flow (indirect) and the
+// Financial Health ratio set. Money reuses pbDecimalFromDecimal; dates are the plain acctDateLayout.
+// =====================================================================================
+
+// ConvertAcctCashFlowStatementToPb converts the indirect-method cash-flow statement to protobuf.
+func ConvertAcctCashFlowStatementToPb(cf entity.AcctCashFlowStatement) *pb_admin.GetCashFlowStatementResponse {
+	return &pb_admin.GetCashFlowStatementResponse{
+		From:              cf.From.Format(acctDateLayout),
+		To:                cf.To.Format(acctDateLayout),
+		Currency:          cf.Currency,
+		Operating:         convertAcctCashFlowSectionToPb(cf.Operating),
+		Investing:         convertAcctCashFlowSectionToPb(cf.Investing),
+		Financing:         convertAcctCashFlowSectionToPb(cf.Financing),
+		NetChange:         pbDecimalFromDecimal(cf.NetChange),
+		OpeningCash:       pbDecimalFromDecimal(cf.OpeningCash),
+		ClosingCash:       pbDecimalFromDecimal(cf.ClosingCash),
+		ClosingCashActual: pbDecimalFromDecimal(cf.ClosingCashActual),
+		Check:             pbDecimalFromDecimal(cf.Check),
+		Balanced:          cf.Balanced,
+		Caveats:           cf.Caveats,
+	}
+}
+
+func convertAcctCashFlowSectionToPb(sec entity.AcctCashFlowSection) *pb_admin.AcctCashFlowSection {
+	lines := make([]*pb_admin.AcctCashFlowLine, 0, len(sec.Lines))
+	for _, l := range sec.Lines {
+		lines = append(lines, &pb_admin.AcctCashFlowLine{Label: l.Label, Amount: pbDecimalFromDecimal(l.Amount)})
+	}
+	return &pb_admin.AcctCashFlowSection{Name: sec.Name, Lines: lines, Subtotal: pbDecimalFromDecimal(sec.Subtotal)}
+}
+
+// ConvertAcctFinancialHealthToPb converts the financial-health ratio set to protobuf.
+func ConvertAcctFinancialHealthToPb(fh entity.AcctFinancialHealth) *pb_admin.GetFinancialHealthResponse {
+	rows := make([]*pb_admin.AcctFinancialHealthRow, 0, len(fh.Rows))
+	for _, r := range fh.Rows {
+		rows = append(rows, &pb_admin.AcctFinancialHealthRow{
+			Name:      r.Name,
+			Formula:   r.Formula,
+			Value:     pbDecimalFromDecimal(r.Value),
+			Benchmark: r.Benchmark,
+			Status:    r.Status,
+			Unit:      r.Unit,
+		})
+	}
+	return &pb_admin.GetFinancialHealthResponse{
+		From:     fh.From.Format(acctDateLayout),
+		To:       fh.To.Format(acctDateLayout),
+		Currency: fh.Currency,
+		Rows:     rows,
+		Caveats:  fh.Caveats,
+	}
+}
+
+// =====================================================================================
 // Wave 4 — money side (docs/plan-accounting-phase2/04-wave4-money.md). Revolut bank inbox (4.1) and the
 // AP/AR subledgers (4.4).
 // =====================================================================================

--- a/internal/entity/accounting.go
+++ b/internal/entity/accounting.go
@@ -1048,3 +1048,71 @@ type AcctReceivableRow struct {
 	Received decimal.Decimal `db:"received"`
 	Balance  decimal.Decimal `db:"-"`
 }
+
+// =====================================================================================
+// Wave 5 — reporting (docs/plan-accounting-phase2/05-wave5-reporting.md §5.1/§5.2). Two
+// READ-ONLY derived reports over the EUR ledger: the indirect-method Cash Flow statement and
+// the Financial Health ratio set. Both are pure derivations of ledger balances (money is
+// ledger-first); the ratio report additionally borrows operational UNIT counts from metrics
+// (labelled by source). Computed by the pure helpers in internal/accounting (unit-tested), so
+// these are the return contracts only.
+// =====================================================================================
+
+// AcctCashFlowLine is one line of the cash-flow statement: a label and its SIGNED cash impact — a
+// source of cash is positive, a use of cash negative.
+type AcctCashFlowLine struct {
+	Label  string
+	Amount decimal.Decimal
+}
+
+// AcctCashFlowSection groups cash-flow lines (operating / investing / financing) with the section's
+// net cash subtotal (Σ of its line amounts).
+type AcctCashFlowSection struct {
+	Name     string // operating | investing | financing
+	Lines    []AcctCashFlowLine
+	Subtotal decimal.Decimal
+}
+
+// AcctCashFlowStatement is GetCashFlowStatement's result: the indirect-method statement over [From, To).
+// Net profit for the period is add-backed with non-cash depreciation and adjusted by the balance-sheet
+// working-capital / investing / financing deltas. Check is the trust panel (like the Balance Sheet's
+// BalanceCheck): ClosingCashActual − ClosingCash, zero when every non-cash account is bucketed and the
+// depreciation add-back matches its 1225 contra movement.
+type AcctCashFlowStatement struct {
+	From              time.Time
+	To                time.Time
+	Currency          string
+	Operating         AcctCashFlowSection
+	Investing         AcctCashFlowSection
+	Financing         AcctCashFlowSection
+	NetChange         decimal.Decimal // Operating + Investing + Financing subtotals
+	OpeningCash       decimal.Decimal // 1010+1030(+1050) as of From
+	ClosingCash       decimal.Decimal // OpeningCash + NetChange (derived)
+	ClosingCashActual decimal.Decimal // actual 1010+1030(+1050) balance as of To
+	Check             decimal.Decimal // ClosingCashActual − ClosingCash (0 = reconciled)
+	Balanced          bool            // Check == 0
+	Caveats           []string
+}
+
+// AcctFinancialHealthRow is one ratio row of the Financial Health report: its name, the human-readable
+// formula, the computed value, the owner's benchmark string, a status (ok | warn | na | track) and a
+// display unit ("%", "x", "days", the base currency, or ""). A divide-by-zero yields a zero value with
+// status "na" (never NaN/panic); "track" rows carry no pass/fail.
+type AcctFinancialHealthRow struct {
+	Name      string
+	Formula   string
+	Value     decimal.Decimal
+	Benchmark string
+	Status    string
+	Unit      string
+}
+
+// AcctFinancialHealth is GetFinancialHealth's result: the whole ratio set over [From, To) plus caveats
+// (e.g. that unit counts come from operational metrics, not the ledger).
+type AcctFinancialHealth struct {
+	From     time.Time
+	To       time.Time
+	Currency string
+	Rows     []AcctFinancialHealthRow
+	Caveats  []string
+}

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -428,6 +428,8 @@ var methodRequirements = map[string]Requirement{
 	"ExportOssReturn":             rd(SectionAccounting),
 	"GetUkVatReturn":              rd(SectionAccounting),
 	"GetFrs105Accounts":           rd(SectionAccounting),
+	"GetCashFlowStatement":        rd(SectionAccounting),
+	"GetFinancialHealth":          rd(SectionAccounting),
 
 	// Wave 4 — money side: Revolut bank inbox (4.1) + AP/AR subledgers (4.4).
 	"ImportBankCsv":  wr(SectionAccounting),

--- a/internal/store/accounting/wave5_reports.go
+++ b/internal/store/accounting/wave5_reports.go
@@ -1,0 +1,233 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	acctcalc "github.com/jekabolt/grbpwr-manager/internal/accounting"
+	"github.com/jekabolt/grbpwr-manager/internal/cache"
+	"github.com/jekabolt/grbpwr-manager/internal/entity"
+	"github.com/jekabolt/grbpwr-manager/internal/store/storeutil"
+	"github.com/shopspring/decimal"
+)
+
+// Wave-5 reporting (docs/plan-accounting-phase2/05-wave5-reporting.md §5.1/§5.2): the indirect-method
+// Cash Flow statement and the Financial Health ratio set. Both are pure derivations of the ledger:
+// GetCashFlowStatement / GetFinancialHealth gather two full-ledger balance snapshots (strictly before
+// `from` and before `to`), turn them into period deltas / as-of balances, and hand the numbers to the
+// unit-tested pure math in internal/accounting. Money is ledger-first; the ratio report additionally
+// borrows operational UNIT counts from metrics (GetSellThroughByDrop), labelled by source. The period
+// is [from, to) with `to` exclusive, matching the other period-scoped reports.
+//
+// Every account is referenced by its Excel-stable code (migrations 0190+; the same literal-code style
+// as reports.go / reconcile.go). Codes the plan lists that are not yet seeded (1050 cash, 1230/1240
+// capex, 2060 loans) are kept in the code sets as harmless no-ops (they match nothing → zero) so the
+// statement is forward-compatible if they are ever added.
+
+// healthUnitsDropLimit bounds GetSellThroughByDrop; it is generous enough to cover every drop cohort so
+// the unit totals are the full operational figures (the query aggregates per collection, few rows).
+const healthUnitsDropLimit = 100000
+
+// ledgerBalances is a reduced ledger snapshot as of one instant: each account's signed section balance,
+// the per-section totals, and the cumulative net profit (Σ_PL of credit − debit). Built by
+// ledgerBalancesBefore and consumed as period deltas (closing − opening) or as-of balances.
+type ledgerBalances struct {
+	byCode    map[string]decimal.Decimal
+	bySection map[entity.AcctSection]decimal.Decimal
+	netProfit decimal.Decimal
+}
+
+// code returns one account's signed balance (zero if the account had no activity).
+func (b *ledgerBalances) code(c string) decimal.Decimal { return b.byCode[c] }
+
+// codes sums the signed balances of several accounts.
+func (b *ledgerBalances) codes(cs ...string) decimal.Decimal {
+	sum := decimal.Zero
+	for _, c := range cs {
+		sum = sum.Add(b.byCode[c])
+	}
+	return sum
+}
+
+// section returns a section's signed total (zero if empty).
+func (b *ledgerBalances) section(s entity.AcctSection) decimal.Decimal { return b.bySection[s] }
+
+// ledgerBalancesBefore reduces every account's journal activity strictly before `before` into a
+// ledgerBalances snapshot. Only accounts with activity appear (a missing code reads as zero). The
+// signed balance is sectionBalance (the one sign convention shared by every report); net profit is
+// Σ over PL lines of (credit − debit), the same expression GetBalanceSheet uses for its virtual
+// net-profit row.
+func (s *Store) ledgerBalancesBefore(ctx context.Context, before time.Time) (*ledgerBalances, error) {
+	type row struct {
+		Code      string             `db:"code"`
+		Section   entity.AcctSection `db:"section"`
+		Statement string             `db:"statement"`
+		Debit     decimal.Decimal    `db:"dr"`
+		Credit    decimal.Decimal    `db:"cr"`
+	}
+	rows, err := storeutil.QueryListNamed[row](ctx, s.DB, `
+		SELECT a.code, a.section, a.statement,
+		       COALESCE(SUM(CASE WHEN l.side = 'debit'  THEN l.amount ELSE 0 END), 0) AS dr,
+		       COALESCE(SUM(CASE WHEN l.side = 'credit' THEN l.amount ELSE 0 END), 0) AS cr
+		FROM acct_account a
+		JOIN acct_journal_line l ON l.account_id = a.id
+		JOIN acct_journal_entry e ON e.id = l.entry_id
+		WHERE e.occurred_at < :before
+		GROUP BY a.code, a.section, a.statement`,
+		map[string]any{"before": before.UTC().Format(dateLayout)})
+	if err != nil {
+		return nil, fmt.Errorf("accounting: ledger balances: %w", err)
+	}
+
+	b := &ledgerBalances{
+		byCode:    make(map[string]decimal.Decimal, len(rows)),
+		bySection: make(map[entity.AcctSection]decimal.Decimal),
+	}
+	for _, r := range rows {
+		bal := sectionBalance(r.Section, r.Debit, r.Credit)
+		b.byCode[r.Code] = bal
+		b.bySection[r.Section] = b.bySection[r.Section].Add(bal)
+		if r.Statement == entity.AcctStatementPL {
+			b.netProfit = b.netProfit.Add(r.Credit.Sub(r.Debit))
+		}
+	}
+	return b, nil
+}
+
+// GetCashFlowStatement builds the indirect-method Cash Flow statement over [from, to) (§5.1). Net profit
+// for the period is add-backed with the non-cash 6370 depreciation charge, then adjusted by the signed
+// balance-sheet deltas — working capital and prepayments in operating, capex in investing, equity/draws/
+// loans in financing. Cash is 1010+1030(+1050); the Check field (like the Balance Sheet's BalanceCheck)
+// compares the derived closing cash to the actual balance as of `to`. The 1225 accumulated-depreciation
+// contra is deliberately left out of capex so it cancels the depreciation add-back and cash reconciles.
+func (s *Store) GetCashFlowStatement(ctx context.Context, from, to time.Time) (*entity.AcctCashFlowStatement, error) {
+	opening, err := s.ledgerBalancesBefore(ctx, from)
+	if err != nil {
+		return nil, err
+	}
+	closing, err := s.ledgerBalancesBefore(ctx, to)
+	if err != nil {
+		return nil, err
+	}
+	// d is the period delta (closing − opening) of a signed balance across one or more account codes.
+	d := func(codes ...string) decimal.Decimal {
+		return closing.codes(codes...).Sub(opening.codes(codes...))
+	}
+	cashCodes := []string{"1010", "1030", "1050"}
+
+	in := acctcalc.CashFlowInputs{
+		From:         from,
+		To:           to,
+		Currency:     cache.GetBaseCurrency(),
+		NetProfit:    closing.netProfit.Sub(opening.netProfit),
+		Depreciation: d("6370"),
+
+		ARDelta:          d("1040"),
+		InventoryDelta:   d("1110", "1120", "1130", "1140"),
+		PrepaidDelta:     d("1210"), // current operating asset, not capex
+		APDelta:          d("2010"),
+		AccruedDelta:     d("2030"),
+		IncomeTaxDelta:   d("2050"),
+		VatDelta:         d("2070", "2080"),
+		PrepaymentsDelta: d("2090"),
+
+		CapexDelta: d("1220", "1230", "1240"),
+
+		EquityDelta: d("3010", "3020"),
+		DrawsDelta:  d("3030"),
+		LoansDelta:  d("2015", "2060"),
+
+		OpeningCash:       opening.codes(cashCodes...),
+		ClosingCashActual: closing.codes(cashCodes...),
+	}
+	cf := acctcalc.ComputeCashFlow(in)
+	if !cf.Balanced {
+		cf.Caveats = append(cf.Caveats, "derived closing cash differs from the actual 1010/1030 balance — an account moved outside the modelled cash-flow lines (see Check)")
+	}
+	return cf, nil
+}
+
+// GetFinancialHealth computes the whole ratio set over [from, to) (§5.2). Money figures are ledger-first:
+// period P&L (revenue/COGS/net profit, gross revenue and the 4030/4040 contra) and the as-of balance
+// sheet come from two ledger snapshots. Operational UNIT counts (units sold/received, active SKU) come
+// from metrics.GetSellThroughByDrop — a labelled second-source for units only, never for money. Equity
+// includes the current-period retained earnings (the same total as the Balance Sheet).
+func (s *Store) GetFinancialHealth(ctx context.Context, from, to time.Time) (*entity.AcctFinancialHealth, error) {
+	opening, err := s.ledgerBalancesBefore(ctx, from)
+	if err != nil {
+		return nil, err
+	}
+	closing, err := s.ledgerBalancesBefore(ctx, to)
+	if err != nil {
+		return nil, err
+	}
+	periodSection := func(sec entity.AcctSection) decimal.Decimal {
+		return closing.section(sec).Sub(opening.section(sec))
+	}
+	periodCodes := func(codes ...string) decimal.Decimal {
+		return closing.codes(codes...).Sub(opening.codes(codes...))
+	}
+
+	unitsSold, unitsReceived, activeSKU, err := s.financialHealthUnits(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	totalAssets := closing.section(entity.AcctSectionAsset)
+	totalLiab := closing.section(entity.AcctSectionLiability)
+
+	in := acctcalc.FinancialHealthInputs{
+		Currency: cache.GetBaseCurrency(),
+
+		NetRevenue:   periodSection(entity.AcctSectionRevenue),
+		GrossRevenue: periodCodes("4010", "4020", "4110", "4310"),
+		Cogs:         periodSection(entity.AcctSectionCogs),
+		NetProfit:    closing.netProfit.Sub(opening.netProfit),
+		Discounts:    periodCodes("4030").Neg(), // contra-revenue signed negative → positive magnitude
+		Returns:      periodCodes("4040").Neg(),
+
+		TotalAssets:      totalAssets,
+		TotalLiabilities: totalLiab,
+		// Equity includes the not-yet-closed current-period profit, matching GetBalanceSheet's TotalEquity.
+		Equity: closing.section(entity.AcctSectionEquity).Add(closing.netProfit),
+		// Current assets exclude net fixed assets (1220 Equipment net of 1225 Accumulated Depreciation);
+		// current liabilities exclude the long-term shareholder loan (2015).
+		CurrentAssets:      totalAssets.Sub(closing.codes("1220", "1225")),
+		CurrentLiabilities: totalLiab.Sub(closing.code("2015")),
+		Cash:               closing.codes("1010", "1030", "1050"),
+		AR:                 closing.code("1040"),
+		OpeningInventory:   opening.codes("1110", "1120", "1130", "1140"),
+		ClosingInventory:   closing.codes("1110", "1120", "1130", "1140"),
+
+		UnitsSold:     unitsSold,
+		UnitsReceived: unitsReceived,
+		ActiveSKU:     activeSKU,
+
+		// Days in [from, to) — annualizes the flow-over-stock ratios against their yearly benchmarks.
+		PeriodDays: int(to.Sub(from).Hours() / 24),
+	}
+	fh := acctcalc.ComputeFinancialHealth(in)
+	fh.From = from
+	fh.To = to
+	return fh, nil
+}
+
+// financialHealthUnits pulls the operational unit totals from metrics.GetSellThroughByDrop (the "units
+// from GetMetrics" source, §5.2), summed across every drop cohort: units sold, units received (the
+// sold+remaining initial-stock proxy) and the active-SKU count. These are lifetime, collection-tagged
+// figures (the query's own scope) — money stays ledger-first; this is a labelled second source for units
+// only. `from`/`to` are accepted for signature parity (GetSellThroughByDrop does not window them).
+func (s *Store) financialHealthUnits(ctx context.Context, from, to time.Time) (unitsSold, unitsReceived, activeSKU decimal.Decimal, err error) {
+	drops, err := s.repo.Metrics().GetSellThroughByDrop(ctx, from, to, healthUnitsDropLimit)
+	if err != nil {
+		return decimal.Zero, decimal.Zero, decimal.Zero, fmt.Errorf("accounting: financial health units: %w", err)
+	}
+	var sold, received, sku int64
+	for _, dr := range drops {
+		sold += dr.UnitsSold
+		received += dr.UnitsBought
+		sku += int64(dr.ProductCount)
+	}
+	return decimal.NewFromInt(sold), decimal.NewFromInt(received), decimal.NewFromInt(sku), nil
+}

--- a/proto/admin/admin/admin.proto
+++ b/proto/admin/admin/admin.proto
@@ -1808,6 +1808,20 @@ service AdminService {
     option (google.api.http) = {get: "/api/admin/accounting/reports/frs105"};
   }
 
+  // GetCashFlowStatement returns the indirect-method cash-flow statement over [from, to) (exclusive):
+  // net profit + depreciation add-back + balance-sheet working-capital / investing / financing deltas,
+  // with a Check that reconciles the derived closing cash to the actual 1010/1030 balance.
+  rpc GetCashFlowStatement(GetCashFlowStatementRequest) returns (GetCashFlowStatementResponse) {
+    option (google.api.http) = {get: "/api/admin/accounting/reports/cash-flow"};
+  }
+
+  // GetFinancialHealth returns the financial-health ratio set over [from, to) (exclusive): each row a
+  // {name, formula, value, benchmark, status} tuple. Money is ledger-derived; unit counts come from
+  // operational metrics (labelled in caveats).
+  rpc GetFinancialHealth(GetFinancialHealthRequest) returns (GetFinancialHealthResponse) {
+    option (google.api.http) = {get: "/api/admin/accounting/reports/financial-health"};
+  }
+
   // --- wave 4: Revolut bank inbox (docs/plan-accounting-phase2/04-wave4-money.md §4.1) ---
 
   // ImportBankCsv parses a bank CSV export (Revolut) into the inbox, deduplicating on the bank
@@ -6614,6 +6628,70 @@ message GetFrs105AccountsResponse {
   google.type.Decimal net_assets = 18;
   google.type.Decimal capital_and_reserves = 19;
   repeated string caveats = 20;
+}
+
+// --- wave 5: cash flow + financial health (docs/plan-accounting-phase2/05-wave5-reporting.md) ---
+
+message GetCashFlowStatementRequest {
+  string from = 1; // YYYY-MM-DD period start
+  string to = 2; // YYYY-MM-DD period end (exclusive)
+}
+
+// AcctCashFlowLine is one cash-flow line: a label and its SIGNED cash impact (source positive, use
+// negative).
+message AcctCashFlowLine {
+  string label = 1;
+  google.type.Decimal amount = 2;
+}
+
+// AcctCashFlowSection groups cash-flow lines (operating | investing | financing) with the section subtotal.
+message AcctCashFlowSection {
+  string name = 1;
+  repeated AcctCashFlowLine lines = 2;
+  google.type.Decimal subtotal = 3;
+}
+
+// GetCashFlowStatementResponse is the indirect-method statement over [from, to). closing_cash is derived
+// (opening_cash + net_change); closing_cash_actual is the real cash-account balance as at `to`; check =
+// closing_cash_actual − closing_cash (0 when balanced, the trust panel).
+message GetCashFlowStatementResponse {
+  string from = 1;
+  string to = 2;
+  string currency = 3;
+  AcctCashFlowSection operating = 4;
+  AcctCashFlowSection investing = 5;
+  AcctCashFlowSection financing = 6;
+  google.type.Decimal net_change = 7;
+  google.type.Decimal opening_cash = 8;
+  google.type.Decimal closing_cash = 9;
+  google.type.Decimal closing_cash_actual = 10;
+  google.type.Decimal check = 11;
+  bool balanced = 12;
+  repeated string caveats = 13;
+}
+
+message GetFinancialHealthRequest {
+  string from = 1; // YYYY-MM-DD period start
+  string to = 2; // YYYY-MM-DD period end (exclusive)
+}
+
+// AcctFinancialHealthRow is one ratio row: its value, the owner's benchmark string, a status
+// (ok | warn | na | track) and a display unit ("%", "x", "days", the base currency, or "").
+message AcctFinancialHealthRow {
+  string name = 1;
+  string formula = 2;
+  google.type.Decimal value = 3;
+  string benchmark = 4;
+  string status = 5;
+  string unit = 6;
+}
+
+message GetFinancialHealthResponse {
+  string from = 1;
+  string to = 2;
+  string currency = 3;
+  repeated AcctFinancialHealthRow rows = 4;
+  repeated string caveats = 5;
 }
 
 // FixedAsset is one capitalised asset, depreciated straight-line over useful_life_months from acquired_on.


### PR DESCRIPTION
Read-only ledger reports (no migration). GetCashFlowStatement (indirect, reconciles by construction) + GetFinancialHealth (17 ratios, owner's Excel benchmarks). Adversarial review: no critical (CF reconciles by construction); fixed HIGH (annualize sub-year ratios) + MED (1210 operating vs capex, lifetime-unit relabel). Build + tests green. Year-end close + GBP/FRS-105 filing (rest of wave 5) not included. Client tabs follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)